### PR TITLE
Improve indentation of Fixpoint, Inductive, Program

### DIFF
--- a/base/Control/Applicative.v
+++ b/base/Control/Applicative.v
@@ -23,11 +23,11 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive WrappedMonad (m : Type -> Type) a : Type
-  := | WrapMonad (unwrapMonad : m a) : WrappedMonad m a.
+Inductive WrappedMonad (m : Type -> Type) a : Type :=
+  | WrapMonad (unwrapMonad : m a) : WrappedMonad m a.
 
-Inductive WrappedArrow (a : Type -> Type -> Type) b c : Type
-  := | WrapArrow (unwrapArrow : a b c) : WrappedArrow a b c.
+Inductive WrappedArrow (a : Type -> Type -> Type) b c : Type :=
+  | WrapArrow (unwrapArrow : a b c) : WrappedArrow a b c.
 
 Arguments WrapMonad {_} {_} _.
 

--- a/base/Control/Arrow.v
+++ b/base/Control/Arrow.v
@@ -25,11 +25,11 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Kleisli (m : Type -> Type) a b : Type
-  := | Mk_Kleisli (runKleisli : a -> m b) : Kleisli m a b.
+Inductive Kleisli (m : Type -> Type) a b : Type :=
+  | Mk_Kleisli (runKleisli : a -> m b) : Kleisli m a b.
 
-Inductive ArrowMonad (a : Type -> Type -> Type) b : Type
-  := | Mk_ArrowMonad : (a unit b) -> ArrowMonad a b.
+Inductive ArrowMonad (a : Type -> Type -> Type) b : Type :=
+  | Mk_ArrowMonad : (a unit b) -> ArrowMonad a b.
 
 Record Arrow__Dict (a : Type -> Type -> Type) := Arrow__Dict_Build {
   arr__ : forall {b} {c}, (b -> c) -> a b c ;

--- a/base/Data/Either.v
+++ b/base/Data/Either.v
@@ -18,9 +18,9 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Either a b : Type
-  := | Left : a -> Either a b
-  |  Right : b -> Either a b.
+Inductive Either a b : Type :=
+  | Left : a -> Either a b
+  | Right : b -> Either a b.
 
 Arguments Left {_} {_} _.
 

--- a/base/Data/Functor/Classes.v
+++ b/base/Data/Functor/Classes.v
@@ -114,12 +114,12 @@ Local Definition Eq1__list_liftEq
    : forall {a} {b}, (a -> b -> bool) -> list a -> list b -> bool :=
   fun {a} {b} =>
     fix liftEq arg_69__ arg_70__ arg_71__
-          := match arg_69__, arg_70__, arg_71__ with
-             | _, nil, nil => true
-             | _, nil, cons _ _ => false
-             | _, cons _ _, nil => false
-             | eq, cons x xs, cons y ys => andb (eq x y) (liftEq eq xs ys)
-             end.
+      := match arg_69__, arg_70__, arg_71__ with
+         | _, nil, nil => true
+         | _, nil, cons _ _ => false
+         | _, cons _ _, nil => false
+         | eq, cons x xs, cons y ys => andb (eq x y) (liftEq eq xs ys)
+         end.
 
 Program Instance Eq1__list : Eq1 list :=
   fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__list_liftEq |}.
@@ -128,13 +128,13 @@ Local Definition Ord1__list_liftCompare
    : forall {a} {b}, (a -> b -> comparison) -> list a -> list b -> comparison :=
   fun {a} {b} =>
     fix liftCompare arg_69__ arg_70__ arg_71__
-          := match arg_69__, arg_70__, arg_71__ with
-             | _, nil, nil => Eq
-             | _, nil, cons _ _ => Lt
-             | _, cons _ _, nil => Gt
-             | comp, cons x xs, cons y ys =>
-                 GHC.Base.mappend (comp x y) (liftCompare comp xs ys)
-             end.
+      := match arg_69__, arg_70__, arg_71__ with
+         | _, nil, nil => Eq
+         | _, nil, cons _ _ => Lt
+         | _, cons _ _, nil => Gt
+         | comp, cons x xs, cons y ys =>
+             GHC.Base.mappend (comp x y) (liftCompare comp xs ys)
+         end.
 
 Program Instance Ord1__list : Ord1 list :=
   fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__list_liftCompare |}.

--- a/base/Data/Functor/Compose.v
+++ b/base/Data/Functor/Compose.v
@@ -26,8 +26,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Compose (f : Type -> Type) (g : Type -> Type) (a : Type) : Type
-  := | Mk_Compose (getCompose : f (g a)) : Compose f g a.
+Inductive Compose (f : Type -> Type) (g : Type -> Type) (a : Type) : Type :=
+  | Mk_Compose (getCompose : f (g a)) : Compose f g a.
 
 Arguments Mk_Compose {_} {_} {_} _.
 

--- a/base/Data/Functor/Product.v
+++ b/base/Data/Functor/Product.v
@@ -27,8 +27,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Product (f : Type -> Type) (g : Type -> Type) a : Type
-  := | Pair : (f a) -> (g a) -> Product f g a.
+Inductive Product (f : Type -> Type) (g : Type -> Type) a : Type :=
+  | Pair : (f a) -> (g a) -> Product f g a.
 
 Arguments Pair {_} {_} {_} _ _.
 

--- a/base/Data/Functor/Sum.v
+++ b/base/Data/Functor/Sum.v
@@ -26,9 +26,9 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Sum (f : Type -> Type) (g : Type -> Type) a : Type
-  := | InL : (f a) -> Sum f g a
-  |  InR : (g a) -> Sum f g a.
+Inductive Sum (f : Type -> Type) (g : Type -> Type) a : Type :=
+  | InL : (f a) -> Sum f g a
+  | InR : (g a) -> Sum f g a.
 
 Arguments InL {_} {_} {_} _.
 

--- a/base/Data/Functor/Utils.v
+++ b/base/Data/Functor/Utils.v
@@ -17,11 +17,11 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive StateR s a : Type
-  := | Mk_StateR (runStateR : s -> (s * a)%type) : StateR s a.
+Inductive StateR s a : Type :=
+  | Mk_StateR (runStateR : s -> (s * a)%type) : StateR s a.
 
-Inductive StateL s a : Type
-  := | Mk_StateL (runStateL : s -> (s * a)%type) : StateL s a.
+Inductive StateL s a : Type :=
+  | Mk_StateL (runStateL : s -> (s * a)%type) : StateL s a.
 
 Inductive Min a : Type := | Mk_Min (getMin : option a) : Min a.
 

--- a/base/Data/List.v
+++ b/base/Data/List.v
@@ -20,14 +20,14 @@ Import GHC.Base.Notations.
 (* Converted value declarations: *)
 
 Fixpoint isSubsequenceOf {a} `{(GHC.Base.Eq_ a)} (arg_0__ arg_1__ : list a)
-           : bool
-           := match arg_0__, arg_1__ with
-              | nil, _ => true
-              | _, nil => false
-              | (cons x a' as a), cons y b =>
-                  if x GHC.Base.== y : bool then isSubsequenceOf a' b else
-                  isSubsequenceOf a b
-              end.
+  : bool
+  := match arg_0__, arg_1__ with
+     | nil, _ => true
+     | _, nil => false
+     | (cons x a' as a), cons y b =>
+         if x GHC.Base.== y : bool then isSubsequenceOf a' b else
+         isSubsequenceOf a b
+     end.
 
 (* External variables:
      bool cons false list nil true GHC.Base.Eq_ GHC.Base.op_zeze__

--- a/base/Data/Maybe.v
+++ b/base/Data/Maybe.v
@@ -58,11 +58,11 @@ Definition catMaybes {a} : list (option a) -> list a :=
 
 Fixpoint mapMaybe {a} {b} (arg_0__ : (a -> option b)) (arg_1__ : list a) : list
                                                                            b
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | f, cons x xs =>
-                  let rs := mapMaybe f xs in match f x with | None => rs | Some r => cons r rs end
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => nil
+     | f, cons x xs =>
+         let rs := mapMaybe f xs in match f x with | None => rs | Some r => cons r rs end
+     end.
 
 Definition mapMaybeFB {b} {r} {a}
    : (b -> r -> r) -> (a -> option b) -> a -> r -> r :=

--- a/base/Data/OldList.v
+++ b/base/Data/OldList.v
@@ -28,8 +28,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive SnocBuilder a : Type
-  := | Mk_SnocBuilder : GHC.Num.Word -> list a -> list a -> SnocBuilder a.
+Inductive SnocBuilder a : Type :=
+  | Mk_SnocBuilder : GHC.Num.Word -> list a -> list a -> SnocBuilder a.
 
 Arguments Mk_SnocBuilder {_} _ _ _.
 
@@ -234,11 +234,11 @@ Definition dropWhileEnd {a} : (a -> bool) -> list a -> list a :=
              else cons x xs) nil.
 
 Fixpoint stripPrefix {a} `{Eq_ a} (arg_0__ arg_1__ : list a) : option (list a)
-           := match arg_0__, arg_1__ with
-              | nil, ys => Some ys
-              | cons x xs, cons y ys => if x == y : bool then stripPrefix xs ys else None
-              | _, _ => None
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, ys => Some ys
+     | cons x xs, cons y ys => if x == y : bool then stripPrefix xs ys else None
+     | _, _ => None
+     end.
 
 (* Skipping definition `Data.OldList.elemIndex' *)
 
@@ -252,26 +252,26 @@ Definition find {a} : (a -> bool) -> list a -> option a :=
 (* Skipping definition `Data.OldList.findIndices' *)
 
 Fixpoint isPrefixOf {a} `{(Eq_ a)} (arg_0__ arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | nil, _ => true
-              | _, nil => false
-              | cons x xs, cons y ys => andb (x == y) (isPrefixOf xs ys)
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, _ => true
+     | _, nil => false
+     | cons x xs, cons y ys => andb (x == y) (isPrefixOf xs ys)
+     end.
 
 Fixpoint dropLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list b
-           := match arg_0__, arg_1__ with
-              | nil, y => y
-              | _, nil => nil
-              | cons _ x', cons _ y' => dropLength x' y'
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, y => y
+     | _, nil => nil
+     | cons _ x', cons _ y' => dropLength x' y'
+     end.
 
 Fixpoint dropLengthMaybe {a} {b} (arg_0__ : list a) (arg_1__ : list b) : option
                                                                          (list b)
-           := match arg_0__, arg_1__ with
-              | nil, y => Some y
-              | _, nil => None
-              | cons _ x', cons _ y' => dropLengthMaybe x' y'
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, y => Some y
+     | _, nil => None
+     | cons _ x', cons _ y' => dropLengthMaybe x' y'
+     end.
 
 Definition isSuffixOf {a} `{(Eq_ a)} : list a -> list a -> bool :=
   fun ns hs =>
@@ -282,20 +282,20 @@ Definition isSuffixOf {a} `{(Eq_ a)} : list a -> list a -> bool :=
 
 Fixpoint elem_by {a} (arg_0__ : (a -> a -> bool)) (arg_1__ : a) (arg_2__
                    : list a) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, _, nil => false
-              | eq, y, cons x xs => orb (eq x y) (elem_by eq y xs)
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, _, nil => false
+     | eq, y, cons x xs => orb (eq x y) (elem_by eq y xs)
+     end.
 
 Definition nubBy {a} : (a -> a -> bool) -> list a -> list a :=
   fun eq l =>
     let fix nubBy' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, _ => nil
-                 | cons y ys, xs =>
-                     if elem_by eq y xs : bool then nubBy' ys xs else
-                     cons y (nubBy' ys (cons y xs))
-                 end in
+      := match arg_0__, arg_1__ with
+         | nil, _ => nil
+         | cons y ys, xs =>
+             if elem_by eq y xs : bool then nubBy' ys xs else
+             cons y (nubBy' ys (cons y xs))
+         end in
     nubBy' l nil.
 
 Definition nub {a} `{(Eq_ a)} : list a -> list a :=
@@ -303,10 +303,10 @@ Definition nub {a} `{(Eq_ a)} : list a -> list a :=
 
 Fixpoint deleteBy {a} (arg_0__ : (a -> a -> bool)) (arg_1__ : a) (arg_2__
                     : list a) : list a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, _, nil => nil
-              | eq, x, cons y ys => if eq x y : bool then ys else cons y (deleteBy eq x ys)
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, _, nil => nil
+     | eq, x, cons y ys => if eq x y : bool then ys else cons y (deleteBy eq x ys)
+     end.
 
 Definition delete {a} `{(Eq_ a)} : a -> list a -> list a :=
   deleteBy _==_.
@@ -342,10 +342,10 @@ Definition intersect {a} `{(Eq_ a)} : list a -> list a -> list a :=
 (* Skipping definition `Data.OldList.intersperse' *)
 
 Fixpoint prependToAll {a} (arg_0__ : a) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | sep, cons x xs => cons sep (cons x (prependToAll sep xs))
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => nil
+     | sep, cons x xs => cons sep (cons x (prependToAll sep xs))
+     end.
 
 (* Skipping definition `Data.OldList.intercalate' *)
 
@@ -365,13 +365,13 @@ Definition partition {a} : (a -> bool) -> list a -> (list a * list a)%type :=
 
 Fixpoint mapAccumL {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
                    (arg_1__ : acc) (arg_2__ : list x) : (acc * list y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, nil => pair s nil
-              | f, s, cons x xs =>
-                  let 'pair s' y := f s x in
-                  let 'pair s'' ys := mapAccumL f s' xs in
-                  pair s'' (cons y ys)
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, s, nil => pair s nil
+     | f, s, cons x xs =>
+         let 'pair s' y := f s x in
+         let 'pair s'' ys := mapAccumL f s' xs in
+         pair s'' (cons y ys)
+     end.
 
 Definition pairWithNil {acc} {y} : acc -> (acc * list y)%type :=
   fun x => pair x nil.
@@ -388,24 +388,24 @@ Definition mapAccumLF {acc} {x} {y}
 
 Fixpoint mapAccumR {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
                    (arg_1__ : acc) (arg_2__ : list x) : (acc * list y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, nil => pair s nil
-              | f, s, cons x xs =>
-                  let 'pair s' ys := mapAccumR f s xs in
-                  let 'pair s'' y := f s' x in
-                  pair s'' (cons y ys)
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, s, nil => pair s nil
+     | f, s, cons x xs =>
+         let 'pair s' ys := mapAccumR f s xs in
+         let 'pair s'' y := f s' x in
+         pair s'' (cons y ys)
+     end.
 
 Fixpoint insertBy {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ : a) (arg_2__
                     : list a) : list a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, x, nil => cons x nil
-              | cmp, x, (cons y ys' as ys) =>
-                  match cmp x y with
-                  | Gt => cons y (insertBy cmp x ys')
-                  | _ => cons x ys
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, x, nil => cons x nil
+     | cmp, x, (cons y ys' as ys) =>
+         match cmp x y with
+         | Gt => cons y (insertBy cmp x ys')
+         | _ => cons x ys
+         end
+     end.
 
 Definition insert {a} `{Ord a} : a -> list a -> list a :=
   fun e ls => insertBy (compare) e ls.
@@ -435,54 +435,54 @@ Definition minimumBy {a} {_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
     end.
 
 Fixpoint genericLength {i} {a} `{(GHC.Num.Num i)} (arg_0__ : list a) : i
-           := match arg_0__ with
-              | nil => #0
-              | cons _ l => #1 GHC.Num.+ genericLength l
-              end.
+  := match arg_0__ with
+     | nil => #0
+     | cons _ l => #1 GHC.Num.+ genericLength l
+     end.
 
 Definition strictGenericLength {i} {b} `{(GHC.Num.Num i)} : list b -> i :=
   fun l =>
     let fix gl arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, a => a
-                 | cons _ xs, a => let a' := a GHC.Num.+ #1 in GHC.Prim.seq a' (gl xs a')
-                 end in
+      := match arg_0__, arg_1__ with
+         | nil, a => a
+         | cons _ xs, a => let a' := a GHC.Num.+ #1 in GHC.Prim.seq a' (gl xs a')
+         end in
     gl l #0.
 
 Fixpoint genericTake {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
                        : list a) : list a
-           := match arg_0__, arg_1__ with
-              | n, _ =>
-                  if n <= #0 : bool then nil else
-                  match arg_0__, arg_1__ with
-                  | _, nil => nil
-                  | n, cons x xs => cons x (genericTake (n GHC.Num.- #1) xs)
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | n, _ =>
+         if n <= #0 : bool then nil else
+         match arg_0__, arg_1__ with
+         | _, nil => nil
+         | n, cons x xs => cons x (genericTake (n GHC.Num.- #1) xs)
+         end
+     end.
 
 Fixpoint genericDrop {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
                        : list a) : list a
-           := match arg_0__, arg_1__ with
-              | n, xs =>
-                  if n <= #0 : bool then xs else
-                  match arg_0__, arg_1__ with
-                  | _, nil => nil
-                  | n, cons _ xs => genericDrop (n GHC.Num.- #1) xs
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | n, xs =>
+         if n <= #0 : bool then xs else
+         match arg_0__, arg_1__ with
+         | _, nil => nil
+         | n, cons _ xs => genericDrop (n GHC.Num.- #1) xs
+         end
+     end.
 
 Fixpoint genericSplitAt {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
                           : list a) : (list a * list a)%type
-           := match arg_0__, arg_1__ with
-              | n, xs =>
-                  if n <= #0 : bool then pair nil xs else
-                  match arg_0__, arg_1__ with
-                  | _, nil => pair nil nil
-                  | n, cons x xs =>
-                      let 'pair xs' xs'' := genericSplitAt (n GHC.Num.- #1) xs in
-                      pair (cons x xs') xs''
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | n, xs =>
+         if n <= #0 : bool then pair nil xs else
+         match arg_0__, arg_1__ with
+         | _, nil => pair nil nil
+         | n, cons x xs =>
+             let 'pair xs' xs'' := genericSplitAt (n GHC.Num.- #1) xs in
+             pair (cons x xs') xs''
+         end
+     end.
 
 (* Skipping definition `Data.OldList.genericIndex' *)
 
@@ -490,12 +490,12 @@ Fixpoint genericSplitAt {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
 
 Fixpoint zipWith4 {a} {b} {c} {d} {e} (arg_0__ : (a -> b -> c -> d -> e))
                   (arg_1__ : list a) (arg_2__ : list b) (arg_3__ : list c) (arg_4__ : list d)
-           : list e
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-              | z, cons a as_, cons b bs, cons c cs, cons d ds =>
-                  cons (z a b c d) (zipWith4 z as_ bs cs ds)
-              | _, _, _, _, _ => nil
-              end.
+  : list e
+  := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+     | z, cons a as_, cons b bs, cons c cs, cons d ds =>
+         cons (z a b c d) (zipWith4 z as_ bs cs ds)
+     | _, _, _, _, _ => nil
+     end.
 
 Definition zip4 {a} {b} {c} {d}
    : list a -> list b -> list c -> list d -> list (a * b * c * d)%type :=
@@ -504,11 +504,11 @@ Definition zip4 {a} {b} {c} {d}
 Fixpoint zipWith5 {a} {b} {c} {d} {e} {f} (arg_0__
                     : (a -> b -> c -> d -> e -> f)) (arg_1__ : list a) (arg_2__ : list b) (arg_3__
                     : list c) (arg_4__ : list d) (arg_5__ : list e) : list f
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__ with
-              | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es =>
-                  cons (z a b c d e) (zipWith5 z as_ bs cs ds es)
-              | _, _, _, _, _, _ => nil
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__ with
+     | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es =>
+         cons (z a b c d e) (zipWith5 z as_ bs cs ds es)
+     | _, _, _, _, _, _ => nil
+     end.
 
 Definition zip5 {a} {b} {c} {d} {e}
    : list a ->
@@ -518,12 +518,12 @@ Definition zip5 {a} {b} {c} {d} {e}
 Fixpoint zipWith6 {a} {b} {c} {d} {e} {f} {g} (arg_0__
                     : (a -> b -> c -> d -> e -> f -> g)) (arg_1__ : list a) (arg_2__ : list b)
                   (arg_3__ : list c) (arg_4__ : list d) (arg_5__ : list e) (arg_6__ : list f)
-           : list g
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__, arg_6__ with
-              | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es, cons f fs =>
-                  cons (z a b c d e f) (zipWith6 z as_ bs cs ds es fs)
-              | _, _, _, _, _, _, _ => nil
-              end.
+  : list g
+  := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__, arg_6__ with
+     | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es, cons f fs =>
+         cons (z a b c d e f) (zipWith6 z as_ bs cs ds es fs)
+     | _, _, _, _, _, _, _ => nil
+     end.
 
 Definition zip6 {a} {b} {c} {d} {e} {f}
    : list a ->
@@ -535,25 +535,25 @@ Fixpoint zipWith7 {a} {b} {c} {d} {e} {f} {g} {h} (arg_0__
                     : (a -> b -> c -> d -> e -> f -> g -> h)) (arg_1__ : list a) (arg_2__ : list b)
                   (arg_3__ : list c) (arg_4__ : list d) (arg_5__ : list e) (arg_6__ : list f)
                   (arg_7__ : list g) : list h
-           := match arg_0__
-                  , arg_1__
-                  , arg_2__
-                  , arg_3__
-                  , arg_4__
-                  , arg_5__
-                  , arg_6__
-                  , arg_7__ with
-              | z
-              , cons a as_
-              , cons b bs
-              , cons c cs
-              , cons d ds
-              , cons e es
-              , cons f fs
-              , cons g gs =>
-                  cons (z a b c d e f g) (zipWith7 z as_ bs cs ds es fs gs)
-              | _, _, _, _, _, _, _, _ => nil
-              end.
+  := match arg_0__
+         , arg_1__
+         , arg_2__
+         , arg_3__
+         , arg_4__
+         , arg_5__
+         , arg_6__
+         , arg_7__ with
+     | z
+     , cons a as_
+     , cons b bs
+     , cons c cs
+     , cons d ds
+     , cons e es
+     , cons f fs
+     , cons g gs =>
+         cons (z a b c d e f g) (zipWith7 z as_ bs cs ds es fs gs)
+     | _, _, _, _, _, _, _, _ => nil
+     end.
 
 Definition zip7 {a} {b} {c} {d} {e} {f} {g}
    : list a ->
@@ -618,18 +618,18 @@ Definition tails {a} : list a -> list (list a) :=
     build' (fun _ =>
               (fun c n =>
                  let fix tailsGo xs
-                           := c xs (match xs with | nil => n | cons _ xs' => tailsGo xs' end) in
+                   := c xs (match xs with | nil => n | cons _ xs' => tailsGo xs' end) in
                  tailsGo lst)).
 
 (* Skipping definition `Data.OldList.subsequences' *)
 
 Fixpoint nonEmptySubsequences {a} (arg_0__ : list a) : list (list a)
-           := match arg_0__ with
-              | nil => nil
-              | cons x xs =>
-                  let f := fun ys r => cons ys (cons (cons x ys) r) in
-                  cons (cons x nil) (foldr f nil (nonEmptySubsequences xs))
-              end.
+  := match arg_0__ with
+     | nil => nil
+     | cons x xs =>
+         let f := fun ys r => cons ys (cons (cons x ys) r) in
+         cons (cons x nil) (foldr f nil (nonEmptySubsequences xs))
+     end.
 
 (* Skipping definition `Data.OldList.permutations' *)
 
@@ -660,10 +660,10 @@ Definition unwords : list String -> String :=
     | nil => GHC.Base.hs_string__ ""
     | cons w ws =>
         let fix go arg_2__
-                  := match arg_2__ with
-                     | nil => GHC.Base.hs_string__ ""
-                     | cons v vs => cons (GHC.Char.hs_char__ " ") (Coq.Init.Datatypes.app v (go vs))
-                     end in
+          := match arg_2__ with
+             | nil => GHC.Base.hs_string__ ""
+             | cons v vs => cons (GHC.Char.hs_char__ " ") (Coq.Init.Datatypes.app v (go vs))
+             end in
         Coq.Init.Datatypes.app w (go ws)
     end.
 

--- a/base/Data/Semigroup.v
+++ b/base/Data/Semigroup.v
@@ -30,8 +30,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive WrappedMonoid m : Type
-  := | WrapMonoid (unwrapMonoid : m) : WrappedMonoid m.
+Inductive WrappedMonoid m : Type :=
+  | WrapMonoid (unwrapMonoid : m) : WrappedMonoid m.
 
 Inductive Option a : Type := | Mk_Option (getOption : option a) : Option a.
 

--- a/base/GHC/Base.v
+++ b/base/GHC/Base.v
@@ -690,10 +690,10 @@ Local Definition Monoid__arrow_mempty {inst_b} {inst_a} `{Monoid inst_b}
 Definition foldr {a} {b} : (a -> b -> b) -> b -> list a -> b :=
   fun k z =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | nil => z
-                 | cons y ys => k y (go ys)
-                 end in
+      := match arg_0__ with
+         | nil => z
+         | cons y ys => k y (go ys)
+         end in
     go.
 
 Local Definition Monoid__arrow_mconcat {inst_b} {inst_a} `{Monoid inst_b}
@@ -1308,11 +1308,11 @@ Definition otherwise : bool :=
 (* Skipping definition `GHC.Base.ord' *)
 
 Fixpoint eqString (arg_0__ arg_1__ : String) : bool
-           := match arg_0__, arg_1__ with
-              | nil, nil => true
-              | cons c1 cs1, cons c2 cs2 => andb (c1 == c2) (eqString cs1 cs2)
-              | _, _ => false
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, nil => true
+     | cons c1 cs1, cons c2 cs2 => andb (c1 == c2) (eqString cs1 cs2)
+     | _, _ => false
+     end.
 
 (* Skipping definition `GHC.Base.minInt' *)
 

--- a/base/GHC/List.v
+++ b/base/GHC/List.v
@@ -120,10 +120,10 @@ Definition init {a} `{_ : GHC.Err.Default a} : list a -> list a :=
     | nil => errorEmptyList (GHC.Base.hs_string__ "init")
     | cons x xs =>
         let fix init' arg_2__ arg_3__
-                  := match arg_2__, arg_3__ with
-                     | _, nil => nil
-                     | y, cons z zs => cons y (init' z zs)
-                     end in
+          := match arg_2__, arg_3__ with
+             | _, nil => nil
+             | y, cons z zs => cons y (init' z zs)
+             end in
         init' x xs
     end.
 
@@ -131,10 +131,10 @@ Definition null {a} : list a -> bool :=
   fun arg_0__ => match arg_0__ with | nil => true | cons _ _ => false end.
 
 Fixpoint lenAcc {a} (arg_0__ : list a) (arg_1__ : GHC.Num.Int) : GHC.Num.Int
-           := match arg_0__, arg_1__ with
-              | nil, n => n
-              | cons _ ys, n => lenAcc ys (n GHC.Num.+ #1)
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, n => n
+     | cons _ ys, n => lenAcc ys (n GHC.Num.+ #1)
+     end.
 
 Definition length {a} : list a -> GHC.Num.Int :=
   fun xs => lenAcc xs #0.
@@ -150,12 +150,12 @@ Definition idLength : GHC.Num.Int -> GHC.Num.Int :=
   id.
 
 Fixpoint filter {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _pred, nil => nil
-              | pred, cons x xs =>
-                  if pred x : bool then cons x (filter pred xs) else
-                  filter pred xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _pred, nil => nil
+     | pred, cons x xs =>
+         if pred x : bool then cons x (filter pred xs) else
+         filter pred xs
+     end.
 
 Definition filterFB {a} {b} : (a -> b -> b) -> (a -> bool) -> a -> b -> b :=
   fun c p x r => if p x : bool then c x r else r.
@@ -186,10 +186,10 @@ Definition product {a} `{(GHC.Num.Num a)} : list a -> a :=
 Definition scanl {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
   let scanlGo {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
     fix scanlGo (f : (b -> a -> b)) (q : b) (ls : list a) : list b
-          := cons q (match ls with
-                   | nil => nil
-                   | cons x xs => scanlGo f (f q x) xs
-                   end) in
+      := cons q (match ls with
+               | nil => nil
+               | cons x xs => scanlGo f (f q x) xs
+               end) in
   scanlGo.
 
 Definition scanlFB {b} {a} {c}
@@ -209,10 +209,10 @@ Definition scanl1 {a} : (a -> a -> a) -> list a -> list a :=
 Definition scanl' {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
   let scanlGo' {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
     fix scanlGo' (f : (b -> a -> b)) (q : b) (ls : list a) : list b
-          := cons q (match ls with
-                   | nil => nil
-                   | cons x xs => scanlGo' f (f q x) xs
-                   end) in
+      := cons q (match ls with
+               | nil => nil
+               | cons x xs => scanlGo' f (f q x) xs
+               end) in
   scanlGo'.
 
 Definition scanlFB' {b} {a} {c}
@@ -225,11 +225,11 @@ Definition flipSeqScanl' {a} {b} : a -> b -> a :=
 Definition foldr1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | cons x nil => x
-                 | cons x xs => f x (go xs)
-                 | nil => errorEmptyList (GHC.Base.hs_string__ "foldr1")
-                 end in
+      := match arg_0__ with
+         | cons x nil => x
+         | cons x xs => f x (go xs)
+         | nil => errorEmptyList (GHC.Base.hs_string__ "foldr1")
+         end in
     go.
 
 (* Skipping definition `GHC.List.scanr' *)
@@ -248,15 +248,15 @@ Definition scanrFB {a} {b} {c}
 
 Fixpoint scanr1 {a} `{_ : GHC.Err.Default a} (arg_0__ : a -> a -> a) (arg_1__
                   : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | _, cons x nil => cons x nil
-              | f, cons x xs =>
-                  match scanr1 f xs with
-                  | (cons q _ as qs) => cons (f x q) qs
-                  | _ => GHC.Err.patternFailure
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => nil
+     | _, cons x nil => cons x nil
+     | f, cons x xs =>
+         match scanr1 f xs with
+         | (cons q _ as qs) => cons (f x q) qs
+         | _ => GHC.Err.patternFailure
+         end
+     end.
 
 Definition maximum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
    : list a -> a :=
@@ -291,20 +291,20 @@ Definition minimum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
 (* Skipping definition `GHC.List.cycle' *)
 
 Fixpoint takeWhile {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | p, cons x xs => if p x : bool then cons x (takeWhile p xs) else nil
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => nil
+     | p, cons x xs => if p x : bool then cons x (takeWhile p xs) else nil
+     end.
 
 Definition takeWhileFB {a} {b}
    : (a -> bool) -> (a -> b -> b) -> b -> a -> b -> b :=
   fun p c n => fun x r => if p x : bool then c x r else n.
 
 Fixpoint dropWhile {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | p, (cons x xs' as xs) => if p x : bool then dropWhile p xs' else xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => nil
+     | p, (cons x xs' as xs) => if p x : bool then dropWhile p xs' else xs
+     end.
 
 (* Skipping definition `GHC.List.take' *)
 
@@ -327,74 +327,74 @@ Definition takeFB {a} {b}
 
 Fixpoint span {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : (list a *
                                                                 list a)%type
-           := match arg_0__, arg_1__ with
-              | _, (nil as xs) => pair xs xs
-              | p, (cons x xs' as xs) =>
-                  if p x : bool then let 'pair ys zs := span p xs' in pair (cons x ys) zs else
-                  pair nil xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, (nil as xs) => pair xs xs
+     | p, (cons x xs' as xs) =>
+         if p x : bool then let 'pair ys zs := span p xs' in pair (cons x ys) zs else
+         pair nil xs
+     end.
 
 Fixpoint break {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : (list a *
                                                                  list a)%type
-           := match arg_0__, arg_1__ with
-              | _, (nil as xs) => pair xs xs
-              | p, (cons x xs' as xs) =>
-                  if p x : bool then pair nil xs else
-                  let 'pair ys zs := break p xs' in
-                  pair (cons x ys) zs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, (nil as xs) => pair xs xs
+     | p, (cons x xs' as xs) =>
+         if p x : bool then pair nil xs else
+         let 'pair ys zs := break p xs' in
+         pair (cons x ys) zs
+     end.
 
 Definition reverse {a} : list a -> list a :=
   fun l =>
     let fix rev arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, a => a
-                 | cons x xs, a => rev xs (cons x a)
-                 end in
+      := match arg_0__, arg_1__ with
+         | nil, a => a
+         | cons x xs, a => rev xs (cons x a)
+         end in
     rev l nil.
 
 Fixpoint and (arg_0__ : list bool) : bool
-           := match arg_0__ with
-              | nil => true
-              | cons x xs => andb x (and xs)
-              end.
+  := match arg_0__ with
+     | nil => true
+     | cons x xs => andb x (and xs)
+     end.
 
 Fixpoint or (arg_0__ : list bool) : bool
-           := match arg_0__ with
-              | nil => false
-              | cons x xs => orb x (or xs)
-              end.
+  := match arg_0__ with
+     | nil => false
+     | cons x xs => orb x (or xs)
+     end.
 
 Fixpoint any {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | _, nil => false
-              | p, cons x xs => orb (p x) (any p xs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => false
+     | p, cons x xs => orb (p x) (any p xs)
+     end.
 
 Fixpoint all {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | _, nil => true
-              | p, cons x xs => andb (p x) (all p xs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => true
+     | p, cons x xs => andb (p x) (all p xs)
+     end.
 
 Fixpoint elem {a} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | _, nil => false
-              | x, cons y ys => orb (x == y) (elem x ys)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => false
+     | x, cons y ys => orb (x == y) (elem x ys)
+     end.
 
 Fixpoint notElem {a} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | _, nil => true
-              | x, cons y ys => andb (x /= y) (notElem x ys)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => true
+     | x, cons y ys => andb (x /= y) (notElem x ys)
+     end.
 
 Fixpoint lookup {a} {b} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list (a * b)%type)
-           : option b
-           := match arg_0__, arg_1__ with
-              | _key, nil => None
-              | key, cons (pair x y) xys => if key == x : bool then Some y else lookup key xys
-              end.
+  : option b
+  := match arg_0__, arg_1__ with
+     | _key, nil => None
+     | key, cons (pair x y) xys => if key == x : bool then Some y else lookup key xys
+     end.
 
 (* Skipping definition `Coq.Lists.List.flat_map' *)
 
@@ -427,11 +427,11 @@ Definition foldr2 {a} {b} {c}
    : (a -> b -> c -> c) -> c -> list a -> list b -> c :=
   fun k z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, _ys => z
-                 | _xs, nil => z
-                 | cons x xs, cons y ys => k x y (go xs ys)
-                 end in
+      := match arg_0__, arg_1__ with
+         | nil, _ys => z
+         | _xs, nil => z
+         | cons x xs, cons y ys => k x y (go xs ys)
+         end in
     go.
 
 Definition foldr2_left {a} {b} {c} {d}
@@ -443,11 +443,11 @@ Definition foldr2_left {a} {b} {c} {d}
     end.
 
 Fixpoint zip {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list (a * b)%type
-           := match arg_0__, arg_1__ with
-              | nil, _bs => nil
-              | _as, nil => nil
-              | cons a as_, cons b bs => cons (pair a b) (zip as_ bs)
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, _bs => nil
+     | _as, nil => nil
+     | cons a as_, cons b bs => cons (pair a b) (zip as_ bs)
+     end.
 
 Definition zipFB {a} {b} {c} {d}
    : ((a * b)%type -> c -> d) -> a -> b -> c -> d :=
@@ -455,19 +455,19 @@ Definition zipFB {a} {b} {c} {d}
 
 Fixpoint zip3 {a} {b} {c} (arg_0__ : list a) (arg_1__ : list b) (arg_2__
                 : list c) : list (a * b * c)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | cons a as_, cons b bs, cons c cs => cons (pair (pair a b) c) (zip3 as_ bs cs)
-              | _, _, _ => nil
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | cons a as_, cons b bs, cons c cs => cons (pair (pair a b) c) (zip3 as_ bs cs)
+     | _, _, _ => nil
+     end.
 
 Definition zipWith {a} {b} {c} : (a -> b -> c) -> list a -> list b -> list c :=
   fun f =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, _ => nil
-                 | _, nil => nil
-                 | cons x xs, cons y ys => cons (f x y) (go xs ys)
-                 end in
+      := match arg_0__, arg_1__ with
+         | nil, _ => nil
+         | _, nil => nil
+         | cons x xs, cons y ys => cons (f x y) (go xs ys)
+         end in
     go.
 
 Definition zipWithFB {a} {b} {c} {d} {e}
@@ -478,10 +478,10 @@ Definition zipWith3 {a} {b} {c} {d}
    : (a -> b -> c -> d) -> list a -> list b -> list c -> list d :=
   fun z =>
     let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | cons a as_, cons b bs, cons c cs => cons (z a b c) (go as_ bs cs)
-                 | _, _, _ => nil
-                 end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | cons a as_, cons b bs, cons c cs => cons (z a b c) (go as_ bs cs)
+         | _, _, _ => nil
+         end in
     go.
 
 Definition unzip {a} {b} : list (a * b)%type -> (list a * list b)%type :=

--- a/examples/containers/hs-spec/IntSetProperties.v
+++ b/examples/containers/hs-spec/IntSetProperties.v
@@ -249,23 +249,21 @@ Definition powersOf2 : Data.IntSet.Internal.IntSet :=
                                                          (GHC.Enum.enumFromTo #0 #63)).
 
 Fixpoint prop_MaskPow2 (arg_0__ : Data.IntSet.Internal.IntSet) : bool
-           := match arg_0__ with
-              | Data.IntSet.Internal.Bin _ msk left_ right_ =>
-                  andb (Data.IntSet.Internal.member msk powersOf2) (andb (prop_MaskPow2 left_)
-                                                                         (prop_MaskPow2 right_))
-              | _ => true
-              end.
+  := match arg_0__ with
+     | Data.IntSet.Internal.Bin _ msk left_ right_ =>
+         andb (Data.IntSet.Internal.member msk powersOf2) (andb (prop_MaskPow2 left_)
+                                                                (prop_MaskPow2 right_))
+     | _ => true
+     end.
 
 Fixpoint prop_Prefix (arg_0__ : Data.IntSet.Internal.IntSet) : bool
-           := match arg_0__ with
-              | (Data.IntSet.Internal.Bin prefix msk left_ right_ as s) =>
-                  andb (Data.Foldable.all (fun elem =>
-                                             Data.IntSet.Internal.match_ elem prefix msk) (Data.IntSet.Internal.toList
-                                                                                           s)) (andb (prop_Prefix left_)
-                                                                                                     (prop_Prefix
-                                                                                                      right_))
-              | _ => true
-              end.
+  := match arg_0__ with
+     | (Data.IntSet.Internal.Bin prefix msk left_ right_ as s) =>
+         andb (Data.Foldable.all (fun elem =>
+                                    Data.IntSet.Internal.match_ elem prefix msk) (Data.IntSet.Internal.toList s))
+              (andb (prop_Prefix left_) (prop_Prefix right_))
+     | _ => true
+     end.
 
 Definition prop_LeftRight : Data.IntSet.Internal.IntSet -> bool :=
   fun arg_0__ =>

--- a/examples/containers/lib/Data/IntMap/Internal.v
+++ b/examples/containers/lib/Data/IntMap/Internal.v
@@ -40,8 +40,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive WhenMatched f x y z : Type
-  := | Mk_WhenMatched (matchedKey
+Inductive WhenMatched f x y z : Type :=
+  | Mk_WhenMatched (matchedKey
     : Data.IntSet.Internal.Key -> x -> y -> f (option z))
    : WhenMatched f x y z.
 
@@ -63,23 +63,23 @@ Definition IntSetPrefix :=
 Definition IntSetBitMap :=
   GHC.Num.Word%type.
 
-Inductive IntMap a : Type
-  := | Bin : Prefix -> Mask -> (IntMap a) -> (IntMap a) -> IntMap a
-  |  Tip : Data.IntSet.Internal.Key -> a -> IntMap a
-  |  Nil : IntMap a.
+Inductive IntMap a : Type :=
+  | Bin : Prefix -> Mask -> (IntMap a) -> (IntMap a) -> IntMap a
+  | Tip : Data.IntSet.Internal.Key -> a -> IntMap a
+  | Nil : IntMap a.
 
-Inductive SplitLookup a : Type
-  := | Mk_SplitLookup : (IntMap a) -> (option a) -> (IntMap a) -> SplitLookup a.
+Inductive SplitLookup a : Type :=
+  | Mk_SplitLookup : (IntMap a) -> (option a) -> (IntMap a) -> SplitLookup a.
 
-Inductive Stack a : Type
-  := | Push : Prefix -> (IntMap a) -> (Stack a) -> Stack a
-  |  Nada : Stack a.
+Inductive Stack a : Type :=
+  | Push : Prefix -> (IntMap a) -> (Stack a) -> Stack a
+  | Nada : Stack a.
 
-Inductive View a : Type
-  := | Mk_View : Data.IntSet.Internal.Key -> a -> (IntMap a) -> View a.
+Inductive View a : Type :=
+  | Mk_View : Data.IntSet.Internal.Key -> a -> (IntMap a) -> View a.
 
-Inductive WhenMissing f x y : Type
-  := | Mk_WhenMissing (missingSubtree : IntMap x -> f (IntMap y)) (missingKey
+Inductive WhenMissing f x y : Type :=
+  | Mk_WhenMissing (missingSubtree : IntMap x -> f (IntMap y)) (missingKey
     : Data.IntSet.Internal.Key -> x -> f (option y))
    : WhenMissing f x y.
 
@@ -200,34 +200,32 @@ Definition mergeWithKey' {c} {a} {b}
                                           maybe_link p1 (g1 t1) p2 (g2 t2)
                                       | (Bin _ _ _ _ as t1'), (Tip k2' _ as t2') =>
                                           let fix merge0 arg_18__ arg_19__ arg_20__
-                                                    := match arg_18__, arg_19__, arg_20__ with
-                                                       | t2, k2, (Bin p1 m1 l1 r1 as t1) =>
-                                                           if nomatch k2 p1 m1 : bool
-                                                           then maybe_link p1 (g1 t1) k2 (g2 t2) else
-                                                           if Data.IntSet.Internal.zero k2 m1 : bool
-                                                           then bin' p1 m1 (merge0 t2 k2 l1) (g1 r1) else
-                                                           bin' p1 m1 (g1 l1) (merge0 t2 k2 r1)
-                                                       | t2, k2, (Tip k1 _ as t1) =>
-                                                           if k1 GHC.Base.== k2 : bool then f t1 t2 else
-                                                           maybe_link k1 (g1 t1) k2 (g2 t2)
-                                                       | t2, _, Nil => g2 t2
-                                                       end in
+                                            := match arg_18__, arg_19__, arg_20__ with
+                                               | t2, k2, (Bin p1 m1 l1 r1 as t1) =>
+                                                   if nomatch k2 p1 m1 : bool then maybe_link p1 (g1 t1) k2 (g2 t2) else
+                                                   if Data.IntSet.Internal.zero k2 m1 : bool
+                                                   then bin' p1 m1 (merge0 t2 k2 l1) (g1 r1) else
+                                                   bin' p1 m1 (g1 l1) (merge0 t2 k2 r1)
+                                               | t2, k2, (Tip k1 _ as t1) =>
+                                                   if k1 GHC.Base.== k2 : bool then f t1 t2 else
+                                                   maybe_link k1 (g1 t1) k2 (g2 t2)
+                                               | t2, _, Nil => g2 t2
+                                               end in
                                           merge0 t2' k2' t1'
                                       | (Bin _ _ _ _ as t1), Nil => g1 t1
                                       | (Tip k1' _ as t1'), t2' =>
                                           let fix merge0 arg_30__ arg_31__ arg_32__
-                                                    := match arg_30__, arg_31__, arg_32__ with
-                                                       | t1, k1, (Bin p2 m2 l2 r2 as t2) =>
-                                                           if nomatch k1 p2 m2 : bool
-                                                           then maybe_link k1 (g1 t1) p2 (g2 t2) else
-                                                           if Data.IntSet.Internal.zero k1 m2 : bool
-                                                           then bin' p2 m2 (merge0 t1 k1 l2) (g2 r2) else
-                                                           bin' p2 m2 (g2 l2) (merge0 t1 k1 r2)
-                                                       | t1, k1, (Tip k2 _ as t2) =>
-                                                           if k1 GHC.Base.== k2 : bool then f t1 t2 else
-                                                           maybe_link k1 (g1 t1) k2 (g2 t2)
-                                                       | t1, _, Nil => g1 t1
-                                                       end in
+                                            := match arg_30__, arg_31__, arg_32__ with
+                                               | t1, k1, (Bin p2 m2 l2 r2 as t2) =>
+                                                   if nomatch k1 p2 m2 : bool then maybe_link k1 (g1 t1) p2 (g2 t2) else
+                                                   if Data.IntSet.Internal.zero k1 m2 : bool
+                                                   then bin' p2 m2 (merge0 t1 k1 l2) (g2 r2) else
+                                                   bin' p2 m2 (g2 l2) (merge0 t1 k1 r2)
+                                               | t1, k1, (Tip k2 _ as t2) =>
+                                                   if k1 GHC.Base.== k2 : bool then f t1 t2 else
+                                                   maybe_link k1 (g1 t1) k2 (g2 t2)
+                                               | t1, _, Nil => g1 t1
+                                               end in
                                           merge0 t1' k1' t2'
                                       | Nil, t2 => g2 t2
                                       end) in
@@ -272,11 +270,11 @@ Local Definition Foldable__IntMap_fold
    : forall {m}, forall `{GHC.Base.Monoid m}, IntMap m -> m :=
   fun {m} `{GHC.Base.Monoid m} =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => GHC.Base.mempty
-                 | Tip _ v => v
-                 | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
-                 end in
+      := match arg_0__ with
+         | Nil => GHC.Base.mempty
+         | Tip _ v => v
+         | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
+         end in
     go.
 
 Local Definition Foldable__IntMap_foldMap
@@ -284,21 +282,21 @@ Local Definition Foldable__IntMap_foldMap
   fun {m} {a} `{GHC.Base.Monoid m} =>
     fun f t =>
       let fix go arg_0__
-                := match arg_0__ with
-                   | Nil => GHC.Base.mempty
-                   | Tip _ v => f v
-                   | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
-                   end in
+        := match arg_0__ with
+           | Nil => GHC.Base.mempty
+           | Tip _ v => f v
+           | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
+           end in
       go t.
 
 Definition foldl {a} {b} : (a -> b -> a) -> a -> IntMap b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f z' x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip _ x => f z' x
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
@@ -312,11 +310,11 @@ Local Definition Foldable__IntMap_foldl
 Definition foldl' {a} {b} : (a -> b -> a) -> a -> IntMap b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f z' x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip _ x => f z' x
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
@@ -330,11 +328,11 @@ Local Definition Foldable__IntMap_foldl'
 Definition foldr {a} {b} : (a -> b -> b) -> b -> IntMap a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip _ x => f x z'
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -348,11 +346,11 @@ Local Definition Foldable__IntMap_foldr
 Definition foldr' {a} {b} : (a -> b -> b) -> b -> IntMap a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip _ x => f x z'
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -365,11 +363,11 @@ Local Definition Foldable__IntMap_foldr'
 
 Definition size {a} : IntMap a -> Coq.Numbers.BinNums.N :=
   let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | acc, Bin _ _ l r => go (go acc l) r
-               | acc, Tip _ _ => #1 GHC.Num.+ acc
-               | acc, Nil => acc
-               end in
+    := match arg_0__, arg_1__ with
+       | acc, Bin _ _ l r => go (go acc l) r
+       | acc, Tip _ _ => #1 GHC.Num.+ acc
+       | acc, Nil => acc
+       end in
   go #0.
 
 Definition Foldable__IntMap_length : forall {a}, IntMap a -> GHC.Num.Int :=
@@ -416,11 +414,11 @@ Definition traverseWithKey {t} {a} {b} `{GHC.Base.Applicative t}
    : (Data.IntSet.Internal.Key -> a -> t b) -> IntMap a -> t (IntMap b) :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => GHC.Base.pure Nil
-                 | Tip k v => Tip k Data.Functor.<$> f k v
-                 | Bin p m l r => GHC.Base.liftA2 (Bin p m) (go l) (go r)
-                 end in
+      := match arg_0__ with
+         | Nil => GHC.Base.pure Nil
+         | Tip k v => Tip k Data.Functor.<$> f k v
+         | Bin p m l r => GHC.Base.liftA2 (Bin p m) (go l) (go r)
+         end in
     go.
 
 Local Definition Traversable__IntMap_traverse
@@ -447,11 +445,11 @@ Local Definition Traversable__IntMap_sequence
 Definition map {a} {b} : (a -> b) -> IntMap a -> IntMap b :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r => Bin p m (go l) (go r)
-                 | Tip k x => Tip k (f x)
-                 | Nil => Nil
-                 end in
+      := match arg_0__ with
+         | Bin p m l r => Bin p m (go l) (go r)
+         | Tip k x => Tip k (f x)
+         | Nil => Nil
+         end in
     go.
 
 Local Definition Functor__IntMap_fmap
@@ -511,28 +509,28 @@ Program Instance Traversable__IntMap : Data.Traversable.Traversable IntMap :=
    `Data.IntMap.Internal.IsList__IntMap' *)
 
 Fixpoint equal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
-                                                                            r2)))
-              | Tip kx x, Tip ky y => andb (kx GHC.Base.== ky) (x GHC.Base.== y)
-              | Nil, Nil => true
-              | _, _ => false
-              end.
+  := match arg_0__, arg_1__ with
+     | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+         andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
+                                                                   r2)))
+     | Tip kx x, Tip ky y => andb (kx GHC.Base.== ky) (x GHC.Base.== y)
+     | Nil, Nil => true
+     | _, _ => false
+     end.
 
 Local Definition Eq___IntMap_op_zeze__ {inst_a} `{GHC.Base.Eq_ inst_a}
    : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
   fun t1 t2 => equal t1 t2.
 
 Fixpoint nequal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
-                                                                         r2)))
-              | Tip kx x, Tip ky y => orb (kx GHC.Base./= ky) (x GHC.Base./= y)
-              | Nil, Nil => false
-              | _, _ => true
-              end.
+  := match arg_0__, arg_1__ with
+     | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+         orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
+                                                                r2)))
+     | Tip kx x, Tip ky y => orb (kx GHC.Base./= ky) (x GHC.Base./= y)
+     | Nil, Nil => false
+     | _, _ => true
+     end.
 
 Local Definition Eq___IntMap_op_zsze__ {inst_a} `{GHC.Base.Eq_ inst_a}
    : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
@@ -550,11 +548,11 @@ Definition foldrWithKey {a} {b}
    : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f kx x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx x => f kx x z'
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -639,14 +637,14 @@ Definition bitmapOf : Coq.Numbers.BinNums.N -> IntSetBitMap :=
 Definition lookup {a} : Data.IntSet.Internal.Key -> IntMap a -> option a :=
   fun k =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch k p m : bool then None else
-                     if Data.IntSet.Internal.zero k m : bool then go l else
-                     go r
-                 | Tip kx x => if k GHC.Base.== kx : bool then Some x else None
-                 | Nil => None
-                 end in
+      := match arg_0__ with
+         | Bin p m l r =>
+             if nomatch k p m : bool then None else
+             if Data.IntSet.Internal.zero k m : bool then go l else
+             go r
+         | Tip kx x => if k GHC.Base.== kx : bool then Some x else None
+         | Nil => None
+         end in
     go.
 
 Definition op_znz3fU__ {a} : IntMap a -> Data.IntSet.Internal.Key -> option a :=
@@ -700,14 +698,14 @@ Infix "\\" := (_\\_) (at level 99).
 Definition member {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
   fun k =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch k p m : bool then false else
-                     if Data.IntSet.Internal.zero k m : bool then go l else
-                     go r
-                 | Tip kx _ => k GHC.Base.== kx
-                 | Nil => false
-                 end in
+      := match arg_0__ with
+         | Bin p m l r =>
+             if nomatch k p m : bool then false else
+             if Data.IntSet.Internal.zero k m : bool then go l else
+             go r
+         | Tip kx _ => k GHC.Base.== kx
+         | Nil => false
+         end in
     go.
 
 Definition notMember {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
@@ -719,42 +717,42 @@ Definition findWithDefault {a}
    : a -> Data.IntSet.Internal.Key -> IntMap a -> a :=
   fun def k =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch k p m : bool then def else
-                     if Data.IntSet.Internal.zero k m : bool then go l else
-                     go r
-                 | Tip kx x => if k GHC.Base.== kx : bool then x else def
-                 | Nil => def
-                 end in
+      := match arg_0__ with
+         | Bin p m l r =>
+             if nomatch k p m : bool then def else
+             if Data.IntSet.Internal.zero k m : bool then go l else
+             go r
+         | Tip kx x => if k GHC.Base.== kx : bool then x else def
+         | Nil => def
+         end in
     go.
 
 Fixpoint unsafeFindMax {a} (arg_0__ : IntMap a) : option
                                                   (Data.IntSet.Internal.Key * a)%type
-           := match arg_0__ with
-              | Nil => None
-              | Tip ky y => Some (pair ky y)
-              | Bin _ _ _ r => unsafeFindMax r
-              end.
+  := match arg_0__ with
+     | Nil => None
+     | Tip ky y => Some (pair ky y)
+     | Bin _ _ _ r => unsafeFindMax r
+     end.
 
 Definition lookupLT {a}
    : Data.IntSet.Internal.Key ->
      IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
   fun k t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if Data.IntSet.Internal.zero k m : bool then go def l else
-                     go l r
-                 | def, Tip ky y =>
-                     if k GHC.Base.<= ky : bool then unsafeFindMax def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMax def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch k p m : bool
+             then if k GHC.Base.< p : bool
+                  then unsafeFindMax def
+                  else unsafeFindMax r else
+             if Data.IntSet.Internal.zero k m : bool then go def l else
+             go l r
+         | def, Tip ky y =>
+             if k GHC.Base.<= ky : bool then unsafeFindMax def else
+             Some (pair ky y)
+         | def, Nil => unsafeFindMax def
+         end in
     let j_10__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -768,30 +766,30 @@ Definition lookupLT {a}
 
 Fixpoint unsafeFindMin {a} (arg_0__ : IntMap a) : option
                                                   (Data.IntSet.Internal.Key * a)%type
-           := match arg_0__ with
-              | Nil => None
-              | Tip ky y => Some (pair ky y)
-              | Bin _ _ l _ => unsafeFindMin l
-              end.
+  := match arg_0__ with
+     | Nil => None
+     | Tip ky y => Some (pair ky y)
+     | Bin _ _ l _ => unsafeFindMin l
+     end.
 
 Definition lookupGT {a}
    : Data.IntSet.Internal.Key ->
      IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
   fun k t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if Data.IntSet.Internal.zero k m : bool then go r l else
-                     go def r
-                 | def, Tip ky y =>
-                     if k GHC.Base.>= ky : bool then unsafeFindMin def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMin def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch k p m : bool
+             then if k GHC.Base.< p : bool
+                  then unsafeFindMin l
+                  else unsafeFindMin def else
+             if Data.IntSet.Internal.zero k m : bool then go r l else
+             go def r
+         | def, Tip ky y =>
+             if k GHC.Base.>= ky : bool then unsafeFindMin def else
+             Some (pair ky y)
+         | def, Nil => unsafeFindMin def
+         end in
     let j_10__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -808,19 +806,19 @@ Definition lookupLE {a}
      IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
   fun k t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if Data.IntSet.Internal.zero k m : bool then go def l else
-                     go l r
-                 | def, Tip ky y =>
-                     if k GHC.Base.< ky : bool then unsafeFindMax def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMax def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch k p m : bool
+             then if k GHC.Base.< p : bool
+                  then unsafeFindMax def
+                  else unsafeFindMax r else
+             if Data.IntSet.Internal.zero k m : bool then go def l else
+             go l r
+         | def, Tip ky y =>
+             if k GHC.Base.< ky : bool then unsafeFindMax def else
+             Some (pair ky y)
+         | def, Nil => unsafeFindMax def
+         end in
     let j_10__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -837,19 +835,19 @@ Definition lookupGE {a}
      IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
   fun k t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if Data.IntSet.Internal.zero k m : bool then go r l else
-                     go def r
-                 | def, Tip ky y =>
-                     if k GHC.Base.> ky : bool then unsafeFindMin def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMin def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch k p m : bool
+             then if k GHC.Base.< p : bool
+                  then unsafeFindMin l
+                  else unsafeFindMin def else
+             if Data.IntSet.Internal.zero k m : bool then go r l else
+             go def r
+         | def, Tip ky y =>
+             if k GHC.Base.> ky : bool then unsafeFindMin def else
+             Some (pair ky y)
+         | def, Nil => unsafeFindMin def
+         end in
     let j_10__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -866,31 +864,31 @@ Definition singleton {a} : Data.IntSet.Internal.Key -> a -> IntMap a :=
 
 Fixpoint insert {a} (arg_0__ : Data.IntSet.Internal.Key) (arg_1__ : a) (arg_2__
                   : IntMap a) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | k, x, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then link k (Tip k x) p t else
-                  if Data.IntSet.Internal.zero k m : bool then Bin p m (insert k x l) r else
-                  Bin p m l (insert k x r)
-              | k, x, (Tip ky _ as t) =>
-                  if k GHC.Base.== ky : bool then Tip k x else
-                  link k (Tip k x) ky t
-              | k, x, Nil => Tip k x
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | k, x, (Bin p m l r as t) =>
+         if nomatch k p m : bool then link k (Tip k x) p t else
+         if Data.IntSet.Internal.zero k m : bool then Bin p m (insert k x l) r else
+         Bin p m l (insert k x r)
+     | k, x, (Tip ky _ as t) =>
+         if k GHC.Base.== ky : bool then Tip k x else
+         link k (Tip k x) ky t
+     | k, x, Nil => Tip k x
+     end.
 
 Fixpoint insertWithKey {a} (arg_0__ : (Data.IntSet.Internal.Key -> a -> a -> a))
                        (arg_1__ : Data.IntSet.Internal.Key) (arg_2__ : a) (arg_3__ : IntMap a) : IntMap
                                                                                                  a
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | f, k, x, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then link k (Tip k x) p t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then Bin p m (insertWithKey f k x l) r else
-                  Bin p m l (insertWithKey f k x r)
-              | f, k, x, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool then Tip k (f k x y) else
-                  link k (Tip k x) ky t
-              | _, k, x, Nil => Tip k x
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | f, k, x, (Bin p m l r as t) =>
+         if nomatch k p m : bool then link k (Tip k x) p t else
+         if Data.IntSet.Internal.zero k m : bool
+         then Bin p m (insertWithKey f k x l) r else
+         Bin p m l (insertWithKey f k x r)
+     | f, k, x, (Tip ky y as t) =>
+         if k GHC.Base.== ky : bool then Tip k (f k x y) else
+         link k (Tip k x) ky t
+     | _, k, x, Nil => Tip k x
+     end.
 
 Definition insertWith {a}
    : (a -> a -> a) -> Data.IntSet.Internal.Key -> a -> IntMap a -> IntMap a :=
@@ -904,19 +902,19 @@ Fixpoint insertLookupWithKey {a} (arg_0__
                                : (Data.IntSet.Internal.Key -> a -> a -> a)) (arg_1__
                                : Data.IntSet.Internal.Key) (arg_2__ : a) (arg_3__ : IntMap a) : (option a *
                                                                                                  IntMap a)%type
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | f, k, x, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then pair None (link k (Tip k x) p t) else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then let 'pair found l' := insertLookupWithKey f k x l in
-                       pair found (Bin p m l' r) else
-                  let 'pair found r' := insertLookupWithKey f k x r in
-                  pair found (Bin p m l r')
-              | f, k, x, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool then pair (Some y) (Tip k (f k x y)) else
-                  pair None (link k (Tip k x) ky t)
-              | _, k, x, Nil => pair None (Tip k x)
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | f, k, x, (Bin p m l r as t) =>
+         if nomatch k p m : bool then pair None (link k (Tip k x) p t) else
+         if Data.IntSet.Internal.zero k m : bool
+         then let 'pair found l' := insertLookupWithKey f k x l in
+              pair found (Bin p m l' r) else
+         let 'pair found r' := insertLookupWithKey f k x r in
+         pair found (Bin p m l r')
+     | f, k, x, (Tip ky y as t) =>
+         if k GHC.Base.== ky : bool then pair (Some y) (Tip k (f k x y)) else
+         pair None (link k (Tip k x) ky t)
+     | _, k, x, Nil => pair None (Tip k x)
+     end.
 
 Definition binCheckLeft {a}
    : Prefix -> Mask -> IntMap a -> IntMap a -> IntMap a :=
@@ -935,28 +933,28 @@ Definition binCheckRight {a}
     end.
 
 Fixpoint delete {a} (arg_0__ : Data.IntSet.Internal.Key) (arg_1__ : IntMap a)
-           : IntMap a
-           := match arg_0__, arg_1__ with
-              | k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then binCheckLeft p m (delete k l) r else
-                  binCheckRight p m l (delete k r)
-              | k, (Tip ky _ as t) => if k GHC.Base.== ky : bool then Nil else t
-              | _k, Nil => Nil
-              end.
+  : IntMap a
+  := match arg_0__, arg_1__ with
+     | k, (Bin p m l r as t) =>
+         if nomatch k p m : bool then t else
+         if Data.IntSet.Internal.zero k m : bool
+         then binCheckLeft p m (delete k l) r else
+         binCheckRight p m l (delete k r)
+     | k, (Tip ky _ as t) => if k GHC.Base.== ky : bool then Nil else t
+     | _k, Nil => Nil
+     end.
 
 Fixpoint adjustWithKey {a} (arg_0__ : (Data.IntSet.Internal.Key -> a -> a))
                        (arg_1__ : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then Bin p m (adjustWithKey f k l) r else
-                  Bin p m l (adjustWithKey f k r)
-              | f, k, (Tip ky y as t) => if k GHC.Base.== ky : bool then Tip ky (f k y) else t
-              | _, _, Nil => Nil
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | f, k, (Bin p m l r as t) =>
+         if nomatch k p m : bool then t else
+         if Data.IntSet.Internal.zero k m : bool
+         then Bin p m (adjustWithKey f k l) r else
+         Bin p m l (adjustWithKey f k r)
+     | f, k, (Tip ky y as t) => if k GHC.Base.== ky : bool then Tip ky (f k y) else t
+     | _, _, Nil => Nil
+     end.
 
 Definition adjust {a}
    : (a -> a) -> Data.IntSet.Internal.Key -> IntMap a -> IntMap a :=
@@ -969,21 +967,21 @@ Definition adjust {a}
 Fixpoint updateWithKey {a} (arg_0__
                          : (Data.IntSet.Internal.Key -> a -> option a)) (arg_1__
                          : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then binCheckLeft p m (updateWithKey f k l) r else
-                  binCheckRight p m l (updateWithKey f k r)
-              | f, k, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool
-                  then match (f k y) with
-                       | Some y' => Tip ky y'
-                       | None => Nil
-                       end else
-                  t
-              | _, _, Nil => Nil
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | f, k, (Bin p m l r as t) =>
+         if nomatch k p m : bool then t else
+         if Data.IntSet.Internal.zero k m : bool
+         then binCheckLeft p m (updateWithKey f k l) r else
+         binCheckRight p m l (updateWithKey f k r)
+     | f, k, (Tip ky y as t) =>
+         if k GHC.Base.== ky : bool
+         then match (f k y) with
+              | Some y' => Tip ky y'
+              | None => Nil
+              end else
+         t
+     | _, _, Nil => Nil
+     end.
 
 Definition update {a}
    : (a -> option a) -> Data.IntSet.Internal.Key -> IntMap a -> IntMap a :=
@@ -996,48 +994,48 @@ Definition update {a}
 Fixpoint updateLookupWithKey {a} (arg_0__
                                : (Data.IntSet.Internal.Key -> a -> option a)) (arg_1__
                                : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : (option a * IntMap a)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then pair None t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then let 'pair found l' := updateLookupWithKey f k l in
-                       pair found (binCheckLeft p m l' r) else
-                  let 'pair found r' := updateLookupWithKey f k r in
-                  pair found (binCheckRight p m l r')
-              | f, k, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool
-                  then match (f k y) with
-                       | Some y' => pair (Some y) (Tip ky y')
-                       | None => pair (Some y) Nil
-                       end else
-                  pair None t
-              | _, _, Nil => pair None Nil
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | f, k, (Bin p m l r as t) =>
+         if nomatch k p m : bool then pair None t else
+         if Data.IntSet.Internal.zero k m : bool
+         then let 'pair found l' := updateLookupWithKey f k l in
+              pair found (binCheckLeft p m l' r) else
+         let 'pair found r' := updateLookupWithKey f k r in
+         pair found (binCheckRight p m l r')
+     | f, k, (Tip ky y as t) =>
+         if k GHC.Base.== ky : bool
+         then match (f k y) with
+              | Some y' => pair (Some y) (Tip ky y')
+              | None => pair (Some y) Nil
+              end else
+         pair None t
+     | _, _, Nil => pair None Nil
+     end.
 
 Fixpoint alter {a} (arg_0__ : (option a -> option a)) (arg_1__
                  : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool
-                  then match f None with
-                       | None => t
-                       | Some x => link k (Tip k x) p t
-                       end else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then binCheckLeft p m (alter f k l) r else
-                  binCheckRight p m l (alter f k r)
-              | f, k, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool
-                  then match f (Some y) with
-                       | Some x => Tip ky x
-                       | None => Nil
-                       end else
-                  match f None with
-                  | Some x => link k (Tip k x) ky t
-                  | None => Tip ky y
-                  end
-              | f, k, Nil => match f None with | Some x => Tip k x | None => Nil end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | f, k, (Bin p m l r as t) =>
+         if nomatch k p m : bool
+         then match f None with
+              | None => t
+              | Some x => link k (Tip k x) p t
+              end else
+         if Data.IntSet.Internal.zero k m : bool
+         then binCheckLeft p m (alter f k l) r else
+         binCheckRight p m l (alter f k r)
+     | f, k, (Tip ky y as t) =>
+         if k GHC.Base.== ky : bool
+         then match f (Some y) with
+              | Some x => Tip ky x
+              | None => Nil
+              end else
+         match f None with
+         | Some x => link k (Tip k x) ky t
+         | None => Tip ky y
+         end
+     | f, k, Nil => match f None with | Some x => Tip k x | None => Nil end
+     end.
 
 Definition alterF {f} {a} `{GHC.Base.Functor f}
    : (option a -> f (option a)) ->
@@ -1086,26 +1084,26 @@ Definition differenceWith {a} {b}
 
 Fixpoint updatePrefix {a} (arg_0__ : IntSetPrefix) (arg_1__ : IntMap a) (arg_2__
                         : (IntMap a -> IntMap a)) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | kp, (Bin p m l r as t), f =>
-                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
-                     #0 : bool
-                  then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
-                          GHC.Base.==
-                          kp : bool
-                       then f t
-                       else t else
-                  if nomatch kp p m : bool then t else
-                  if Data.IntSet.Internal.zero kp m : bool
-                  then binCheckLeft p m (updatePrefix kp l f) r else
-                  binCheckRight p m l (updatePrefix kp r f)
-              | kp, (Tip kx _ as t), f =>
-                  if Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask GHC.Base.==
-                     kp : bool
-                  then f t else
-                  t
-              | _, Nil, _ => Nil
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | kp, (Bin p m l r as t), f =>
+         if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
+            #0 : bool
+         then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
+                 GHC.Base.==
+                 kp : bool
+              then f t
+              else t else
+         if nomatch kp p m : bool then t else
+         if Data.IntSet.Internal.zero kp m : bool
+         then binCheckLeft p m (updatePrefix kp l f) r else
+         binCheckRight p m l (updatePrefix kp r f)
+     | kp, (Tip kx _ as t), f =>
+         if Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask GHC.Base.==
+            kp : bool
+         then f t else
+         t
+     | _, Nil, _ => Nil
+     end.
 
 Definition withoutBM {a} : IntSetBitMap -> IntMap a -> IntMap a :=
   GHC.DeferredFix.deferredFix2 (fun withoutBM
@@ -1174,25 +1172,25 @@ Definition intersection {a} {b} : IntMap a -> IntMap b -> IntMap a :=
 
 Fixpoint lookupPrefix {a} (arg_0__ : IntSetPrefix) (arg_1__ : IntMap a) : IntMap
                                                                           a
-           := match arg_0__, arg_1__ with
-              | kp, (Bin p m l r as t) =>
-                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
-                     #0 : bool
-                  then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
-                          GHC.Base.==
-                          kp : bool
-                       then t
-                       else Nil else
-                  if nomatch kp p m : bool then Nil else
-                  if Data.IntSet.Internal.zero kp m : bool then lookupPrefix kp l else
-                  lookupPrefix kp r
-              | kp, (Tip kx _ as t) =>
-                  if (Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask) GHC.Base.==
-                     kp : bool
-                  then t else
-                  Nil
-              | _, Nil => Nil
-              end.
+  := match arg_0__, arg_1__ with
+     | kp, (Bin p m l r as t) =>
+         if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
+            #0 : bool
+         then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
+                 GHC.Base.==
+                 kp : bool
+              then t
+              else Nil else
+         if nomatch kp p m : bool then Nil else
+         if Data.IntSet.Internal.zero kp m : bool then lookupPrefix kp l else
+         lookupPrefix kp r
+     | kp, (Tip kx _ as t) =>
+         if (Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask) GHC.Base.==
+            kp : bool
+         then t else
+         Nil
+     | _, Nil => Nil
+     end.
 
 Definition restrictBM {a} : IntSetBitMap -> IntMap a -> IntMap a :=
   GHC.DeferredFix.deferredFix2 (fun restrictBM
@@ -1354,11 +1352,11 @@ Definition preserveMissing {f} {x} `{GHC.Base.Applicative f}
 
 Fixpoint mapWithKey {a} {b} (f : (Data.IntSet.Internal.Key -> a -> b)) (t
                       : IntMap a) : IntMap b
-           := match t with
-              | Bin p m l r => Bin p m (mapWithKey f l) (mapWithKey f r)
-              | Tip k x => Tip k (f k x)
-              | Nil => Nil
-              end.
+  := match t with
+     | Bin p m l r => Bin p m (mapWithKey f l) (mapWithKey f r)
+     | Tip k x => Tip k (f k x)
+     | Nil => Nil
+     end.
 
 Definition mapMissing {f} {x} {y} `{GHC.Base.Applicative f}
    : (Data.IntSet.Internal.Key -> x -> y) -> WhenMissing f x y :=
@@ -1368,11 +1366,11 @@ Definition mapMissing {f} {x} {y} `{GHC.Base.Applicative f}
 
 Fixpoint mapMaybeWithKey {a} {b} (arg_0__
                            : (Data.IntSet.Internal.Key -> a -> option b)) (arg_1__ : IntMap a) : IntMap b
-           := match arg_0__, arg_1__ with
-              | f, Bin p m l r => bin p m (mapMaybeWithKey f l) (mapMaybeWithKey f r)
-              | f, Tip k x => match f k x with | Some y => Tip k y | None => Nil end
-              | _, Nil => Nil
-              end.
+  := match arg_0__, arg_1__ with
+     | f, Bin p m l r => bin p m (mapMaybeWithKey f l) (mapMaybeWithKey f r)
+     | f, Tip k x => match f k x with | Some y => Tip k y | None => Nil end
+     | _, Nil => Nil
+     end.
 
 Definition mapMaybeMissing {f} {x} {y} `{GHC.Base.Applicative f}
    : (Data.IntSet.Internal.Key -> x -> option y) -> WhenMissing f x y :=
@@ -1384,11 +1382,11 @@ Definition filterWithKey {a}
    : (Data.IntSet.Internal.Key -> a -> bool) -> IntMap a -> IntMap a :=
   fun predicate =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => Nil
-                 | (Tip k x as t) => if predicate k x : bool then t else Nil
-                 | Bin p m l r => bin p m (go l) (go r)
-                 end in
+      := match arg_0__ with
+         | Nil => Nil
+         | (Tip k x as t) => if predicate k x : bool then t else Nil
+         | Bin p m l r => bin p m (go l) (go r)
+         end in
     go.
 
 Definition filterMissing {f} {x} `{GHC.Base.Applicative f}
@@ -1407,13 +1405,13 @@ Definition boolITE {a} : a -> a -> bool -> a :=
 Fixpoint filterWithKeyA {f} {a} `{GHC.Base.Applicative f} (arg_0__
                           : (Data.IntSet.Internal.Key -> a -> f bool)) (arg_1__ : IntMap a) : f (IntMap
                                                                                                  a)
-           := match arg_0__, arg_1__ with
-              | _, Nil => GHC.Base.pure Nil
-              | f, (Tip k x as t) =>
-                  (fun b => if b : bool then t else Nil) Data.Functor.<$> f k x
-              | f, Bin p m l r =>
-                  GHC.Base.liftA2 (bin p m) (filterWithKeyA f l) (filterWithKeyA f r)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Nil => GHC.Base.pure Nil
+     | f, (Tip k x as t) =>
+         (fun b => if b : bool then t else Nil) Data.Functor.<$> f k x
+     | f, Bin p m l r =>
+         GHC.Base.liftA2 (bin p m) (filterWithKeyA f l) (filterWithKeyA f r)
+     end.
 
 Definition filterAMissing {f} {x} `{GHC.Base.Applicative f}
    : (Data.IntSet.Internal.Key -> x -> f bool) -> WhenMissing f x x :=
@@ -1431,11 +1429,11 @@ Definition traverseMaybeWithKey {f} {a} {b} `{GHC.Base.Applicative f}
      IntMap a -> f (IntMap b) :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => GHC.Base.pure Nil
-                 | Tip k x => Data.Maybe.maybe Nil (Tip k) Data.Functor.<$> f k x
-                 | Bin p m l r => GHC.Base.liftA2 (bin p m) (go l) (go r)
-                 end in
+      := match arg_0__ with
+         | Nil => GHC.Base.pure Nil
+         | Tip k x => Data.Maybe.maybe Nil (Tip k) Data.Functor.<$> f k x
+         | Bin p m l r => GHC.Base.liftA2 (bin p m) (go l) (go r)
+         end in
     go.
 
 Definition traverseMaybeMissing {f} {x} {y} `{GHC.Base.Applicative f}
@@ -1478,11 +1476,11 @@ Definition lookupMin {a}
     | Tip k v => Some (pair k v)
     | Bin _ m l r =>
         let fix go arg_2__
-                  := match arg_2__ with
-                     | Tip k v => Some (pair k v)
-                     | Bin _ _ l' _ => go l'
-                     | Nil => None
-                     end in
+          := match arg_2__ with
+             | Tip k v => Some (pair k v)
+             | Bin _ _ l' _ => go l'
+             | Nil => None
+             end in
         if m GHC.Base.< #0 : bool then go r else
         go l
     end.
@@ -1497,11 +1495,11 @@ Definition lookupMax {a}
     | Tip k v => Some (pair k v)
     | Bin _ m l r =>
         let fix go arg_2__
-                  := match arg_2__ with
-                     | Tip k v => Some (pair k v)
-                     | Bin _ _ _ r' => go r'
-                     | Nil => None
-                     end in
+          := match arg_2__ with
+             | Tip k v => Some (pair k v)
+             | Bin _ _ _ r' => go r'
+             | Nil => None
+             end in
         if m GHC.Base.< #0 : bool then go l else
         go r
     end.
@@ -1514,42 +1512,42 @@ Definition lookupMax {a}
 
 Fixpoint submapCmp {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : IntMap a)
                    (arg_2__ : IntMap b) : comparison
-           := match arg_0__, arg_1__, arg_2__ with
-              | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  let submapCmpEq :=
-                    match pair (submapCmp predicate l1 l2) (submapCmp predicate r1 r2) with
-                    | pair Gt _ => Gt
-                    | pair _ Gt => Gt
-                    | pair Eq Eq => Eq
-                    | _ => Lt
-                    end in
-                  let submapCmpLt :=
-                    if nomatch p1 p2 m2 : bool then Gt else
-                    if Data.IntSet.Internal.zero p1 m2 : bool then submapCmp predicate t1 l2 else
-                    submapCmp predicate t1 r2 in
-                  if shorter m1 m2 : bool then Gt else
-                  if shorter m2 m1 : bool then submapCmpLt else
-                  if p1 GHC.Base.== p2 : bool then submapCmpEq else
-                  Gt
-              | _, _, _ =>
-                  match arg_0__, arg_1__, arg_2__ with
-                  | _, Bin _ _ _ _, _ => Gt
-                  | predicate, Tip kx x, Tip ky y =>
-                      if andb (kx GHC.Base.== ky) (predicate x y) : bool then Eq else
-                      Gt
-                  | _, _, _ =>
-                      match arg_0__, arg_1__, arg_2__ with
-                      | predicate, Tip k x, t =>
-                          match lookup k t with
-                          | Some y => if predicate x y : bool then Lt else Gt
-                          | _ => Gt
-                          end
-                      | _, Nil, Nil => Eq
-                      | _, Nil, _ => Lt
-                      | _, _, _ => GHC.Err.patternFailure
-                      end
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+         let submapCmpEq :=
+           match pair (submapCmp predicate l1 l2) (submapCmp predicate r1 r2) with
+           | pair Gt _ => Gt
+           | pair _ Gt => Gt
+           | pair Eq Eq => Eq
+           | _ => Lt
+           end in
+         let submapCmpLt :=
+           if nomatch p1 p2 m2 : bool then Gt else
+           if Data.IntSet.Internal.zero p1 m2 : bool then submapCmp predicate t1 l2 else
+           submapCmp predicate t1 r2 in
+         if shorter m1 m2 : bool then Gt else
+         if shorter m2 m1 : bool then submapCmpLt else
+         if p1 GHC.Base.== p2 : bool then submapCmpEq else
+         Gt
+     | _, _, _ =>
+         match arg_0__, arg_1__, arg_2__ with
+         | _, Bin _ _ _ _, _ => Gt
+         | predicate, Tip kx x, Tip ky y =>
+             if andb (kx GHC.Base.== ky) (predicate x y) : bool then Eq else
+             Gt
+         | _, _, _ =>
+             match arg_0__, arg_1__, arg_2__ with
+             | predicate, Tip k x, t =>
+                 match lookup k t with
+                 | Some y => if predicate x y : bool then Lt else Gt
+                 | _ => Gt
+                 end
+             | _, Nil, Nil => Eq
+             | _, Nil, _ => Lt
+             | _, _, _ => GHC.Err.patternFailure
+             end
+         end
+     end.
 
 Definition isProperSubmapOfBy {a} {b}
    : (a -> b -> bool) -> IntMap a -> IntMap b -> bool :=
@@ -1568,41 +1566,41 @@ Definition match_ : Data.IntSet.Internal.Key -> Prefix -> Mask -> bool :=
 
 Fixpoint isSubmapOfBy {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : IntMap a)
                       (arg_2__ : IntMap b) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  if shorter m1 m2 : bool then false else
-                  if shorter m2 m1 : bool
-                  then andb (match_ p1 p2 m2) (if Data.IntSet.Internal.zero p1 m2 : bool
-                             then isSubmapOfBy predicate t1 l2
-                             else isSubmapOfBy predicate t1 r2) else
-                  andb (p1 GHC.Base.== p2) (andb (isSubmapOfBy predicate l1 l2) (isSubmapOfBy
-                                                  predicate r1 r2))
-              | _, _, _ =>
-                  match arg_0__, arg_1__, arg_2__ with
-                  | _, Bin _ _ _ _, _ => false
-                  | predicate, Tip k x, t =>
-                      match lookup k t with
-                      | Some y => predicate x y
-                      | None => false
-                      end
-                  | _, Nil, _ => true
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+         if shorter m1 m2 : bool then false else
+         if shorter m2 m1 : bool
+         then andb (match_ p1 p2 m2) (if Data.IntSet.Internal.zero p1 m2 : bool
+                    then isSubmapOfBy predicate t1 l2
+                    else isSubmapOfBy predicate t1 r2) else
+         andb (p1 GHC.Base.== p2) (andb (isSubmapOfBy predicate l1 l2) (isSubmapOfBy
+                                         predicate r1 r2))
+     | _, _, _ =>
+         match arg_0__, arg_1__, arg_2__ with
+         | _, Bin _ _ _ _, _ => false
+         | predicate, Tip k x, t =>
+             match lookup k t with
+             | Some y => predicate x y
+             | None => false
+             end
+         | _, Nil, _ => true
+         end
+     end.
 
 Definition isSubmapOf {a} `{GHC.Base.Eq_ a} : IntMap a -> IntMap a -> bool :=
   fun m1 m2 => isSubmapOfBy _GHC.Base.==_ m1 m2.
 
 Fixpoint mapAccumL {a} {b} {c} (f
                      : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type)) (a0 : a) (t : IntMap b)
-           : (a * IntMap c)%type
-           := match t with
-              | Bin p m l r =>
-                  let 'pair a1 l' := mapAccumL f a0 l in
-                  let 'pair a2 r' := mapAccumL f a1 r in
-                  pair a2 (Bin p m l' r')
-              | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
-              | Nil => pair a0 Nil
-              end.
+  : (a * IntMap c)%type
+  := match t with
+     | Bin p m l r =>
+         let 'pair a1 l' := mapAccumL f a0 l in
+         let 'pair a2 r' := mapAccumL f a1 r in
+         pair a2 (Bin p m l' r')
+     | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
+     | Nil => pair a0 Nil
+     end.
 
 Definition mapAccumWithKey {a} {b} {c}
    : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type) ->
@@ -1619,15 +1617,15 @@ Definition mapAccum {a} {b} {c}
 
 Fixpoint mapAccumRWithKey {a} {b} {c} (f
                             : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type)) (a0 : a) (t : IntMap b)
-           : (a * IntMap c)%type
-           := match t with
-              | Bin p m l r =>
-                  let 'pair a1 r' := mapAccumRWithKey f a0 r in
-                  let 'pair a2 l' := mapAccumRWithKey f a1 l in
-                  pair a2 (Bin p m l' r')
-              | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
-              | Nil => pair a0 Nil
-              end.
+  : (a * IntMap c)%type
+  := match t with
+     | Bin p m l r =>
+         let 'pair a1 r' := mapAccumRWithKey f a0 r in
+         let 'pair a2 l' := mapAccumRWithKey f a1 l in
+         pair a2 (Bin p m l' r')
+     | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
+     | Nil => pair a0 Nil
+     end.
 
 Definition fromList {a}
    : list (Data.IntSet.Internal.Key * a)%type -> IntMap a :=
@@ -1686,14 +1684,14 @@ Definition partitionWithKey {a}
      IntMap a -> (IntMap a * IntMap a)%type :=
   fun predicate0 t0 =>
     let fix go predicate t
-              := match t with
-                 | Bin p m l r =>
-                     let 'pair r1 r2 := go predicate r in
-                     let 'pair l1 l2 := go predicate l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | Tip k x => if predicate k x : bool then (pair t Nil) else (pair Nil t)
-                 | Nil => (pair Nil Nil)
-                 end in
+      := match t with
+         | Bin p m l r =>
+             let 'pair r1 r2 := go predicate r in
+             let 'pair l1 l2 := go predicate l in
+             pair (bin p m l1 r1) (bin p m l2 r2)
+         | Tip k x => if predicate k x : bool then (pair t Nil) else (pair Nil t)
+         | Nil => (pair Nil Nil)
+         end in
     id (go predicate0 t0).
 
 Definition partition {a}
@@ -1716,18 +1714,18 @@ Definition mapEitherWithKey {a} {b} {c}
      IntMap a -> (IntMap b * IntMap c)%type :=
   fun f0 t0 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | f, Bin p m l r =>
-                     let 'pair r1 r2 := go f r in
-                     let 'pair l1 l2 := go f l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | f, Tip k x =>
-                     match f k x with
-                     | Data.Either.Left y => (pair (Tip k y) Nil)
-                     | Data.Either.Right z => (pair Nil (Tip k z))
-                     end
-                 | _, Nil => (pair Nil Nil)
-                 end in
+      := match arg_0__, arg_1__ with
+         | f, Bin p m l r =>
+             let 'pair r1 r2 := go f r in
+             let 'pair l1 l2 := go f l in
+             pair (bin p m l1 r1) (bin p m l2 r2)
+         | f, Tip k x =>
+             match f k x with
+             | Data.Either.Left y => (pair (Tip k y) Nil)
+             | Data.Either.Right z => (pair Nil (Tip k z))
+             end
+         | _, Nil => (pair Nil Nil)
+         end in
     id (go f0 t0).
 
 Definition mapEither {a} {b} {c}
@@ -1742,23 +1740,23 @@ Definition split {a}
    : Data.IntSet.Internal.Key -> IntMap a -> (IntMap a * IntMap a)%type :=
   fun k t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | k', (Bin p m l r as t') =>
-                     if nomatch k' p m : bool
-                     then if k' GHC.Base.> p : bool
-                          then pair t' Nil
-                          else pair Nil t' else
-                     if Data.IntSet.Internal.zero k' m : bool
-                     then let 'pair lt gt := go k' l in
-                          pair lt (union gt r) else
-                     let 'pair lt gt := go k' r in
-                     pair (union l lt) gt
-                 | k', (Tip ky _ as t') =>
-                     if k' GHC.Base.> ky : bool then (pair t' Nil) else
-                     if k' GHC.Base.< ky : bool then (pair Nil t') else
-                     (pair Nil Nil)
-                 | _, Nil => (pair Nil Nil)
-                 end in
+      := match arg_0__, arg_1__ with
+         | k', (Bin p m l r as t') =>
+             if nomatch k' p m : bool
+             then if k' GHC.Base.> p : bool
+                  then pair t' Nil
+                  else pair Nil t' else
+             if Data.IntSet.Internal.zero k' m : bool
+             then let 'pair lt gt := go k' l in
+                  pair lt (union gt r) else
+             let 'pair lt gt := go k' r in
+             pair (union l lt) gt
+         | k', (Tip ky _ as t') =>
+             if k' GHC.Base.> ky : bool then (pair t' Nil) else
+             if k' GHC.Base.< ky : bool then (pair Nil t') else
+             (pair Nil Nil)
+         | _, Nil => (pair Nil Nil)
+         end in
     let j_20__ := let 'pair lt gt := go k t in pair lt gt in
     match t with
     | Bin _ m l r =>
@@ -1791,21 +1789,21 @@ Definition splitLookup {a}
      IntMap a -> (IntMap a * option a * IntMap a)%type :=
   fun k t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | k', (Bin p m l r as t') =>
-                     if nomatch k' p m : bool
-                     then if k' GHC.Base.> p : bool
-                          then Mk_SplitLookup t' None Nil
-                          else Mk_SplitLookup Nil None t' else
-                     if Data.IntSet.Internal.zero k' m : bool
-                     then mapGT (fun arg_2__ => union arg_2__ r) (go k' l) else
-                     mapLT (union l) (go k' r)
-                 | k', (Tip ky y as t') =>
-                     if k' GHC.Base.> ky : bool then Mk_SplitLookup t' None Nil else
-                     if k' GHC.Base.< ky : bool then Mk_SplitLookup Nil None t' else
-                     Mk_SplitLookup Nil (Some y) Nil
-                 | _, Nil => Mk_SplitLookup Nil None Nil
-                 end in
+      := match arg_0__, arg_1__ with
+         | k', (Bin p m l r as t') =>
+             if nomatch k' p m : bool
+             then if k' GHC.Base.> p : bool
+                  then Mk_SplitLookup t' None Nil
+                  else Mk_SplitLookup Nil None t' else
+             if Data.IntSet.Internal.zero k' m : bool
+             then mapGT (fun arg_2__ => union arg_2__ r) (go k' l) else
+             mapLT (union l) (go k' r)
+         | k', (Tip ky y as t') =>
+             if k' GHC.Base.> ky : bool then Mk_SplitLookup t' None Nil else
+             if k' GHC.Base.< ky : bool then Mk_SplitLookup Nil None t' else
+             Mk_SplitLookup Nil (Some y) Nil
+         | _, Nil => Mk_SplitLookup Nil None Nil
+         end in
     let 'Mk_SplitLookup lt fnd gt := (let j_12__ := go k t in
                                         match t with
                                         | Bin _ m l r =>
@@ -1822,11 +1820,11 @@ Definition foldrWithKey' {a} {b}
    : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f kx x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx x => f kx x z'
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -1837,11 +1835,11 @@ Definition foldlWithKey {a} {b}
    : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f z' kx x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx x => f z' kx x
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
@@ -1852,11 +1850,11 @@ Definition foldlWithKey' {a} {b}
    : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f z' kx x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx x => f z' kx x
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
@@ -1867,11 +1865,11 @@ Definition foldMapWithKey {m} {a} `{GHC.Base.Monoid m}
    : (Data.IntSet.Internal.Key -> a -> m) -> IntMap a -> m :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => GHC.Base.mempty
-                 | Tip kx x => f kx x
-                 | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
-                 end in
+      := match arg_0__ with
+         | Nil => GHC.Base.mempty
+         | Tip kx x => f kx x
+         | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
+         end in
     go.
 
 Definition keys {a} : IntMap a -> list Data.IntSet.Internal.Key :=
@@ -1884,57 +1882,53 @@ Definition assocs {a} : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
   toAscList.
 
 Fixpoint keysSet {a} (arg_0__ : IntMap a) : Data.IntSet.Internal.IntSet
-           := match arg_0__ with
-              | Nil => Data.IntSet.Internal.Nil
-              | Tip kx _ => Data.IntSet.Internal.singleton kx
-              | Bin p m l r =>
-                  let fix computeBm arg_2__ arg_3__
-                            := match arg_2__, arg_3__ with
-                               | acc, Bin _ _ l' r' => computeBm (computeBm acc l') r'
-                               | acc, Tip kx _ => acc Data.Bits..|.(**) Data.IntSet.Internal.bitmapOf kx
-                               | _, Nil => GHC.Err.error (GHC.Base.hs_string__ "Data.IntSet.keysSet: Nil")
-                               end in
-                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base.==
-                     #0 : bool
-                  then Data.IntSet.Internal.Bin p m (keysSet l) (keysSet r) else
-                  Data.IntSet.Internal.Tip (Coq.NArith.BinNat.N.ldiff p
-                                                                      Data.IntSet.Internal.suffixBitMask) (computeBm
-                                                                                                           (computeBm #0
-                                                                                                            l) r)
-              end.
+  := match arg_0__ with
+     | Nil => Data.IntSet.Internal.Nil
+     | Tip kx _ => Data.IntSet.Internal.singleton kx
+     | Bin p m l r =>
+         let fix computeBm arg_2__ arg_3__
+           := match arg_2__, arg_3__ with
+              | acc, Bin _ _ l' r' => computeBm (computeBm acc l') r'
+              | acc, Tip kx _ => acc Data.Bits..|.(**) Data.IntSet.Internal.bitmapOf kx
+              | _, Nil => GHC.Err.error (GHC.Base.hs_string__ "Data.IntSet.keysSet: Nil")
+              end in
+         if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base.==
+            #0 : bool
+         then Data.IntSet.Internal.Bin p m (keysSet l) (keysSet r) else
+         Data.IntSet.Internal.Tip (Coq.NArith.BinNat.N.ldiff p
+                                                             Data.IntSet.Internal.suffixBitMask) (computeBm (computeBm
+                                                                                                             #0 l) r)
+     end.
 
 Fixpoint fromSet {a} (arg_0__ : (Data.IntSet.Internal.Key -> a)) (arg_1__
                    : Data.IntSet.Internal.IntSet) : IntMap a
-           := match arg_0__, arg_1__ with
-              | _, Data.IntSet.Internal.Nil => Nil
-              | f, Data.IntSet.Internal.Bin p m l r => Bin p m (fromSet f l) (fromSet f r)
-              | f, Data.IntSet.Internal.Tip kx bm =>
-                  let buildTree :=
-                    GHC.DeferredFix.deferredFix4 (fun buildTree g prefix bmask bits =>
-                                                    let 'num_3__ := bits in
-                                                    if num_3__ GHC.Base.== #0 : bool then Tip prefix (g prefix) else
-                                                    let 'bits2 := Utils.Containers.Internal.BitUtil.shiftRL (bits) #1 in
-                                                    if (bmask Data.Bits..&.(**)
-                                                        ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.-
-                                                         #1)) GHC.Base.==
-                                                       #0 : bool
-                                                    then buildTree g (prefix GHC.Num.+ bits2)
-                                                         (Utils.Containers.Internal.BitUtil.shiftRL bmask bits2)
-                                                         bits2 else
-                                                    if ((Utils.Containers.Internal.BitUtil.shiftRL bmask bits2)
-                                                        Data.Bits..&.(**)
-                                                        ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.-
-                                                         #1)) GHC.Base.==
-                                                       #0 : bool
-                                                    then buildTree g prefix bmask bits2 else
-                                                    Bin prefix bits2 (buildTree g prefix bmask bits2) (buildTree g
-                                                                                                       (prefix GHC.Num.+
-                                                                                                        bits2)
-                                                                                                       (Utils.Containers.Internal.BitUtil.shiftRL
-                                                                                                        bmask bits2)
-                                                                                                       bits2)) in
-                  buildTree f kx bm (Data.IntSet.Internal.suffixBitMask GHC.Num.+ #1)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Data.IntSet.Internal.Nil => Nil
+     | f, Data.IntSet.Internal.Bin p m l r => Bin p m (fromSet f l) (fromSet f r)
+     | f, Data.IntSet.Internal.Tip kx bm =>
+         let buildTree :=
+           GHC.DeferredFix.deferredFix4 (fun buildTree g prefix bmask bits =>
+                                           let 'num_3__ := bits in
+                                           if num_3__ GHC.Base.== #0 : bool then Tip prefix (g prefix) else
+                                           let 'bits2 := Utils.Containers.Internal.BitUtil.shiftRL (bits) #1 in
+                                           if (bmask Data.Bits..&.(**)
+                                               ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.- #1))
+                                              GHC.Base.==
+                                              #0 : bool
+                                           then buildTree g (prefix GHC.Num.+ bits2)
+                                                (Utils.Containers.Internal.BitUtil.shiftRL bmask bits2) bits2 else
+                                           if ((Utils.Containers.Internal.BitUtil.shiftRL bmask bits2) Data.Bits..&.(**)
+                                               ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.- #1))
+                                              GHC.Base.==
+                                              #0 : bool
+                                           then buildTree g prefix bmask bits2 else
+                                           Bin prefix bits2 (buildTree g prefix bmask bits2) (buildTree g (prefix
+                                                                                                           GHC.Num.+
+                                                                                                           bits2)
+                                                                                              (Utils.Containers.Internal.BitUtil.shiftRL
+                                                                                               bmask bits2) bits2)) in
+         buildTree f kx bm (Data.IntSet.Internal.suffixBitMask GHC.Num.+ #1)
+     end.
 
 Definition toDescList {a}
    : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=

--- a/examples/containers/lib/Data/IntSet/Internal.v
+++ b/examples/containers/lib/Data/IntSet/Internal.v
@@ -50,14 +50,14 @@ Definition Key :=
 Definition BitMap :=
   Coq.Numbers.BinNums.N.
 
-Inductive IntSet : Type
-  := | Bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet
-  |  Tip : Prefix -> BitMap -> IntSet
-  |  Nil : IntSet.
+Inductive IntSet : Type :=
+  | Bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet
+  | Tip : Prefix -> BitMap -> IntSet
+  | Nil : IntSet.
 
-Inductive Stack : Type
-  := | Push : Prefix -> IntSet -> Stack -> Stack
-  |  Nada : Stack.
+Inductive Stack : Type :=
+  | Push : Prefix -> IntSet -> Stack -> Stack
+  | Nada : Stack.
 
 Instance Default__IntSet : GHC.Err.Default IntSet :=
   GHC.Err.Build_Default _ Nil.
@@ -110,45 +110,45 @@ Definition nomatch : Coq.Numbers.BinNums.N -> Prefix -> Mask -> bool :=
   fun i p m => (mask i m) GHC.Base./= p.
 
 Fixpoint insertBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
-           : IntSet
-           := match arg_0__, arg_1__, arg_2__ with
-              | kx, bm, (Bin p m l r as t) =>
-                  if nomatch kx p m : bool then link kx (Tip kx bm) p t else
-                  if zero kx m : bool then Bin p m (insertBM kx bm l) r else
-                  Bin p m l (insertBM kx bm r)
-              | kx, bm, (Tip kx' bm' as t) =>
-                  if kx' GHC.Base.== kx : bool then Tip kx' (bm Data.Bits..|.(**) bm') else
-                  link kx (Tip kx bm) kx' t
-              | kx, bm, Nil => Tip kx bm
-              end.
+  : IntSet
+  := match arg_0__, arg_1__, arg_2__ with
+     | kx, bm, (Bin p m l r as t) =>
+         if nomatch kx p m : bool then link kx (Tip kx bm) p t else
+         if zero kx m : bool then Bin p m (insertBM kx bm l) r else
+         Bin p m l (insertBM kx bm r)
+     | kx, bm, (Tip kx' bm' as t) =>
+         if kx' GHC.Base.== kx : bool then Tip kx' (bm Data.Bits..|.(**) bm') else
+         link kx (Tip kx bm) kx' t
+     | kx, bm, Nil => Tip kx bm
+     end.
 
 Definition shorter : Mask -> Mask -> bool :=
   fun m1 m2 => (m1) GHC.Base.> (m2).
 
 Program Fixpoint union (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__ +
                         size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let union2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then link p1 t1 p2 t2 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2)
-                            then Bin p2 m2 (union t1 l2) r2 else
-                            Bin p2 m2 l2 (union t1 r2) in
-                          let union1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then link p1 t1 p2 t2 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
-                            then Bin p1 m1 (union l1 t2) r1 else
-                            Bin p1 m1 l1 (union r1 t2) in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then union1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then union2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then Bin p1 m1 (union l1 l2) (union r1 r2) else
-                          link p1 t1 p2 t2
-                      | (Bin _ _ _ _ as t), Tip kx bm => insertBM kx bm t
-                      | (Bin _ _ _ _ as t), Nil => t
-                      | Tip kx bm, t => insertBM kx bm t
-                      | Nil, t => t
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let union2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then link p1 t1 p2 t2 else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2)
+           then Bin p2 m2 (union t1 l2) r2 else
+           Bin p2 m2 l2 (union t1 r2) in
+         let union1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then link p1 t1 p2 t2 else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
+           then Bin p1 m1 (union l1 t2) r1 else
+           Bin p1 m1 l1 (union r1 t2) in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then union1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then union2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then Bin p1 m1 (union l1 l2) (union r1 r2) else
+         link p1 t1 p2 t2
+     | (Bin _ _ _ _ as t), Tip kx bm => insertBM kx bm t
+     | (Bin _ _ _ _ as t), Nil => t
+     | Tip kx bm, t => insertBM kx bm t
+     | Nil, t => t
+     end.
 Solve Obligations with (termination_by_omega).
 
 Local Definition Semigroup__IntSet_op_zlzlzgzg__ : IntSet -> IntSet -> IntSet :=
@@ -186,27 +186,27 @@ Program Instance Monoid__IntSet : GHC.Base.Monoid IntSet :=
    `Data.IntSet.Internal.IsList__IntSet' *)
 
 Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
-                                                                            r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
-              | Nil, Nil => true
-              | _, _ => false
-              end.
+  := match arg_0__, arg_1__ with
+     | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+         andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
+                                                                   r2)))
+     | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
+     | Nil, Nil => true
+     | _, _ => false
+     end.
 
 Local Definition Eq___IntSet_op_zeze__ : IntSet -> IntSet -> bool :=
   fun t1 t2 => equal t1 t2.
 
 Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
-                                                                         r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
-              | Nil, Nil => false
-              | _, _ => true
-              end.
+  := match arg_0__, arg_1__ with
+     | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+         orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
+                                                                r2)))
+     | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
+     | Nil, Nil => false
+     | _, _ => true
+     end.
 
 Local Definition Eq___IntSet_op_zsze__ : IntSet -> IntSet -> bool :=
   fun t1 t2 => nequal t1 t2.
@@ -248,35 +248,35 @@ Definition revNatSafe n :=
   Coq.NArith.BinNat.N.modulo (revNat n) (Coq.NArith.BinNat.N.pow 2 64).
 
 Program Definition foldrBits {a}
-           : Coq.Numbers.BinNums.N ->
-             (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNatSafe bitmap) z.
+   : Coq.Numbers.BinNums.N ->
+     (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                  GHC.Num.-
+                                                                  bi)) acc)
+                           end
+                       end) in
+    go (revNatSafe bitmap) z.
 Solve Obligations with (BitTerminationProofs.termination_foldl).
 
 Definition foldr {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldrBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldrBits kx f z' bm
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -349,56 +349,56 @@ Definition tip : Prefix -> BitMap -> IntSet :=
     end.
 
 Fixpoint deleteBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
-           : IntSet
-           := match arg_0__, arg_1__, arg_2__ with
-              | kx, bm, (Bin p m l r as t) =>
-                  if nomatch kx p m : bool then t else
-                  if zero kx m : bool then bin p m (deleteBM kx bm l) r else
-                  bin p m l (deleteBM kx bm r)
-              | kx, bm, (Tip kx' bm' as t) =>
-                  if kx' GHC.Base.== kx : bool
-                  then tip kx (Data.Bits.xor bm' (bm' Data.Bits..&.(**) bm)) else
-                  t
-              | _, _, Nil => Nil
-              end.
+  : IntSet
+  := match arg_0__, arg_1__, arg_2__ with
+     | kx, bm, (Bin p m l r as t) =>
+         if nomatch kx p m : bool then t else
+         if zero kx m : bool then bin p m (deleteBM kx bm l) r else
+         bin p m l (deleteBM kx bm r)
+     | kx, bm, (Tip kx' bm' as t) =>
+         if kx' GHC.Base.== kx : bool
+         then tip kx (Data.Bits.xor bm' (bm' Data.Bits..&.(**) bm)) else
+         t
+     | _, _, Nil => Nil
+     end.
 
 Program Fixpoint difference (arg_0__ arg_1__ : IntSet) {measure (size_nat
                              arg_0__ +
                              size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let difference2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
-                            difference t1 r2 in
-                          let difference1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
-                            then bin p1 m1 (difference l1 t2) r1 else
-                            bin p1 m1 l1 (difference r1 t2) in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (difference l1 l2) (difference r1 r2) else
-                          t1
-                      | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
-                      | (Bin _ _ _ _ as t), Nil => t
-                      | (Tip kx bm as t1), t2 =>
-                          let fix differenceTip arg_12__
-                                    := match arg_12__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
-                                           differenceTip r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
-                                           then tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**) bm2)) else
-                                           t1
-                                       | Nil => t1
-                                       end in
-                          differenceTip t2
-                      | Nil, _ => Nil
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let difference2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
+           difference t1 r2 in
+         let difference1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
+           then bin p1 m1 (difference l1 t2) r1 else
+           bin p1 m1 l1 (difference r1 t2) in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then bin p1 m1 (difference l1 l2) (difference r1 r2) else
+         t1
+     | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
+     | (Bin _ _ _ _ as t), Nil => t
+     | (Tip kx bm as t1), t2 =>
+         let fix differenceTip arg_12__
+           := match arg_12__ with
+              | Bin p2 m2 l2 r2 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
+                  differenceTip r2
+              | Tip kx2 bm2 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
+                  then tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**) bm2)) else
+                  t1
+              | Nil => t1
+              end in
+         differenceTip t2
+     | Nil, _ => Nil
+     end.
 Solve Obligations with (termination_by_omega).
 
 Definition op_zrzr__ : IntSet -> IntSet -> IntSet :=
@@ -417,12 +417,12 @@ Definition null : IntSet -> bool :=
 
 Definition size : IntSet -> Coq.Numbers.BinNums.N :=
   let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | acc, Bin _ _ l r => go (go acc l) r
-               | acc, Tip _ bm =>
-                   acc GHC.Num.+ Utils.Containers.Internal.BitUtil.bitcount #0 bm
-               | acc, Nil => acc
-               end in
+    := match arg_0__, arg_1__ with
+       | acc, Bin _ _ l r => go (go acc l) r
+       | acc, Tip _ bm =>
+           acc GHC.Num.+ Utils.Containers.Internal.BitUtil.bitcount #0 bm
+       | acc, Nil => acc
+       end in
   go #0.
 
 Definition bitmapOfSuffix : Coq.Numbers.BinNums.N -> BitMap :=
@@ -443,16 +443,16 @@ Definition prefixOf : Coq.Numbers.BinNums.N -> Prefix :=
 Definition member : Key -> IntSet -> bool :=
   fun x =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch x p m : bool then false else
-                     if zero x m : bool then go l else
-                     go r
-                 | Tip y bm =>
-                     andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
-                           #0)
-                 | Nil => false
-                 end in
+      := match arg_0__ with
+         | Bin p m l r =>
+             if nomatch x p m : bool then false else
+             if zero x m : bool then go l else
+             go r
+         | Tip y bm =>
+             andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
+                   #0)
+         | Nil => false
+         end in
     go.
 
 Definition notMember : Key -> IntSet -> bool :=
@@ -462,32 +462,32 @@ Definition highestBitSet : Nat -> Coq.Numbers.BinNums.N :=
   fun x => indexOfTheOnlyBit (Utils.Containers.Internal.BitUtil.highestBitMask x).
 
 Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
-              | Bin _ _ _ r => unsafeFindMax r
-              end.
+  := match arg_0__ with
+     | Nil => None
+     | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
+     | Bin _ _ _ r => unsafeFindMax r
+     end.
 
 Definition lookupLT : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if zero x m : bool then go def l else
-                     go l r
-                 | def, Tip kx bm =>
-                     let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.> kx : bool
-                     then Some (kx GHC.Num.+ highestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ highestBitSet maskLT) else
-                     unsafeFindMax def
-                 | def, Nil => unsafeFindMax def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMax def
+                  else unsafeFindMax r else
+             if zero x m : bool then go def l else
+             go l r
+         | def, Tip kx bm =>
+             let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
+             if prefixOf x GHC.Base.> kx : bool
+             then Some (kx GHC.Num.+ highestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ highestBitSet maskLT) else
+             unsafeFindMax def
+         | def, Nil => unsafeFindMax def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -505,35 +505,36 @@ Definition lowestBitSet : Nat -> Coq.Numbers.BinNums.N :=
   fun x => indexOfTheOnlyBit (Utils.Containers.Internal.BitUtil.lowestBitMask x).
 
 Fixpoint unsafeFindMin (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
-              | Bin _ _ l _ => unsafeFindMin l
-              end.
+  := match arg_0__ with
+     | Nil => None
+     | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
+     | Bin _ _ l _ => unsafeFindMin l
+     end.
 
 Definition lookupGT : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if zero x m : bool then go r l else
-                     go def r
-                 | def, Tip kx bm =>
-                     let maskGT :=
-                       (Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N))
-                                                  (Coq.NArith.BinNat.N.pred (Utils.Containers.Internal.BitUtil.shiftLL
-                                                                             (bitmapOf x) #1))) Data.Bits..&.(**)
-                       bm in
-                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskGT GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ lowestBitSet maskGT) else
-                     unsafeFindMin def
-                 | def, Nil => unsafeFindMin def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMin l
+                  else unsafeFindMin def else
+             if zero x m : bool then go r l else
+             go def r
+         | def, Tip kx bm =>
+             let maskGT :=
+               (Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N))
+                                          (Coq.NArith.BinNat.N.pred (Utils.Containers.Internal.BitUtil.shiftLL (bitmapOf
+                                                                                                                x) #1)))
+               Data.Bits..&.(**)
+               bm in
+             if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskGT GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ lowestBitSet maskGT) else
+             unsafeFindMin def
+         | def, Nil => unsafeFindMin def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -548,26 +549,26 @@ Definition lookupGT : Key -> IntSet -> option Key :=
 Definition lookupLE : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if zero x m : bool then go def l else
-                     go l r
-                 | def, Tip kx bm =>
-                     let maskLE :=
-                       ((Utils.Containers.Internal.BitUtil.shiftLL (bitmapOf x) #1) GHC.Num.- #1)
-                       Data.Bits..&.(**)
-                       bm in
-                     if prefixOf x GHC.Base.> kx : bool
-                     then Some (kx GHC.Num.+ highestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskLE GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ highestBitSet maskLE) else
-                     unsafeFindMax def
-                 | def, Nil => unsafeFindMax def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMax def
+                  else unsafeFindMax r else
+             if zero x m : bool then go def l else
+             go l r
+         | def, Tip kx bm =>
+             let maskLE :=
+               ((Utils.Containers.Internal.BitUtil.shiftLL (bitmapOf x) #1) GHC.Num.- #1)
+               Data.Bits..&.(**)
+               bm in
+             if prefixOf x GHC.Base.> kx : bool
+             then Some (kx GHC.Num.+ highestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskLE GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ highestBitSet maskLE) else
+             unsafeFindMax def
+         | def, Nil => unsafeFindMax def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -582,25 +583,25 @@ Definition lookupLE : Key -> IntSet -> option Key :=
 Definition lookupGE : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if zero x m : bool then go r l else
-                     go def r
-                 | def, Tip kx bm =>
-                     let maskGE :=
-                       (Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N))
-                                                  (Coq.NArith.BinNat.N.pred (bitmapOf x))) Data.Bits..&.(**)
-                       bm in
-                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ lowestBitSet maskGE) else
-                     unsafeFindMin def
-                 | def, Nil => unsafeFindMin def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMin l
+                  else unsafeFindMin def else
+             if zero x m : bool then go r l else
+             go def r
+         | def, Tip kx bm =>
+             let maskGE :=
+               (Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N))
+                                          (Coq.NArith.BinNat.N.pred (bitmapOf x))) Data.Bits..&.(**)
+               bm in
+             if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ lowestBitSet maskGE) else
+             unsafeFindMin def
+         | def, Nil => unsafeFindMin def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -624,97 +625,97 @@ Definition delete : Key -> IntSet -> IntSet :=
 Program Fixpoint intersection (arg_0__ arg_1__ : IntSet) {measure (size_nat
                                arg_0__ +
                                size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let intersection2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
-                            intersection t1 r2 in
-                          let intersection1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
-                            intersection r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
-                          Nil
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix intersectBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
-                                           intersectBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t1
-                      | Bin _ _ _ _, Nil => Nil
-                      | Tip kx1 bm1, t2 =>
-                          let fix intersectBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
-                                           intersectBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t2
-                      | Nil, _ => Nil
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let intersection2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
+           intersection t1 r2 in
+         let intersection1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
+           intersection r1 t2 in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
+         Nil
+     | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+         let fix intersectBM arg_11__
+           := match arg_11__ with
+              | Bin p1 m1 l1 r1 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
+                  intersectBM r1
+              | Tip kx1 bm1 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                  Nil
+              | Nil => Nil
+              end in
+         intersectBM t1
+     | Bin _ _ _ _, Nil => Nil
+     | Tip kx1 bm1, t2 =>
+         let fix intersectBM arg_18__
+           := match arg_18__ with
+              | Bin p2 m2 l2 r2 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
+                  intersectBM r2
+              | Tip kx2 bm2 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                  Nil
+              | Nil => Nil
+              end in
+         intersectBM t2
+     | Nil, _ => Nil
+     end.
 Solve Obligations with (termination_by_omega).
 
 Fixpoint subsetCmp (arg_0__ arg_1__ : IntSet) : comparison
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  let subsetCmpEq :=
-                    match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
-                    | pair Gt _ => Gt
-                    | pair _ Gt => Gt
-                    | pair Eq Eq => Eq
-                    | _ => Lt
-                    end in
-                  let subsetCmpLt :=
-                    if nomatch p1 p2 m2 : bool then Gt else
-                    if zero p1 m2 : bool then subsetCmp t1 l2 else
-                    subsetCmp t1 r2 in
-                  if shorter m1 m2 : bool then Gt else
-                  if shorter m2 m1 : bool
-                  then match subsetCmpLt with
-                       | Gt => Gt
-                       | _ => Lt
-                       end else
-                  if p1 GHC.Base.== p2 : bool then subsetCmpEq else
-                  Gt
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => Gt
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      if kx1 GHC.Base./= kx2 : bool then Gt else
-                      if bm1 GHC.Base.== bm2 : bool then Eq else
-                      if Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 : bool
-                      then Lt else
-                      Gt
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then Gt else
-                      if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
-                      match subsetCmp t1 r with
-                      | Gt => Gt
-                      | _ => Lt
-                      end
-                  | Tip _ _, Nil => Gt
-                  | Nil, Nil => Eq
-                  | Nil, _ => Lt
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+         let subsetCmpEq :=
+           match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
+           | pair Gt _ => Gt
+           | pair _ Gt => Gt
+           | pair Eq Eq => Eq
+           | _ => Lt
+           end in
+         let subsetCmpLt :=
+           if nomatch p1 p2 m2 : bool then Gt else
+           if zero p1 m2 : bool then subsetCmp t1 l2 else
+           subsetCmp t1 r2 in
+         if shorter m1 m2 : bool then Gt else
+         if shorter m2 m1 : bool
+         then match subsetCmpLt with
+              | Gt => Gt
+              | _ => Lt
+              end else
+         if p1 GHC.Base.== p2 : bool then subsetCmpEq else
+         Gt
+     | _, _ =>
+         match arg_0__, arg_1__ with
+         | Bin _ _ _ _, _ => Gt
+         | Tip kx1 bm1, Tip kx2 bm2 =>
+             if kx1 GHC.Base./= kx2 : bool then Gt else
+             if bm1 GHC.Base.== bm2 : bool then Eq else
+             if Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 : bool
+             then Lt else
+             Gt
+         | (Tip kx _ as t1), Bin p m l r =>
+             if nomatch kx p m : bool then Gt else
+             if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
+             match subsetCmp t1 r with
+             | Gt => Gt
+             | _ => Lt
+             end
+         | Tip _ _, Nil => Gt
+         | Nil, Nil => Eq
+         | Nil, _ => Lt
+         end
+     end.
 
 Definition isProperSubsetOf : IntSet -> IntSet -> bool :=
   fun t1 t2 => match subsetCmp t1 t2 with | Lt => true | _ => false end.
@@ -723,159 +724,159 @@ Definition match_ : Coq.Numbers.BinNums.N -> Prefix -> Mask -> bool :=
   fun i p m => (mask i m) GHC.Base.== p.
 
 Fixpoint isSubsetOf (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  if shorter m1 m2 : bool then false else
-                  if shorter m2 m1 : bool
-                  then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
-                             then isSubsetOf t1 l2
-                             else isSubsetOf t1 r2) else
-                  andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => false
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      andb (kx1 GHC.Base.== kx2) (Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2)
-                            GHC.Base.==
-                            #0)
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then false else
-                      if zero kx m : bool then isSubsetOf t1 l else
-                      isSubsetOf t1 r
-                  | Tip _ _, Nil => false
-                  | Nil, _ => true
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+         if shorter m1 m2 : bool then false else
+         if shorter m2 m1 : bool
+         then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
+                    then isSubsetOf t1 l2
+                    else isSubsetOf t1 r2) else
+         andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
+     | _, _ =>
+         match arg_0__, arg_1__ with
+         | Bin _ _ _ _, _ => false
+         | Tip kx1 bm1, Tip kx2 bm2 =>
+             andb (kx1 GHC.Base.== kx2) (Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2)
+                   GHC.Base.==
+                   #0)
+         | (Tip kx _ as t1), Bin p m l r =>
+             if nomatch kx p m : bool then false else
+             if zero kx m : bool then isSubsetOf t1 l else
+             isSubsetOf t1 r
+         | Tip _ _, Nil => false
+         | Nil, _ => true
+         end
+     end.
 
 Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
                            +
                            size_nat arg_1__)} : bool
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let disjoint2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
-                            disjoint t1 r2 in
-                          let disjoint1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
-                            disjoint r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then andb (disjoint l1 l2) (disjoint r1 r2) else
-                          true
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix disjointBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
-                                           disjointBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t1
-                      | Bin _ _ _ _, Nil => true
-                      | Tip kx1 bm1, t2 =>
-                          let fix disjointBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
-                                           disjointBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t2
-                      | Nil, _ => true
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let disjoint2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
+           disjoint t1 r2 in
+         let disjoint1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
+           disjoint r1 t2 in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then andb (disjoint l1 l2) (disjoint r1 r2) else
+         true
+     | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+         let fix disjointBM arg_11__
+           := match arg_11__ with
+              | Bin p1 m1 l1 r1 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
+                  disjointBM r1
+              | Tip kx1 bm1 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                  true
+              | Nil => true
+              end in
+         disjointBM t1
+     | Bin _ _ _ _, Nil => true
+     | Tip kx1 bm1, t2 =>
+         let fix disjointBM arg_18__
+           := match arg_18__ with
+              | Bin p2 m2 l2 r2 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
+                  disjointBM r2
+              | Tip kx2 bm2 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                  true
+              | Nil => true
+              end in
+         disjointBM t2
+     | Nil, _ => true
+     end.
 Solve Obligations with (termination_by_omega).
 
 Program Definition foldl'Bits {a}
-           : Coq.Numbers.BinNums.N ->
-             (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
+   : Coq.Numbers.BinNums.N ->
+     (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                           end
+                       end) in
+    go bitmap z.
 Solve Obligations with (BitTerminationProofs.termination_foldl).
 
 Fixpoint filter (predicate : (Key -> bool)) (t : IntSet) : IntSet
-           := let bitPred :=
-                fun kx bm bi =>
-                  if predicate (kx GHC.Num.+ bi) : bool
-                  then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                  bm in
-              match t with
-              | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
-              | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
-              | Nil => Nil
-              end.
+  := let bitPred :=
+       fun kx bm bi =>
+         if predicate (kx GHC.Num.+ bi) : bool
+         then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+         bm in
+     match t with
+     | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
+     | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
+     | Nil => Nil
+     end.
 
 Definition partition : (Key -> bool) -> IntSet -> (IntSet * IntSet)%type :=
   fun predicate0 t0 =>
     let fix go predicate t
-              := let bitPred :=
-                   fun kx bm bi =>
-                     if predicate (kx GHC.Num.+ bi) : bool
-                     then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                     bm in
-                 match t with
-                 | Bin p m l r =>
-                     let 'pair r1 r2 := go predicate r in
-                     let 'pair l1 l2 := go predicate l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | Tip kx bm =>
-                     let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
-                     pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
-                 | Nil => (pair Nil Nil)
-                 end in
+      := let bitPred :=
+           fun kx bm bi =>
+             if predicate (kx GHC.Num.+ bi) : bool
+             then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+             bm in
+         match t with
+         | Bin p m l r =>
+             let 'pair r1 r2 := go predicate r in
+             let 'pair l1 l2 := go predicate l in
+             pair (bin p m l1 r1) (bin p m l2 r2)
+         | Tip kx bm =>
+             let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
+             pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
+         | Nil => (pair Nil Nil)
+         end in
     id (go predicate0 t0).
 
 Definition split : Key -> IntSet -> (IntSet * IntSet)%type :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | x', (Bin p m l r as t') =>
-                     if match_ x' p m : bool
-                     then if zero x' m : bool
-                          then let 'pair lt gt := go x' l in
-                               pair lt (union gt r)
-                          else let 'pair lt gt := go x' r in
-                               pair (union lt l) gt else
-                     if x' GHC.Base.< p : bool
-                     then (pair Nil t')
-                     else (pair t' Nil)
-                 | x', (Tip kx' bm as t') =>
-                     let lowerBitmap := bitmapOf x' GHC.Num.- #1 in
-                     let higherBitmap :=
-                       Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N)) (lowerBitmap
-                                                  GHC.Num.+
-                                                  bitmapOf x') in
-                     if kx' GHC.Base.> x' : bool then (pair Nil t') else
-                     if kx' GHC.Base.< prefixOf x' : bool then (pair t' Nil) else
-                     pair (tip kx' (bm Data.Bits..&.(**) lowerBitmap)) (tip kx' (bm Data.Bits..&.(**)
-                                                                                 higherBitmap))
-                 | _, Nil => (pair Nil Nil)
-                 end in
+      := match arg_0__, arg_1__ with
+         | x', (Bin p m l r as t') =>
+             if match_ x' p m : bool
+             then if zero x' m : bool
+                  then let 'pair lt gt := go x' l in
+                       pair lt (union gt r)
+                  else let 'pair lt gt := go x' r in
+                       pair (union lt l) gt else
+             if x' GHC.Base.< p : bool
+             then (pair Nil t')
+             else (pair t' Nil)
+         | x', (Tip kx' bm as t') =>
+             let lowerBitmap := bitmapOf x' GHC.Num.- #1 in
+             let higherBitmap :=
+               Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N)) (lowerBitmap
+                                          GHC.Num.+
+                                          bitmapOf x') in
+             if kx' GHC.Base.> x' : bool then (pair Nil t') else
+             if kx' GHC.Base.< prefixOf x' : bool then (pair t' Nil) else
+             pair (tip kx' (bm Data.Bits..&.(**) lowerBitmap)) (tip kx' (bm Data.Bits..&.(**)
+                                                                         higherBitmap))
+         | _, Nil => (pair Nil Nil)
+         end in
     let j_21__ := let 'pair lt gt := go x t in pair lt gt in
     match t with
     | Bin _ m l r =>
@@ -892,31 +893,31 @@ Definition split : Key -> IntSet -> (IntSet * IntSet)%type :=
 Definition splitMember : Key -> IntSet -> (IntSet * bool * IntSet)%type :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | x', (Bin p m l r as t') =>
-                     if match_ x' p m : bool
-                     then if zero x' m : bool
-                          then let 'pair (pair lt fnd) gt := go x' l in
-                               pair (pair lt fnd) (union gt r)
-                          else let 'pair (pair lt fnd) gt := go x' r in
-                               pair (pair (union lt l) fnd) gt else
-                     if x' GHC.Base.< p : bool
-                     then pair (pair Nil false) t'
-                     else pair (pair t' false) Nil
-                 | x', (Tip kx' bm as t') =>
-                     let bitmapOfx' := bitmapOf x' in
-                     let lowerBitmap := bitmapOfx' GHC.Num.- #1 in
-                     let higherBitmap :=
-                       Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N)) (lowerBitmap
-                                                  GHC.Num.+
-                                                  bitmapOfx') in
-                     if kx' GHC.Base.> x' : bool then pair (pair Nil false) t' else
-                     if kx' GHC.Base.< prefixOf x' : bool then pair (pair t' false) Nil else
-                     let gt := tip kx' (bm Data.Bits..&.(**) higherBitmap) in
-                     let found := (bm Data.Bits..&.(**) bitmapOfx') GHC.Base./= #0 in
-                     let lt := tip kx' (bm Data.Bits..&.(**) lowerBitmap) in pair (pair lt found) gt
-                 | _, Nil => pair (pair Nil false) Nil
-                 end in
+      := match arg_0__, arg_1__ with
+         | x', (Bin p m l r as t') =>
+             if match_ x' p m : bool
+             then if zero x' m : bool
+                  then let 'pair (pair lt fnd) gt := go x' l in
+                       pair (pair lt fnd) (union gt r)
+                  else let 'pair (pair lt fnd) gt := go x' r in
+                       pair (pair (union lt l) fnd) gt else
+             if x' GHC.Base.< p : bool
+             then pair (pair Nil false) t'
+             else pair (pair t' false) Nil
+         | x', (Tip kx' bm as t') =>
+             let bitmapOfx' := bitmapOf x' in
+             let lowerBitmap := bitmapOfx' GHC.Num.- #1 in
+             let higherBitmap :=
+               Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N)) (lowerBitmap
+                                          GHC.Num.+
+                                          bitmapOfx') in
+             if kx' GHC.Base.> x' : bool then pair (pair Nil false) t' else
+             if kx' GHC.Base.< prefixOf x' : bool then pair (pair t' false) Nil else
+             let gt := tip kx' (bm Data.Bits..&.(**) higherBitmap) in
+             let found := (bm Data.Bits..&.(**) bitmapOfx') GHC.Base./= #0 in
+             let lt := tip kx' (bm Data.Bits..&.(**) lowerBitmap) in pair (pair lt found) gt
+         | _, Nil => pair (pair Nil false) Nil
+         end in
     let j_22__ := go x t in
     match t with
     | Bin _ m l r =>
@@ -933,14 +934,14 @@ Definition splitMember : Key -> IntSet -> (IntSet * bool * IntSet)%type :=
 Definition maxView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r => let 'pair result r' := go r in pair result (bin p m l r')
-                 | Tip kx bm =>
-                     let 'bi := highestBitSet bm in
-                     pair (kx GHC.Num.+ bi) (tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**)
-                                                                    bitmapOfSuffix bi)))
-                 | Nil => pair (0 % N) Nil
-                 end in
+      := match arg_0__ with
+         | Bin p m l r => let 'pair result r' := go r in pair result (bin p m l r')
+         | Tip kx bm =>
+             let 'bi := highestBitSet bm in
+             pair (kx GHC.Num.+ bi) (tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**)
+                                                            bitmapOfSuffix bi)))
+         | Nil => pair (0 % N) Nil
+         end in
     let j_12__ := Some (go t) in
     match t with
     | Nil => None
@@ -955,14 +956,14 @@ Definition maxView : IntSet -> option (Key * IntSet)%type :=
 Definition minView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r => let 'pair result l' := go l in pair result (bin p m l' r)
-                 | Tip kx bm =>
-                     let 'bi := lowestBitSet bm in
-                     pair (kx GHC.Num.+ bi) (tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**)
-                                                                    bitmapOfSuffix bi)))
-                 | Nil => pair (0 % N) Nil
-                 end in
+      := match arg_0__ with
+         | Bin p m l r => let 'pair result l' := go l in pair result (bin p m l' r)
+         | Tip kx bm =>
+             let 'bi := lowestBitSet bm in
+             pair (kx GHC.Num.+ bi) (tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**)
+                                                            bitmapOfSuffix bi)))
+         | Nil => pair (0 % N) Nil
+         end in
     let j_12__ := Some (go t) in
     match t with
     | Nil => None
@@ -1001,35 +1002,35 @@ Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   foldr.
 
 Program Definition foldr'Bits {a}
-           : Coq.Numbers.BinNums.N ->
-             (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNatSafe bitmap) z.
+   : Coq.Numbers.BinNums.N ->
+     (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                  GHC.Num.-
+                                                                  bi)) acc)
+                           end
+                       end) in
+    go (revNatSafe bitmap) z.
 Solve Obligations with (BitTerminationProofs.termination_foldl).
 
 Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldr'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldr'Bits kx f z' bm
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -1037,33 +1038,33 @@ Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
       end.
 
 Program Definition foldlBits {a}
-           : Coq.Numbers.BinNums.N ->
-             (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
+   : Coq.Numbers.BinNums.N ->
+     (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                           end
+                       end) in
+    go bitmap z.
 Solve Obligations with (BitTerminationProofs.termination_foldl).
 
 Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldlBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldlBits kx f z' bm
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
@@ -1073,11 +1074,11 @@ Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
 Definition foldl' {a} : (a -> Key -> a) -> a -> IntSet -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldl'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldl'Bits kx f z' bm
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r

--- a/examples/containers/lib/Data/IntSet/InternalWord.v
+++ b/examples/containers/lib/Data/IntSet/InternalWord.v
@@ -48,14 +48,14 @@ Definition Key :=
 Definition BitMap :=
   IntWord.Word%type.
 
-Inductive IntSet : Type
-  := | Bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet
-  |  Tip : Prefix -> BitMap -> IntSet
-  |  Nil : IntSet.
+Inductive IntSet : Type :=
+  | Bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet
+  | Tip : Prefix -> BitMap -> IntSet
+  | Nil : IntSet.
 
-Inductive Stack : Type
-  := | Push : Prefix -> IntSet -> Stack -> Stack
-  |  Nada : Stack.
+Inductive Stack : Type :=
+  | Push : Prefix -> IntSet -> Stack -> Stack
+  | Nada : Stack.
 
 Instance Default__IntSet : GHC.Err.Default IntSet :=
   GHC.Err.Build_Default _ Nil.
@@ -111,45 +111,45 @@ Definition nomatch : IntWord.Int -> Prefix -> Mask -> bool :=
   fun i p m => (mask i m) GHC.Base./= p.
 
 Fixpoint insertBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
-           : IntSet
-           := match arg_0__, arg_1__, arg_2__ with
-              | kx, bm, (Bin p m l r as t) =>
-                  if nomatch kx p m : bool then link kx (Tip kx bm) p t else
-                  if zero kx m : bool then Bin p m (insertBM kx bm l) r else
-                  Bin p m l (insertBM kx bm r)
-              | kx, bm, (Tip kx' bm' as t) =>
-                  if kx' GHC.Base.== kx : bool then Tip kx' (bm Data.Bits..|.(**) bm') else
-                  link kx (Tip kx bm) kx' t
-              | kx, bm, Nil => Tip kx bm
-              end.
+  : IntSet
+  := match arg_0__, arg_1__, arg_2__ with
+     | kx, bm, (Bin p m l r as t) =>
+         if nomatch kx p m : bool then link kx (Tip kx bm) p t else
+         if zero kx m : bool then Bin p m (insertBM kx bm l) r else
+         Bin p m l (insertBM kx bm r)
+     | kx, bm, (Tip kx' bm' as t) =>
+         if kx' GHC.Base.== kx : bool then Tip kx' (bm Data.Bits..|.(**) bm') else
+         link kx (Tip kx bm) kx' t
+     | kx, bm, Nil => Tip kx bm
+     end.
 
 Definition shorter : Mask -> Mask -> bool :=
   fun m1 m2 => (natFromInt m1) GHC.Base.> (natFromInt m2).
 
 Program Fixpoint union (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__ +
                         size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let union2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then link p1 t1 p2 t2 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2)
-                            then Bin p2 m2 (union t1 l2) r2 else
-                            Bin p2 m2 l2 (union t1 r2) in
-                          let union1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then link p1 t1 p2 t2 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
-                            then Bin p1 m1 (union l1 t2) r1 else
-                            Bin p1 m1 l1 (union r1 t2) in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then union1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then union2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then Bin p1 m1 (union l1 l2) (union r1 r2) else
-                          link p1 t1 p2 t2
-                      | (Bin _ _ _ _ as t), Tip kx bm => insertBM kx bm t
-                      | (Bin _ _ _ _ as t), Nil => t
-                      | Tip kx bm, t => insertBM kx bm t
-                      | Nil, t => t
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let union2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then link p1 t1 p2 t2 else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2)
+           then Bin p2 m2 (union t1 l2) r2 else
+           Bin p2 m2 l2 (union t1 r2) in
+         let union1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then link p1 t1 p2 t2 else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
+           then Bin p1 m1 (union l1 t2) r1 else
+           Bin p1 m1 l1 (union r1 t2) in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then union1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then union2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then Bin p1 m1 (union l1 l2) (union r1 r2) else
+         link p1 t1 p2 t2
+     | (Bin _ _ _ _ as t), Tip kx bm => insertBM kx bm t
+     | (Bin _ _ _ _ as t), Nil => t
+     | Tip kx bm, t => insertBM kx bm t
+     | Nil, t => t
+     end.
 Solve Obligations with (termination_by_omega).
 
 Local Definition Semigroup__IntSet_op_zlzlzgzg__ : IntSet -> IntSet -> IntSet :=
@@ -187,27 +187,27 @@ Program Instance Monoid__IntSet : GHC.Base.Monoid IntSet :=
    `Data.IntSet.InternalWord.IsList__IntSet' *)
 
 Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
-                                                                            r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
-              | Nil, Nil => true
-              | _, _ => false
-              end.
+  := match arg_0__, arg_1__ with
+     | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+         andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
+                                                                   r2)))
+     | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
+     | Nil, Nil => true
+     | _, _ => false
+     end.
 
 Local Definition Eq___IntSet_op_zeze__ : IntSet -> IntSet -> bool :=
   fun t1 t2 => equal t1 t2.
 
 Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
-                                                                         r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
-              | Nil, Nil => false
-              | _, _ => true
-              end.
+  := match arg_0__, arg_1__ with
+     | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+         orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
+                                                                r2)))
+     | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
+     | Nil, Nil => false
+     | _, _ => true
+     end.
 
 Local Definition Eq___IntSet_op_zsze__ : IntSet -> IntSet -> bool :=
   fun t1 t2 => nequal t1 t2.
@@ -243,34 +243,34 @@ Definition revNat : Nat -> Nat :=
     (IntWord.shiftRWord x6 #32) Data.Bits..|.(**) (IntWord.shiftLWord x6 #32).
 
 Program Definition foldrBits {a}
-           : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNat bitmap) z.
+   : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                  GHC.Num.-
+                                                                  bi)) acc)
+                           end
+                       end) in
+    go (revNat bitmap) z.
 Admit Obligations.
 
 Definition foldr {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldrBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldrBits kx f z' bm
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -339,56 +339,56 @@ Definition tip : Prefix -> BitMap -> IntSet :=
     end.
 
 Fixpoint deleteBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
-           : IntSet
-           := match arg_0__, arg_1__, arg_2__ with
-              | kx, bm, (Bin p m l r as t) =>
-                  if nomatch kx p m : bool then t else
-                  if zero kx m : bool then bin p m (deleteBM kx bm l) r else
-                  bin p m l (deleteBM kx bm r)
-              | kx, bm, (Tip kx' bm' as t) =>
-                  if kx' GHC.Base.== kx : bool
-                  then tip kx (bm' Data.Bits..&.(**) Data.Bits.complement bm) else
-                  t
-              | _, _, Nil => Nil
-              end.
+  : IntSet
+  := match arg_0__, arg_1__, arg_2__ with
+     | kx, bm, (Bin p m l r as t) =>
+         if nomatch kx p m : bool then t else
+         if zero kx m : bool then bin p m (deleteBM kx bm l) r else
+         bin p m l (deleteBM kx bm r)
+     | kx, bm, (Tip kx' bm' as t) =>
+         if kx' GHC.Base.== kx : bool
+         then tip kx (bm' Data.Bits..&.(**) Data.Bits.complement bm) else
+         t
+     | _, _, Nil => Nil
+     end.
 
 Program Fixpoint difference (arg_0__ arg_1__ : IntSet) {measure (size_nat
                              arg_0__ +
                              size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let difference2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
-                            difference t1 r2 in
-                          let difference1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
-                            then bin p1 m1 (difference l1 t2) r1 else
-                            bin p1 m1 l1 (difference r1 t2) in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (difference l1 l2) (difference r1 r2) else
-                          t1
-                      | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
-                      | (Bin _ _ _ _ as t), Nil => t
-                      | (Tip kx bm as t1), t2 =>
-                          let fix differenceTip arg_12__
-                                    := match arg_12__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
-                                           differenceTip r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
-                                           then tip kx (bm Data.Bits..&.(**) Data.Bits.complement bm2) else
-                                           t1
-                                       | Nil => t1
-                                       end in
-                          differenceTip t2
-                      | Nil, _ => Nil
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let difference2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
+           difference t1 r2 in
+         let difference1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
+           then bin p1 m1 (difference l1 t2) r1 else
+           bin p1 m1 l1 (difference r1 t2) in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then bin p1 m1 (difference l1 l2) (difference r1 r2) else
+         t1
+     | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
+     | (Bin _ _ _ _ as t), Nil => t
+     | (Tip kx bm as t1), t2 =>
+         let fix differenceTip arg_12__
+           := match arg_12__ with
+              | Bin p2 m2 l2 r2 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
+                  differenceTip r2
+              | Tip kx2 bm2 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
+                  then tip kx (bm Data.Bits..&.(**) Data.Bits.complement bm2) else
+                  t1
+              | Nil => t1
+              end in
+         differenceTip t2
+     | Nil, _ => Nil
+     end.
 Solve Obligations with (termination_by_omega).
 
 Definition op_zrzr__ : IntSet -> IntSet -> IntSet :=
@@ -407,11 +407,11 @@ Definition null : IntSet -> bool :=
 
 Definition size : IntSet -> IntWord.Int :=
   let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | acc, Bin _ _ l r => go (go acc l) r
-               | acc, Tip _ bm => acc GHC.Num.+ IntWord.bitcount #0 bm
-               | acc, Nil => acc
-               end in
+    := match arg_0__, arg_1__ with
+       | acc, Bin _ _ l r => go (go acc l) r
+       | acc, Tip _ bm => acc GHC.Num.+ IntWord.bitcount #0 bm
+       | acc, Nil => acc
+       end in
   go #0.
 
 Definition bitmapOfSuffix : IntWord.Int -> BitMap :=
@@ -435,16 +435,16 @@ Definition prefixOf : IntWord.Int -> Prefix :=
 Definition member : Key -> IntSet -> bool :=
   fun x =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch x p m : bool then false else
-                     if zero x m : bool then go l else
-                     go r
-                 | Tip y bm =>
-                     andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
-                           #0)
-                 | Nil => false
-                 end in
+      := match arg_0__ with
+         | Bin p m l r =>
+             if nomatch x p m : bool then false else
+             if zero x m : bool then go l else
+             go r
+         | Tip y bm =>
+             andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
+                   #0)
+         | Nil => false
+         end in
     go.
 
 Definition notMember : Key -> IntSet -> bool :=
@@ -454,32 +454,32 @@ Definition highestBitSet : Nat -> IntWord.Int :=
   fun x => indexOfTheOnlyBit (IntWord.highestBitMask x).
 
 Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
-              | Bin _ _ _ r => unsafeFindMax r
-              end.
+  := match arg_0__ with
+     | Nil => None
+     | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
+     | Bin _ _ _ r => unsafeFindMax r
+     end.
 
 Definition lookupLT : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if zero x m : bool then go def l else
-                     go l r
-                 | def, Tip kx bm =>
-                     let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.> kx : bool
-                     then Some (kx GHC.Num.+ highestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ highestBitSet maskLT) else
-                     unsafeFindMax def
-                 | def, Nil => unsafeFindMax def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMax def
+                  else unsafeFindMax r else
+             if zero x m : bool then go def l else
+             go l r
+         | def, Tip kx bm =>
+             let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
+             if prefixOf x GHC.Base.> kx : bool
+             then Some (kx GHC.Num.+ highestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ highestBitSet maskLT) else
+             unsafeFindMax def
+         | def, Nil => unsafeFindMax def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -495,32 +495,32 @@ Definition lowestBitSet : Nat -> IntWord.Int :=
   fun x => indexOfTheOnlyBit (lowestBitMask x).
 
 Fixpoint unsafeFindMin (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
-              | Bin _ _ l _ => unsafeFindMin l
-              end.
+  := match arg_0__ with
+     | Nil => None
+     | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
+     | Bin _ _ l _ => unsafeFindMin l
+     end.
 
 Definition lookupGT : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if zero x m : bool then go r l else
-                     go def r
-                 | def, Tip kx bm =>
-                     let maskGT :=
-                       (GHC.Num.negate (IntWord.shiftLWord (bitmapOf x) #1)) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskGT GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ lowestBitSet maskGT) else
-                     unsafeFindMin def
-                 | def, Nil => unsafeFindMin def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMin l
+                  else unsafeFindMin def else
+             if zero x m : bool then go r l else
+             go def r
+         | def, Tip kx bm =>
+             let maskGT :=
+               (GHC.Num.negate (IntWord.shiftLWord (bitmapOf x) #1)) Data.Bits..&.(**) bm in
+             if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskGT GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ lowestBitSet maskGT) else
+             unsafeFindMin def
+         | def, Nil => unsafeFindMin def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -535,24 +535,24 @@ Definition lookupGT : Key -> IntSet -> option Key :=
 Definition lookupLE : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if zero x m : bool then go def l else
-                     go l r
-                 | def, Tip kx bm =>
-                     let maskLE :=
-                       ((IntWord.shiftLWord (bitmapOf x) #1) GHC.Num.- #1) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.> kx : bool
-                     then Some (kx GHC.Num.+ highestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskLE GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ highestBitSet maskLE) else
-                     unsafeFindMax def
-                 | def, Nil => unsafeFindMax def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMax def
+                  else unsafeFindMax r else
+             if zero x m : bool then go def l else
+             go l r
+         | def, Tip kx bm =>
+             let maskLE :=
+               ((IntWord.shiftLWord (bitmapOf x) #1) GHC.Num.- #1) Data.Bits..&.(**) bm in
+             if prefixOf x GHC.Base.> kx : bool
+             then Some (kx GHC.Num.+ highestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskLE GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ highestBitSet maskLE) else
+             unsafeFindMax def
+         | def, Nil => unsafeFindMax def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -567,22 +567,22 @@ Definition lookupLE : Key -> IntSet -> option Key :=
 Definition lookupGE : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch x p m : bool
-                     then if x GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if zero x m : bool then go r l else
-                     go def r
-                 | def, Tip kx bm =>
-                     let maskGE := (GHC.Num.negate (bitmapOf x)) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ lowestBitSet maskGE) else
-                     unsafeFindMin def
-                 | def, Nil => unsafeFindMin def
-                 end in
+      := match arg_0__, arg_1__ with
+         | def, Bin p m l r =>
+             if nomatch x p m : bool
+             then if x GHC.Base.< p : bool
+                  then unsafeFindMin l
+                  else unsafeFindMin def else
+             if zero x m : bool then go r l else
+             go def r
+         | def, Tip kx bm =>
+             let maskGE := (GHC.Num.negate (bitmapOf x)) Data.Bits..&.(**) bm in
+             if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
+             if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
+             then Some (kx GHC.Num.+ lowestBitSet maskGE) else
+             unsafeFindMin def
+         | def, Nil => unsafeFindMin def
+         end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
@@ -606,97 +606,97 @@ Definition delete : Key -> IntSet -> IntSet :=
 Program Fixpoint intersection (arg_0__ arg_1__ : IntSet) {measure (size_nat
                                arg_0__ +
                                size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let intersection2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
-                            intersection t1 r2 in
-                          let intersection1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
-                            intersection r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
-                          Nil
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix intersectBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
-                                           intersectBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t1
-                      | Bin _ _ _ _, Nil => Nil
-                      | Tip kx1 bm1, t2 =>
-                          let fix intersectBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
-                                           intersectBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t2
-                      | Nil, _ => Nil
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let intersection2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
+           intersection t1 r2 in
+         let intersection1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
+           intersection r1 t2 in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
+         Nil
+     | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+         let fix intersectBM arg_11__
+           := match arg_11__ with
+              | Bin p1 m1 l1 r1 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
+                  intersectBM r1
+              | Tip kx1 bm1 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                  Nil
+              | Nil => Nil
+              end in
+         intersectBM t1
+     | Bin _ _ _ _, Nil => Nil
+     | Tip kx1 bm1, t2 =>
+         let fix intersectBM arg_18__
+           := match arg_18__ with
+              | Bin p2 m2 l2 r2 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
+                  intersectBM r2
+              | Tip kx2 bm2 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                  Nil
+              | Nil => Nil
+              end in
+         intersectBM t2
+     | Nil, _ => Nil
+     end.
 Solve Obligations with (termination_by_omega).
 
 Fixpoint subsetCmp (arg_0__ arg_1__ : IntSet) : comparison
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  let subsetCmpEq :=
-                    match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
-                    | pair Gt _ => Gt
-                    | pair _ Gt => Gt
-                    | pair Eq Eq => Eq
-                    | _ => Lt
-                    end in
-                  let subsetCmpLt :=
-                    if nomatch p1 p2 m2 : bool then Gt else
-                    if zero p1 m2 : bool then subsetCmp t1 l2 else
-                    subsetCmp t1 r2 in
-                  if shorter m1 m2 : bool then Gt else
-                  if shorter m2 m1 : bool
-                  then match subsetCmpLt with
-                       | Gt => Gt
-                       | _ => Lt
-                       end else
-                  if p1 GHC.Base.== p2 : bool then subsetCmpEq else
-                  Gt
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => Gt
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      if kx1 GHC.Base./= kx2 : bool then Gt else
-                      if bm1 GHC.Base.== bm2 : bool then Eq else
-                      if (bm1 Data.Bits..&.(**) Data.Bits.complement bm2) GHC.Base.== #0 : bool
-                      then Lt else
-                      Gt
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then Gt else
-                      if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
-                      match subsetCmp t1 r with
-                      | Gt => Gt
-                      | _ => Lt
-                      end
-                  | Tip _ _, Nil => Gt
-                  | Nil, Nil => Eq
-                  | Nil, _ => Lt
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+         let subsetCmpEq :=
+           match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
+           | pair Gt _ => Gt
+           | pair _ Gt => Gt
+           | pair Eq Eq => Eq
+           | _ => Lt
+           end in
+         let subsetCmpLt :=
+           if nomatch p1 p2 m2 : bool then Gt else
+           if zero p1 m2 : bool then subsetCmp t1 l2 else
+           subsetCmp t1 r2 in
+         if shorter m1 m2 : bool then Gt else
+         if shorter m2 m1 : bool
+         then match subsetCmpLt with
+              | Gt => Gt
+              | _ => Lt
+              end else
+         if p1 GHC.Base.== p2 : bool then subsetCmpEq else
+         Gt
+     | _, _ =>
+         match arg_0__, arg_1__ with
+         | Bin _ _ _ _, _ => Gt
+         | Tip kx1 bm1, Tip kx2 bm2 =>
+             if kx1 GHC.Base./= kx2 : bool then Gt else
+             if bm1 GHC.Base.== bm2 : bool then Eq else
+             if (bm1 Data.Bits..&.(**) Data.Bits.complement bm2) GHC.Base.== #0 : bool
+             then Lt else
+             Gt
+         | (Tip kx _ as t1), Bin p m l r =>
+             if nomatch kx p m : bool then Gt else
+             if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
+             match subsetCmp t1 r with
+             | Gt => Gt
+             | _ => Lt
+             end
+         | Tip _ _, Nil => Gt
+         | Nil, Nil => Eq
+         | Nil, _ => Lt
+         end
+     end.
 
 Definition isProperSubsetOf : IntSet -> IntSet -> bool :=
   fun t1 t2 => match subsetCmp t1 t2 with | Lt => true | _ => false end.
@@ -705,155 +705,155 @@ Definition match_ : IntWord.Int -> Prefix -> Mask -> bool :=
   fun i p m => (mask i m) GHC.Base.== p.
 
 Fixpoint isSubsetOf (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  if shorter m1 m2 : bool then false else
-                  if shorter m2 m1 : bool
-                  then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
-                             then isSubsetOf t1 l2
-                             else isSubsetOf t1 r2) else
-                  andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => false
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      andb (kx1 GHC.Base.== kx2) ((bm1 Data.Bits..&.(**) Data.Bits.complement bm2)
-                            GHC.Base.==
-                            #0)
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then false else
-                      if zero kx m : bool then isSubsetOf t1 l else
-                      isSubsetOf t1 r
-                  | Tip _ _, Nil => false
-                  | Nil, _ => true
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+         if shorter m1 m2 : bool then false else
+         if shorter m2 m1 : bool
+         then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
+                    then isSubsetOf t1 l2
+                    else isSubsetOf t1 r2) else
+         andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
+     | _, _ =>
+         match arg_0__, arg_1__ with
+         | Bin _ _ _ _, _ => false
+         | Tip kx1 bm1, Tip kx2 bm2 =>
+             andb (kx1 GHC.Base.== kx2) ((bm1 Data.Bits..&.(**) Data.Bits.complement bm2)
+                   GHC.Base.==
+                   #0)
+         | (Tip kx _ as t1), Bin p m l r =>
+             if nomatch kx p m : bool then false else
+             if zero kx m : bool then isSubsetOf t1 l else
+             isSubsetOf t1 r
+         | Tip _ _, Nil => false
+         | Nil, _ => true
+         end
+     end.
 
 Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
                            +
                            size_nat arg_1__)} : bool
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let disjoint2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
-                            disjoint t1 r2 in
-                          let disjoint1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
-                            disjoint r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then andb (disjoint l1 l2) (disjoint r1 r2) else
-                          true
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix disjointBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
-                                           disjointBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t1
-                      | Bin _ _ _ _, Nil => true
-                      | Tip kx1 bm1, t2 =>
-                          let fix disjointBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
-                                           disjointBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t2
-                      | Nil, _ => true
-                      end.
+  := match arg_0__, arg_1__ with
+     | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+         let disjoint2 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
+           if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
+           disjoint t1 r2 in
+         let disjoint1 :=
+           if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
+           if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
+           disjoint r1 t2 in
+         if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
+         if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
+         if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+         then andb (disjoint l1 l2) (disjoint r1 r2) else
+         true
+     | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+         let fix disjointBM arg_11__
+           := match arg_11__ with
+              | Bin p1 m1 l1 r1 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
+                  disjointBM r1
+              | Tip kx1 bm1 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                  true
+              | Nil => true
+              end in
+         disjointBM t1
+     | Bin _ _ _ _, Nil => true
+     | Tip kx1 bm1, t2 =>
+         let fix disjointBM arg_18__
+           := match arg_18__ with
+              | Bin p2 m2 l2 r2 =>
+                  if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
+                  if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
+                  disjointBM r2
+              | Tip kx2 bm2 =>
+                  if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                  then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                  true
+              | Nil => true
+              end in
+         disjointBM t2
+     | Nil, _ => true
+     end.
 Solve Obligations with (termination_by_omega).
 
 Program Definition foldl'Bits {a}
-           : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
+   : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                           end
+                       end) in
+    go bitmap z.
 Admit Obligations.
 
 Fixpoint filter (predicate : (Key -> bool)) (t : IntSet) : IntSet
-           := let bitPred :=
-                fun kx bm bi =>
-                  if predicate (kx GHC.Num.+ bi) : bool
-                  then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                  bm in
-              match t with
-              | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
-              | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
-              | Nil => Nil
-              end.
+  := let bitPred :=
+       fun kx bm bi =>
+         if predicate (kx GHC.Num.+ bi) : bool
+         then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+         bm in
+     match t with
+     | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
+     | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
+     | Nil => Nil
+     end.
 
 Definition partition : (Key -> bool) -> IntSet -> (IntSet * IntSet)%type :=
   fun predicate0 t0 =>
     let fix go predicate t
-              := let bitPred :=
-                   fun kx bm bi =>
-                     if predicate (kx GHC.Num.+ bi) : bool
-                     then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                     bm in
-                 match t with
-                 | Bin p m l r =>
-                     let 'pair r1 r2 := go predicate r in
-                     let 'pair l1 l2 := go predicate l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | Tip kx bm =>
-                     let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
-                     pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
-                 | Nil => (pair Nil Nil)
-                 end in
+      := let bitPred :=
+           fun kx bm bi =>
+             if predicate (kx GHC.Num.+ bi) : bool
+             then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+             bm in
+         match t with
+         | Bin p m l r =>
+             let 'pair r1 r2 := go predicate r in
+             let 'pair l1 l2 := go predicate l in
+             pair (bin p m l1 r1) (bin p m l2 r2)
+         | Tip kx bm =>
+             let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
+             pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
+         | Nil => (pair Nil Nil)
+         end in
     id (go predicate0 t0).
 
 Definition split : Key -> IntSet -> (IntSet * IntSet)%type :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | x', (Bin p m l r as t') =>
-                     if match_ x' p m : bool
-                     then if zero x' m : bool
-                          then let 'pair lt gt := go x' l in
-                               pair lt (union gt r)
-                          else let 'pair lt gt := go x' r in
-                               pair (union lt l) gt else
-                     if x' GHC.Base.< p : bool
-                     then (pair Nil t')
-                     else (pair t' Nil)
-                 | x', (Tip kx' bm as t') =>
-                     let lowerBitmap := bitmapOf x' GHC.Num.- #1 in
-                     let higherBitmap := Data.Bits.complement (lowerBitmap GHC.Num.+ bitmapOf x') in
-                     if kx' GHC.Base.> x' : bool then (pair Nil t') else
-                     if kx' GHC.Base.< prefixOf x' : bool then (pair t' Nil) else
-                     pair (tip kx' (bm Data.Bits..&.(**) lowerBitmap)) (tip kx' (bm Data.Bits..&.(**)
-                                                                                 higherBitmap))
-                 | _, Nil => (pair Nil Nil)
-                 end in
+      := match arg_0__, arg_1__ with
+         | x', (Bin p m l r as t') =>
+             if match_ x' p m : bool
+             then if zero x' m : bool
+                  then let 'pair lt gt := go x' l in
+                       pair lt (union gt r)
+                  else let 'pair lt gt := go x' r in
+                       pair (union lt l) gt else
+             if x' GHC.Base.< p : bool
+             then (pair Nil t')
+             else (pair t' Nil)
+         | x', (Tip kx' bm as t') =>
+             let lowerBitmap := bitmapOf x' GHC.Num.- #1 in
+             let higherBitmap := Data.Bits.complement (lowerBitmap GHC.Num.+ bitmapOf x') in
+             if kx' GHC.Base.> x' : bool then (pair Nil t') else
+             if kx' GHC.Base.< prefixOf x' : bool then (pair t' Nil) else
+             pair (tip kx' (bm Data.Bits..&.(**) lowerBitmap)) (tip kx' (bm Data.Bits..&.(**)
+                                                                         higherBitmap))
+         | _, Nil => (pair Nil Nil)
+         end in
     let j_21__ := let 'pair lt gt := go x t in pair lt gt in
     match t with
     | Bin _ m l r =>
@@ -870,28 +870,28 @@ Definition split : Key -> IntSet -> (IntSet * IntSet)%type :=
 Definition splitMember : Key -> IntSet -> (IntSet * bool * IntSet)%type :=
   fun x t =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | x', (Bin p m l r as t') =>
-                     if match_ x' p m : bool
-                     then if zero x' m : bool
-                          then let 'pair (pair lt fnd) gt := go x' l in
-                               pair (pair lt fnd) (union gt r)
-                          else let 'pair (pair lt fnd) gt := go x' r in
-                               pair (pair (union lt l) fnd) gt else
-                     if x' GHC.Base.< p : bool
-                     then pair (pair Nil false) t'
-                     else pair (pair t' false) Nil
-                 | x', (Tip kx' bm as t') =>
-                     let bitmapOfx' := bitmapOf x' in
-                     let lowerBitmap := bitmapOfx' GHC.Num.- #1 in
-                     let higherBitmap := Data.Bits.complement (lowerBitmap GHC.Num.+ bitmapOfx') in
-                     if kx' GHC.Base.> x' : bool then pair (pair Nil false) t' else
-                     if kx' GHC.Base.< prefixOf x' : bool then pair (pair t' false) Nil else
-                     let gt := tip kx' (bm Data.Bits..&.(**) higherBitmap) in
-                     let found := (bm Data.Bits..&.(**) bitmapOfx') GHC.Base./= #0 in
-                     let lt := tip kx' (bm Data.Bits..&.(**) lowerBitmap) in pair (pair lt found) gt
-                 | _, Nil => pair (pair Nil false) Nil
-                 end in
+      := match arg_0__, arg_1__ with
+         | x', (Bin p m l r as t') =>
+             if match_ x' p m : bool
+             then if zero x' m : bool
+                  then let 'pair (pair lt fnd) gt := go x' l in
+                       pair (pair lt fnd) (union gt r)
+                  else let 'pair (pair lt fnd) gt := go x' r in
+                       pair (pair (union lt l) fnd) gt else
+             if x' GHC.Base.< p : bool
+             then pair (pair Nil false) t'
+             else pair (pair t' false) Nil
+         | x', (Tip kx' bm as t') =>
+             let bitmapOfx' := bitmapOf x' in
+             let lowerBitmap := bitmapOfx' GHC.Num.- #1 in
+             let higherBitmap := Data.Bits.complement (lowerBitmap GHC.Num.+ bitmapOfx') in
+             if kx' GHC.Base.> x' : bool then pair (pair Nil false) t' else
+             if kx' GHC.Base.< prefixOf x' : bool then pair (pair t' false) Nil else
+             let gt := tip kx' (bm Data.Bits..&.(**) higherBitmap) in
+             let found := (bm Data.Bits..&.(**) bitmapOfx') GHC.Base./= #0 in
+             let lt := tip kx' (bm Data.Bits..&.(**) lowerBitmap) in pair (pair lt found) gt
+         | _, Nil => pair (pair Nil false) Nil
+         end in
     let j_22__ := go x t in
     match t with
     | Bin _ m l r =>
@@ -908,14 +908,14 @@ Definition splitMember : Key -> IntSet -> (IntSet * bool * IntSet)%type :=
 Definition maxView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r => let 'pair result r' := go r in pair result (bin p m l r')
-                 | Tip kx bm =>
-                     let 'bi := highestBitSet bm in
-                     pair (kx GHC.Num.+ bi) (tip kx (bm Data.Bits..&.(**)
-                                                     Data.Bits.complement (bitmapOfSuffix bi)))
-                 | Nil => GHC.Err.error (GHC.Base.hs_string__ "maxView Nil")
-                 end in
+      := match arg_0__ with
+         | Bin p m l r => let 'pair result r' := go r in pair result (bin p m l r')
+         | Tip kx bm =>
+             let 'bi := highestBitSet bm in
+             pair (kx GHC.Num.+ bi) (tip kx (bm Data.Bits..&.(**)
+                                             Data.Bits.complement (bitmapOfSuffix bi)))
+         | Nil => GHC.Err.error (GHC.Base.hs_string__ "maxView Nil")
+         end in
     let j_12__ := Some (go t) in
     match t with
     | Nil => None
@@ -930,14 +930,14 @@ Definition maxView : IntSet -> option (Key * IntSet)%type :=
 Definition minView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r => let 'pair result l' := go l in pair result (bin p m l' r)
-                 | Tip kx bm =>
-                     let 'bi := lowestBitSet bm in
-                     pair (kx GHC.Num.+ bi) (tip kx (bm Data.Bits..&.(**)
-                                                     Data.Bits.complement (bitmapOfSuffix bi)))
-                 | Nil => GHC.Err.error (GHC.Base.hs_string__ "minView Nil")
-                 end in
+      := match arg_0__ with
+         | Bin p m l r => let 'pair result l' := go l in pair result (bin p m l' r)
+         | Tip kx bm =>
+             let 'bi := lowestBitSet bm in
+             pair (kx GHC.Num.+ bi) (tip kx (bm Data.Bits..&.(**)
+                                             Data.Bits.complement (bitmapOfSuffix bi)))
+         | Nil => GHC.Err.error (GHC.Base.hs_string__ "minView Nil")
+         end in
     let j_12__ := Some (go t) in
     match t with
     | Nil => None
@@ -976,34 +976,34 @@ Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   foldr.
 
 Program Definition foldr'Bits {a}
-           : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNat bitmap) z.
+   : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                  GHC.Num.-
+                                                                  bi)) acc)
+                           end
+                       end) in
+    go (revNat bitmap) z.
 Admit Obligations.
 
 Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldr'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldr'Bits kx f z' bm
+         | z', Bin _ _ l r => go (go z' r) l
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
@@ -1011,32 +1011,32 @@ Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
       end.
 
 Program Definition foldlBits {a}
-           : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
+   : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
+  fun prefix f z bitmap =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | num_2__, acc =>
+                           if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                           match arg_0__, arg_1__ with
+                           | bm, acc =>
+                               let bitmask := lowestBitMask bm in
+                               let bi := indexOfTheOnlyBit bitmask in
+                               go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                           end
+                       end) in
+    go bitmap z.
 Admit Obligations.
 
 Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldlBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldlBits kx f z' bm
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
@@ -1046,11 +1046,11 @@ Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
 Definition foldl' {a} : (a -> Key -> a) -> a -> IntSet -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldl'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Nil => z'
+         | z', Tip kx bm => foldl'Bits kx f z' bm
+         | z', Bin _ _ l r => go (go z' l) r
+         end in
     fun t =>
       match t with
       | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r

--- a/examples/containers/lib/Data/Map/Internal.v
+++ b/examples/containers/lib/Data/Map/Internal.v
@@ -42,15 +42,15 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive WhenMatched f k x y z : Type
-  := | Mk_WhenMatched (matchedKey : k -> x -> y -> f (option z))
+Inductive WhenMatched f k x y z : Type :=
+  | Mk_WhenMatched (matchedKey : k -> x -> y -> f (option z))
    : WhenMatched f k x y z.
 
-Inductive TraceResult a : Type
-  := | Mk_TraceResult : (option a) -> unit -> TraceResult a.
+Inductive TraceResult a : Type :=
+  | Mk_TraceResult : (option a) -> unit -> TraceResult a.
 
-Inductive StrictTriple a b c : Type
-  := | Mk_StrictTriple : a -> b -> c -> StrictTriple a b c.
+Inductive StrictTriple a b c : Type :=
+  | Mk_StrictTriple : a -> b -> c -> StrictTriple a b c.
 
 Definition Size :=
   GHC.Num.Int%type.
@@ -58,31 +58,31 @@ Definition Size :=
 Definition SimpleWhenMatched :=
   (WhenMatched Data.Functor.Identity.Identity)%type.
 
-Inductive Map k a : Type
-  := | Bin : Size -> k -> a -> (Map k a) -> (Map k a) -> Map k a
-  |  Tip : Map k a.
+Inductive Map k a : Type :=
+  | Bin : Size -> k -> a -> (Map k a) -> (Map k a) -> Map k a
+  | Tip : Map k a.
 
-Inductive MaxView k a : Type
-  := | Mk_MaxView : k -> a -> (Map k a) -> MaxView k a.
+Inductive MaxView k a : Type :=
+  | Mk_MaxView : k -> a -> (Map k a) -> MaxView k a.
 
-Inductive MinView k a : Type
-  := | Mk_MinView : k -> a -> (Map k a) -> MinView k a.
+Inductive MinView k a : Type :=
+  | Mk_MinView : k -> a -> (Map k a) -> MinView k a.
 
-Inductive WhenMissing f k x y : Type
-  := | Mk_WhenMissing (missingSubtree : Map k x -> f (Map k y)) (missingKey
+Inductive WhenMissing f k x y : Type :=
+  | Mk_WhenMissing (missingSubtree : Map k x -> f (Map k y)) (missingKey
     : k -> x -> f (option y))
    : WhenMissing f k x y.
 
 Definition SimpleWhenMissing :=
   (WhenMissing Data.Functor.Identity.Identity)%type.
 
-Inductive AreWeStrict : Type := | Strict : AreWeStrict |  Lazy : AreWeStrict.
+Inductive AreWeStrict : Type := | Strict : AreWeStrict | Lazy : AreWeStrict.
 
-Inductive Altered k a : Type
-  := | AltSmaller : (Map k a) -> Altered k a
-  |  AltBigger : (Map k a) -> Altered k a
-  |  AltAdj : (Map k a) -> Altered k a
-  |  AltSame : Altered k a.
+Inductive Altered k a : Type :=
+  | AltSmaller : (Map k a) -> Altered k a
+  | AltBigger : (Map k a) -> Altered k a
+  | AltAdj : (Map k a) -> Altered k a
+  | AltSame : Altered k a.
 
 Arguments Mk_WhenMatched {_} {_} {_} {_} {_} _.
 
@@ -257,108 +257,108 @@ Definition insert {k} {a} `{GHC.Base.Ord k} : k -> a -> Map k a -> Map k a :=
   fun kx0 =>
     let go {k} {a} `{GHC.Base.Ord k} : k -> k -> a -> Map k a -> Map k a :=
       fix go (arg_0__ arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a) : Map k a
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | orig, _, x, Tip => singleton (orig) x
-               | orig, kx, x, (Bin sz ky y l r as t) =>
-                   match GHC.Base.compare kx ky with
-                   | Lt =>
-                       let l' := go orig kx x l in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                       balanceL ky y l' r
-                   | Gt =>
-                       let r' := go orig kx x r in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                       balanceR ky y l r'
-                   | Eq =>
-                       if andb (Utils.Containers.Internal.PtrEquality.ptrEq x y) (GHC.Prim.seq orig
-                                                                                               (Utils.Containers.Internal.PtrEquality.ptrEq
-                                                                                                orig ky)) : bool
-                       then t else
-                       Bin sz (orig) x l r
-                   end
-               end in
+        := match arg_0__, arg_1__, arg_2__, arg_3__ with
+           | orig, _, x, Tip => singleton (orig) x
+           | orig, kx, x, (Bin sz ky y l r as t) =>
+               match GHC.Base.compare kx ky with
+               | Lt =>
+                   let l' := go orig kx x l in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                   balanceL ky y l' r
+               | Gt =>
+                   let r' := go orig kx x r in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                   balanceR ky y l r'
+               | Eq =>
+                   if andb (Utils.Containers.Internal.PtrEquality.ptrEq x y) (GHC.Prim.seq orig
+                                                                                           (Utils.Containers.Internal.PtrEquality.ptrEq
+                                                                                            orig ky)) : bool
+                   then t else
+                   Bin sz (orig) x l r
+               end
+           end in
     go kx0 kx0.
 
 Definition insertR {k} {a} `{GHC.Base.Ord k} : k -> a -> Map k a -> Map k a :=
   fun kx0 =>
     let go {k} {a} `{GHC.Base.Ord k} : k -> k -> a -> Map k a -> Map k a :=
       fix go (arg_0__ arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a) : Map k a
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | orig, _, x, Tip => singleton (orig) x
-               | orig, kx, x, (Bin _ ky y l r as t) =>
-                   match GHC.Base.compare kx ky with
-                   | Lt =>
-                       let l' := go orig kx x l in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                       balanceL ky y l' r
-                   | Gt =>
-                       let r' := go orig kx x r in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                       balanceR ky y l r'
-                   | Eq => t
-                   end
-               end in
+        := match arg_0__, arg_1__, arg_2__, arg_3__ with
+           | orig, _, x, Tip => singleton (orig) x
+           | orig, kx, x, (Bin _ ky y l r as t) =>
+               match GHC.Base.compare kx ky with
+               | Lt =>
+                   let l' := go orig kx x l in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                   balanceL ky y l' r
+               | Gt =>
+                   let r' := go orig kx x r in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                   balanceR ky y l r'
+               | Eq => t
+               end
+           end in
     go kx0 kx0.
 
 Definition bin {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
   fun k x l r => Bin ((size l GHC.Num.+ size r) GHC.Num.+ #1) k x l r.
 
 Fixpoint insertMax {k} {a} (kx : k) (x : a) (t : Map k a) : Map k a
-           := match t with
-              | Tip => singleton kx x
-              | Bin _ ky y l r => balanceR ky y l (insertMax kx x r)
-              end.
+  := match t with
+     | Tip => singleton kx x
+     | Bin _ ky y l r => balanceR ky y l (insertMax kx x r)
+     end.
 
 Fixpoint insertMin {k} {a} (kx : k) (x : a) (t : Map k a) : Map k a
-           := match t with
-              | Tip => singleton kx x
-              | Bin _ ky y l r => balanceL ky y (insertMin kx x l) r
-              end.
+  := match t with
+     | Tip => singleton kx x
+     | Bin _ ky y l r => balanceL ky y (insertMin kx x l) r
+     end.
 
 Program Fixpoint link {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ arg_3__
                         : Map k a) {measure (Nat.add (map_size arg_2__) (map_size arg_3__))} : Map k a
-                   := match arg_0__, arg_1__, arg_2__, arg_3__ with
-                      | kx, x, Tip, r => insertMin kx x r
-                      | kx, x, l, Tip => insertMax kx x l
-                      | kx, x, (Bin sizeL ky y ly ry as l), (Bin sizeR kz z lz rz as r) =>
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
-                          then balanceL kz z (link kx x l lz) rz else
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
-                          then balanceR ky y ly (link kx x ry r) else
-                          bin kx x l r
-                      end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | kx, x, Tip, r => insertMin kx x r
+     | kx, x, l, Tip => insertMax kx x l
+     | kx, x, (Bin sizeL ky y ly ry as l), (Bin sizeR kz z lz rz as r) =>
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
+         then balanceL kz z (link kx x l lz) rz else
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
+         then balanceR ky y ly (link kx x ry r) else
+         bin kx x l r
+     end.
 Solve Obligations with (termination_by_omega).
 
 Definition split {k} {a} `{GHC.Base.Ord k}
    : k -> Map k a -> (Map k a * Map k a)%type :=
   fun k0 t0 =>
     let fix go k t
-              := match t with
-                 | Tip => pair Tip Tip
-                 | Bin _ kx x l r =>
-                     match GHC.Base.compare k kx with
-                     | Lt => let 'pair lt gt := go k l in pair lt (link kx x gt r)
-                     | Gt => let 'pair lt gt := go k r in pair (link kx x l lt) gt
-                     | Eq => (pair l r)
-                     end
-                 end in
+      := match t with
+         | Tip => pair Tip Tip
+         | Bin _ kx x l r =>
+             match GHC.Base.compare k kx with
+             | Lt => let 'pair lt gt := go k l in pair lt (link kx x gt r)
+             | Gt => let 'pair lt gt := go k r in pair (link kx x l lt) gt
+             | Eq => (pair l r)
+             end
+         end in
     id (go k0 t0).
 
 Fixpoint union {k} {a} `{GHC.Base.Ord k} (arg_0__ arg_1__ : Map k a) : Map k a
-           := match arg_0__, arg_1__ with
-              | t1, Tip => t1
-              | t1, Bin _ k x Tip Tip => insertR k x t1
-              | Bin _ k x Tip Tip, t2 => insert k x t2
-              | Tip, t2 => t2
-              | (Bin _ k1 x1 l1 r1 as t1), t2 =>
-                  let 'pair l2 r2 := split k1 t2 in
-                  let r1r2 := union r1 r2 in
-                  let l1l2 := union l1 l2 in
-                  if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                          (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                  then t1 else
-                  link k1 x1 l1l2 r1r2
-              end.
+  := match arg_0__, arg_1__ with
+     | t1, Tip => t1
+     | t1, Bin _ k x Tip Tip => insertR k x t1
+     | Bin _ k x Tip Tip, t2 => insert k x t2
+     | Tip, t2 => t2
+     | (Bin _ k1 x1 l1 r1 as t1), t2 =>
+         let 'pair l2 r2 := split k1 t2 in
+         let r1r2 := union r1 r2 in
+         let l1l2 := union l1 l2 in
+         if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                 (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+         then t1 else
+         link k1 x1 l1l2 r1r2
+     end.
 
 Local Definition Semigroup__Map_op_zlzlzgzg__ {inst_k} {inst_v} `{(GHC.Base.Ord
    inst_k)}
@@ -401,10 +401,10 @@ Program Instance Monoid__Map {k} {v} `{(GHC.Base.Ord k)}
 Definition map {a} {b} {k} : (a -> b) -> Map k a -> Map k b :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => Tip
-                 | Bin sx kx x l r => Bin sx kx (f x) (go l) (go r)
-                 end in
+      := match arg_0__ with
+         | Tip => Tip
+         | Bin sx kx x l r => Bin sx kx (f x) (go l) (go r)
+         end in
     go.
 
 Local Definition Functor__Map_fmap {inst_k}
@@ -503,10 +503,10 @@ Program Instance Functor__WhenMatched {f} {k} {x} {y} `{GHC.Base.Functor f}
 Definition foldrWithKey {k} {a} {b} : (k -> a -> b -> b) -> b -> Map k a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f kx x (go z' r)) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ kx x l r => go (f kx x (go z' r)) l
+         end in
     go z.
 
 Definition toAscList {k} {a} : Map k a -> list (k * a)%type :=
@@ -624,17 +624,17 @@ Definition traverseWithKey {t} {k} {a} {b} `{GHC.Base.Applicative t}
    : (k -> a -> t b) -> Map k a -> t (Map k b) :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => GHC.Base.pure Tip
-                 | Bin num_1__ k v _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool
-                     then (fun v' => Bin #1 k v' Tip Tip) Data.Functor.<$> f k v else
-                     match arg_0__ with
-                     | Bin s k v l r =>
-                         GHC.Base.liftA3 (GHC.Base.flip (Bin s k)) (go l) (f k v) (go r)
-                     | _ => GHC.Err.patternFailure
-                     end
-                 end in
+      := match arg_0__ with
+         | Tip => GHC.Base.pure Tip
+         | Bin num_1__ k v _ _ =>
+             if num_1__ GHC.Base.== #1 : bool
+             then (fun v' => Bin #1 k v' Tip Tip) Data.Functor.<$> f k v else
+             match arg_0__ with
+             | Bin s k v l r =>
+                 GHC.Base.liftA3 (GHC.Base.flip (Bin s k)) (go l) (f k v) (go r)
+             | _ => GHC.Err.patternFailure
+             end
+         end in
     go.
 
 Local Definition Traversable__Map_traverse {inst_k}
@@ -664,15 +664,15 @@ Local Definition Foldable__Map_fold {inst_k}
    : forall {m}, forall `{GHC.Base.Monoid m}, (Map inst_k) m -> m :=
   fun {m} `{GHC.Base.Monoid m} =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => GHC.Base.mempty
-                 | Bin num_1__ _ v _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool then v else
-                     match arg_0__ with
-                     | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend v (go r))
-                     | _ => GHC.Err.patternFailure
-                     end
-                 end in
+      := match arg_0__ with
+         | Tip => GHC.Base.mempty
+         | Bin num_1__ _ v _ _ =>
+             if num_1__ GHC.Base.== #1 : bool then v else
+             match arg_0__ with
+             | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend v (go r))
+             | _ => GHC.Err.patternFailure
+             end
+         end in
     go.
 
 Local Definition Foldable__Map_foldMap {inst_k}
@@ -681,24 +681,24 @@ Local Definition Foldable__Map_foldMap {inst_k}
   fun {m} {a} `{GHC.Base.Monoid m} =>
     fun f t =>
       let fix go arg_0__
-                := match arg_0__ with
-                   | Tip => GHC.Base.mempty
-                   | Bin num_1__ _ v _ _ =>
-                       if num_1__ GHC.Base.== #1 : bool then f v else
-                       match arg_0__ with
-                       | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f v) (go r))
-                       | _ => GHC.Err.patternFailure
-                       end
-                   end in
+        := match arg_0__ with
+           | Tip => GHC.Base.mempty
+           | Bin num_1__ _ v _ _ =>
+               if num_1__ GHC.Base.== #1 : bool then f v else
+               match arg_0__ with
+               | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f v) (go r))
+               | _ => GHC.Err.patternFailure
+               end
+           end in
       go t.
 
 Definition foldl {a} {b} {k} : (a -> b -> a) -> a -> Map k b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f (go z' l) x) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ _ x l r => go (f (go z' l) x) r
+         end in
     go z.
 
 Local Definition Foldable__Map_foldl {inst_k}
@@ -708,10 +708,10 @@ Local Definition Foldable__Map_foldl {inst_k}
 Definition foldl' {a} {b} {k} : (a -> b -> a) -> a -> Map k b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f (go z' l) x) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ _ x l r => go (f (go z' l) x) r
+         end in
     go z.
 
 Local Definition Foldable__Map_foldl' {inst_k}
@@ -721,10 +721,10 @@ Local Definition Foldable__Map_foldl' {inst_k}
 Definition foldr {a} {b} {k} : (a -> b -> b) -> b -> Map k a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f x (go z' r)) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ _ x l r => go (f x (go z' r)) l
+         end in
     go z.
 
 Local Definition Foldable__Map_foldr {inst_k}
@@ -734,10 +734,10 @@ Local Definition Foldable__Map_foldr {inst_k}
 Definition foldr' {a} {b} {k} : (a -> b -> b) -> b -> Map k a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f x (go z' r)) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ _ x l r => go (f x (go z' r)) l
+         end in
     go z.
 
 Local Definition Foldable__Map_foldr' {inst_k}
@@ -810,15 +810,15 @@ Program Instance Traversable__Map {k} : Data.Traversable.Traversable (Map k) :=
 
 Definition lookup {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> option a :=
   let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => go k l
-                   | Gt => go k r
-                   | Eq => Some x
-                   end
-               end in
+    := match arg_0__, arg_1__ with
+       | _, Tip => None
+       | k, Bin _ kx x l r =>
+           match GHC.Base.compare k kx with
+           | Lt => go k l
+           | Gt => go k r
+           | Eq => Some x
+           end
+       end in
   go.
 
 Definition op_znz3fU__ {k} {a} `{GHC.Base.Ord k} : Map k a -> k -> option a :=
@@ -830,22 +830,22 @@ Infix "!?" := (_!?_) (at level 99).
 
 Definition maxViewSure {k} {a} : k -> a -> Map k a -> Map k a -> MaxView k a :=
   let fix go arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | k, x, l, Tip => Mk_MaxView k x l
-               | k, x, l, Bin _ kr xr rl rr =>
-                   let 'Mk_MaxView km xm r' := go kr xr rl rr in
-                   Mk_MaxView km xm (balanceL k x l r')
-               end in
+    := match arg_0__, arg_1__, arg_2__, arg_3__ with
+       | k, x, l, Tip => Mk_MaxView k x l
+       | k, x, l, Bin _ kr xr rl rr =>
+           let 'Mk_MaxView km xm r' := go kr xr rl rr in
+           Mk_MaxView km xm (balanceL k x l r')
+       end in
   go.
 
 Definition minViewSure {k} {a} : k -> a -> Map k a -> Map k a -> MinView k a :=
   let fix go arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | k, x, Tip, r => Mk_MinView k x r
-               | k, x, Bin _ kl xl ll lr, r =>
-                   let 'Mk_MinView km xm l' := go kl xl ll lr in
-                   Mk_MinView km xm (balanceR k x l' r)
-               end in
+    := match arg_0__, arg_1__, arg_2__, arg_3__ with
+       | k, x, Tip, r => Mk_MinView k x r
+       | k, x, Bin _ kl xl ll lr, r =>
+           let 'Mk_MinView km xm l' := go kl xl ll lr in
+           Mk_MinView km xm (balanceR k x l' r)
+       end in
   go.
 
 Definition glue {k} {a} : Map k a -> Map k a -> Map k a :=
@@ -863,30 +863,30 @@ Definition glue {k} {a} : Map k a -> Map k a -> Map k a :=
 
 Program Fixpoint link2 {k} {a} (arg_0__ arg_1__ : Map k a) {measure (Nat.add
                         (map_size arg_0__) (map_size arg_1__))} : Map k a
-                   := match arg_0__, arg_1__ with
-                      | Tip, r => r
-                      | l, Tip => l
-                      | (Bin sizeL kx x lx rx as l), (Bin sizeR ky y ly ry as r) =>
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
-                          then balanceL ky y (link2 l ly) ry else
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
-                          then balanceR kx x lx (link2 rx r) else
-                          glue l r
-                      end.
+  := match arg_0__, arg_1__ with
+     | Tip, r => r
+     | l, Tip => l
+     | (Bin sizeL kx x lx rx as l), (Bin sizeR ky y ly ry as r) =>
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
+         then balanceL ky y (link2 l ly) ry else
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
+         then balanceR kx x lx (link2 rx r) else
+         glue l r
+     end.
 Solve Obligations with (termination_by_omega).
 
 Fixpoint difference {k} {a} {b} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
                       : Map k b) : Map k a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | t1, Tip => t1
-              | t1, Bin _ k _ l2 r2 =>
-                  let 'pair l1 r1 := split k t1 in
-                  let r1r2 := difference r1 r2 in
-                  let l1l2 := difference l1 l2 in
-                  if (size l1l2 GHC.Num.+ size r1r2) GHC.Base.== size t1 : bool then t1 else
-                  link2 l1l2 r1r2
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => Tip
+     | t1, Tip => t1
+     | t1, Bin _ k _ l2 r2 =>
+         let 'pair l1 r1 := split k t1 in
+         let r1r2 := difference r1 r2 in
+         let l1l2 := difference l1 l2 in
+         if (size l1l2 GHC.Num.+ size r1r2) GHC.Base.== size t1 : bool then t1 else
+         link2 l1l2 r1r2
+     end.
 
 Definition op_zrzr__ {k} {a} {b} `{GHC.Base.Ord k}
    : Map k a -> Map k b -> Map k a :=
@@ -902,15 +902,15 @@ Infix "\\" := (_\\_) (at level 99).
 
 Definition member {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> bool :=
   let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | _, Tip => false
-               | k, Bin _ kx _ l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => go k l
-                   | Gt => go k r
-                   | Eq => true
-                   end
-               end in
+    := match arg_0__, arg_1__ with
+       | _, Tip => false
+       | k, Bin _ kx _ l r =>
+           match GHC.Base.compare k kx with
+           | Lt => go k l
+           | Gt => go k r
+           | Eq => true
+           end
+       end in
   go.
 
 Definition notMember {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> bool :=
@@ -920,99 +920,99 @@ Definition notMember {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> bool :=
 
 Definition findWithDefault {k} {a} `{GHC.Base.Ord k} : a -> k -> Map k a -> a :=
   let fix go arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | def, _, Tip => def
-               | def, k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => go def k l
-                   | Gt => go def k r
-                   | Eq => x
-                   end
-               end in
+    := match arg_0__, arg_1__, arg_2__ with
+       | def, _, Tip => def
+       | def, k, Bin _ kx x l r =>
+           match GHC.Base.compare k kx with
+           | Lt => go def k l
+           | Gt => go def k r
+           | Eq => x
+           end
+       end in
   go.
 
 Definition lookupLT {k} {v} `{GHC.Base.Ord k}
    : k -> Map k v -> option (k * v)%type :=
   let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   if k GHC.Base.<= kx : bool then goJust k kx' x' l else
-                   goJust k kx x r
-               end in
+    := match arg_0__, arg_1__, arg_2__, arg_3__ with
+       | _, kx', x', Tip => Some (pair kx' x')
+       | k, kx', x', Bin _ kx x l r =>
+           if k GHC.Base.<= kx : bool then goJust k kx' x' l else
+           goJust k kx x r
+       end in
   let fix goNothing arg_8__ arg_9__
-            := match arg_8__, arg_9__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   if k GHC.Base.<= kx : bool then goNothing k l else
-                   goJust k kx x r
-               end in
+    := match arg_8__, arg_9__ with
+       | _, Tip => None
+       | k, Bin _ kx x l r =>
+           if k GHC.Base.<= kx : bool then goNothing k l else
+           goJust k kx x r
+       end in
   goNothing.
 
 Definition lookupGT {k} {v} `{GHC.Base.Ord k}
    : k -> Map k v -> option (k * v)%type :=
   let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   if k GHC.Base.< kx : bool then goJust k kx x l else
-                   goJust k kx' x' r
-               end in
+    := match arg_0__, arg_1__, arg_2__, arg_3__ with
+       | _, kx', x', Tip => Some (pair kx' x')
+       | k, kx', x', Bin _ kx x l r =>
+           if k GHC.Base.< kx : bool then goJust k kx x l else
+           goJust k kx' x' r
+       end in
   let fix goNothing arg_8__ arg_9__
-            := match arg_8__, arg_9__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   if k GHC.Base.< kx : bool then goJust k kx x l else
-                   goNothing k r
-               end in
+    := match arg_8__, arg_9__ with
+       | _, Tip => None
+       | k, Bin _ kx x l r =>
+           if k GHC.Base.< kx : bool then goJust k kx x l else
+           goNothing k r
+       end in
   goNothing.
 
 Definition lookupLE {k} {v} `{GHC.Base.Ord k}
    : k -> Map k v -> option (k * v)%type :=
   let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goJust k kx' x' l
-                   | Eq => Some (pair kx x)
-                   | Gt => goJust k kx x r
-                   end
-               end in
+    := match arg_0__, arg_1__, arg_2__, arg_3__ with
+       | _, kx', x', Tip => Some (pair kx' x')
+       | k, kx', x', Bin _ kx x l r =>
+           match GHC.Base.compare k kx with
+           | Lt => goJust k kx' x' l
+           | Eq => Some (pair kx x)
+           | Gt => goJust k kx x r
+           end
+       end in
   let fix goNothing arg_12__ arg_13__
-            := match arg_12__, arg_13__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goNothing k l
-                   | Eq => Some (pair kx x)
-                   | Gt => goJust k kx x r
-                   end
-               end in
+    := match arg_12__, arg_13__ with
+       | _, Tip => None
+       | k, Bin _ kx x l r =>
+           match GHC.Base.compare k kx with
+           | Lt => goNothing k l
+           | Eq => Some (pair kx x)
+           | Gt => goJust k kx x r
+           end
+       end in
   goNothing.
 
 Definition lookupGE {k} {v} `{GHC.Base.Ord k}
    : k -> Map k v -> option (k * v)%type :=
   let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goJust k kx x l
-                   | Eq => Some (pair kx x)
-                   | Gt => goJust k kx' x' r
-                   end
-               end in
+    := match arg_0__, arg_1__, arg_2__, arg_3__ with
+       | _, kx', x', Tip => Some (pair kx' x')
+       | k, kx', x', Bin _ kx x l r =>
+           match GHC.Base.compare k kx with
+           | Lt => goJust k kx x l
+           | Eq => Some (pair kx x)
+           | Gt => goJust k kx' x' r
+           end
+       end in
   let fix goNothing arg_12__ arg_13__
-            := match arg_12__, arg_13__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goJust k kx x l
-                   | Eq => Some (pair kx x)
-                   | Gt => goNothing k r
-                   end
-               end in
+    := match arg_12__, arg_13__ with
+       | _, Tip => None
+       | k, Bin _ kx x l r =>
+           match GHC.Base.compare k kx with
+           | Lt => goJust k kx x l
+           | Eq => Some (pair kx x)
+           | Gt => goNothing k r
+           end
+       end in
   goNothing.
 
 Definition insertWith {k} {a} `{GHC.Base.Ord k}
@@ -1020,16 +1020,16 @@ Definition insertWith {k} {a} `{GHC.Base.Ord k}
   let go {k} {a} `{GHC.Base.Ord k}
    : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
     fix go (arg_0__ : (a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a)
-          : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy kx (f x y) l r
-                 end
-             end in
+      : Map k a
+      := match arg_0__, arg_1__, arg_2__, arg_3__ with
+         | _, kx, x, Tip => singleton kx x
+         | f, kx, x, Bin sy ky y l r =>
+             match GHC.Base.compare kx ky with
+             | Lt => balanceL ky y (go f kx x l) r
+             | Gt => balanceR ky y l (go f kx x r)
+             | Eq => Bin sy kx (f x y) l r
+             end
+         end in
   go.
 
 Definition insertWithR {k} {a} `{GHC.Base.Ord k}
@@ -1037,16 +1037,16 @@ Definition insertWithR {k} {a} `{GHC.Base.Ord k}
   let go {k} {a} `{GHC.Base.Ord k}
    : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
     fix go (arg_0__ : (a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a)
-          : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy ky (f y x) l r
-                 end
-             end in
+      : Map k a
+      := match arg_0__, arg_1__, arg_2__, arg_3__ with
+         | _, kx, x, Tip => singleton kx x
+         | f, kx, x, Bin sy ky y l r =>
+             match GHC.Base.compare kx ky with
+             | Lt => balanceL ky y (go f kx x l) r
+             | Gt => balanceR ky y l (go f kx x r)
+             | Eq => Bin sy ky (f y x) l r
+             end
+         end in
   go.
 
 Definition insertWithKey {k} {a} `{GHC.Base.Ord k}
@@ -1055,15 +1055,15 @@ Definition insertWithKey {k} {a} `{GHC.Base.Ord k}
    : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
     fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
              : Map k a) : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy kx (f kx x y) l r
-                 end
-             end in
+      := match arg_0__, arg_1__, arg_2__, arg_3__ with
+         | _, kx, x, Tip => singleton kx x
+         | f, kx, x, Bin sy ky y l r =>
+             match GHC.Base.compare kx ky with
+             | Lt => balanceL ky y (go f kx x l) r
+             | Gt => balanceR ky y l (go f kx x r)
+             | Eq => Bin sy kx (f kx x y) l r
+             end
+         end in
   go.
 
 Definition insertWithKeyR {k} {a} `{GHC.Base.Ord k}
@@ -1072,15 +1072,15 @@ Definition insertWithKeyR {k} {a} `{GHC.Base.Ord k}
    : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
     fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
              : Map k a) : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy ky (f ky y x) l r
-                 end
-             end in
+      := match arg_0__, arg_1__, arg_2__, arg_3__ with
+         | _, kx, x, Tip => singleton kx x
+         | f, kx, x, Bin sy ky y l r =>
+             match GHC.Base.compare kx ky with
+             | Lt => balanceL ky y (go f kx x l) r
+             | Gt => balanceR ky y l (go f kx x r)
+             | Eq => Bin sy ky (f ky y x) l r
+             end
+         end in
   go.
 
 Definition insertLookupWithKey {k} {a} `{GHC.Base.Ord k}
@@ -1090,54 +1090,54 @@ Definition insertLookupWithKey {k} {a} `{GHC.Base.Ord k}
      : (k -> a -> a -> a) -> k -> a -> Map k a -> prod (option a) (Map k a) :=
       fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
                : Map k a) : prod (option a) (Map k a)
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx, x, Tip => (pair None (singleton kx x))
-               | f, kx, x, Bin sy ky y l r =>
-                   match GHC.Base.compare kx ky with
-                   | Lt =>
-                       let 'pair found l' := go f kx x l in
-                       let t' := balanceL ky y l' r in (pair found t')
-                   | Gt =>
-                       let 'pair found r' := go f kx x r in
-                       let t' := balanceR ky y l r' in (pair found t')
-                   | Eq => (pair (Some y) (Bin sy kx (f kx x y) l r))
-                   end
-               end in
+        := match arg_0__, arg_1__, arg_2__, arg_3__ with
+           | _, kx, x, Tip => (pair None (singleton kx x))
+           | f, kx, x, Bin sy ky y l r =>
+               match GHC.Base.compare kx ky with
+               | Lt =>
+                   let 'pair found l' := go f kx x l in
+                   let t' := balanceL ky y l' r in (pair found t')
+               | Gt =>
+                   let 'pair found r' := go f kx x r in
+                   let t' := balanceR ky y l r' in (pair found t')
+               | Eq => (pair (Some y) (Bin sy kx (f kx x y) l r))
+               end
+           end in
     id GHC.Base.∘ go f0 k0 x0.
 
 Definition delete {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> Map k a :=
   let go {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> Map k a :=
     fix go (arg_0__ : k) (arg_1__ : Map k a) : Map k a
-          := match arg_0__, arg_1__ with
-             | _, Tip => Tip
-             | k, (Bin _ kx x l r as t) =>
-                 match GHC.Base.compare k kx with
-                 | Lt =>
-                     let l' := go k l in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                     balanceR kx x l' r
-                 | Gt =>
-                     let r' := go k r in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                     balanceL kx x l r'
-                 | Eq => glue l r
-                 end
-             end in
+      := match arg_0__, arg_1__ with
+         | _, Tip => Tip
+         | k, (Bin _ kx x l r as t) =>
+             match GHC.Base.compare k kx with
+             | Lt =>
+                 let l' := go k l in
+                 if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                 balanceR kx x l' r
+             | Gt =>
+                 let r' := go k r in
+                 if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                 balanceL kx x l r'
+             | Eq => glue l r
+             end
+         end in
   go.
 
 Definition adjustWithKey {k} {a} `{GHC.Base.Ord k}
    : (k -> a -> a) -> k -> Map k a -> Map k a :=
   let go {k} {a} `{GHC.Base.Ord k} : (k -> a -> a) -> k -> Map k a -> Map k a :=
     fix go (arg_0__ : (k -> a -> a)) (arg_1__ : k) (arg_2__ : Map k a) : Map k a
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => Tip
-             | f, k, Bin sx kx x l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => Bin sx kx x (go f k l) r
-                 | Gt => Bin sx kx x l (go f k r)
-                 | Eq => Bin sx kx (f kx x) l r
-                 end
-             end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | _, _, Tip => Tip
+         | f, k, Bin sx kx x l r =>
+             match GHC.Base.compare k kx with
+             | Lt => Bin sx kx x (go f k l) r
+             | Gt => Bin sx kx x l (go f k r)
+             | Eq => Bin sx kx (f kx x) l r
+             end
+         end in
   go.
 
 Definition adjust {k} {a} `{GHC.Base.Ord k}
@@ -1154,15 +1154,15 @@ Definition updateWithKey {k} {a} `{GHC.Base.Ord k}
    : (k -> a -> option a) -> k -> Map k a -> Map k a :=
     fix go (arg_0__ : (k -> a -> option a)) (arg_1__ : k) (arg_2__ : Map k a) : Map
                                                                                 k a
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => Tip
-             | f, k, Bin sx kx x l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => balanceR kx x (go f k l) r
-                 | Gt => balanceL kx x l (go f k r)
-                 | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
-                 end
-             end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | _, _, Tip => Tip
+         | f, k, Bin sx kx x l r =>
+             match GHC.Base.compare k kx with
+             | Lt => balanceR kx x (go f k l) r
+             | Gt => balanceL kx x l (go f k r)
+             | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
+             end
+         end in
   go.
 
 Definition update {k} {a} `{GHC.Base.Ord k}
@@ -1180,23 +1180,23 @@ Definition updateLookupWithKey {k} {a} `{GHC.Base.Ord k}
      : (k -> a -> option a) -> k -> Map k a -> prod (option a) (Map k a) :=
       fix go (arg_0__ : (k -> a -> option a)) (arg_1__ : k) (arg_2__ : Map k a) : prod
                                                                                   (option a) (Map k a)
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, _, Tip => (pair None Tip)
-               | f, k, Bin sx kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt =>
-                       let 'pair found l' := go f k l in
-                       let t' := balanceR kx x l' r in (pair found t')
-                   | Gt =>
-                       let 'pair found r' := go f k r in
-                       let t' := balanceL kx x l r' in (pair found t')
-                   | Eq =>
-                       match f kx x with
-                       | Some x' => (pair (Some x') (Bin sx kx x' l r))
-                       | None => let glued := glue l r in (pair (Some x) glued)
-                       end
+        := match arg_0__, arg_1__, arg_2__ with
+           | _, _, Tip => (pair None Tip)
+           | f, k, Bin sx kx x l r =>
+               match GHC.Base.compare k kx with
+               | Lt =>
+                   let 'pair found l' := go f k l in
+                   let t' := balanceR kx x l' r in (pair found t')
+               | Gt =>
+                   let 'pair found r' := go f k r in
+                   let t' := balanceL kx x l r' in (pair found t')
+               | Eq =>
+                   match f kx x with
+                   | Some x' => (pair (Some x') (Bin sx kx x' l r))
+                   | None => let glued := glue l r in (pair (Some x) glued)
                    end
-               end in
+               end
+           end in
     id GHC.Base.∘ go f0 k0.
 
 Definition balance {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
@@ -1274,20 +1274,20 @@ Definition alter {k} {a} `{GHC.Base.Ord k}
   let go {k} {a} `{GHC.Base.Ord k}
    : (option a -> option a) -> k -> Map k a -> Map k a :=
     fix go (arg_0__ : (option a -> option a)) (arg_1__ : k) (arg_2__ : Map k a)
-          : Map k a
-          := match arg_0__, arg_1__, arg_2__ with
-             | f, k, Tip => match f None with | None => Tip | Some x => singleton k x end
-             | f, k, Bin sx kx x l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => balance kx x (go f k l) r
-                 | Gt => balance kx x l (go f k r)
-                 | Eq =>
-                     match f (Some x) with
-                     | Some x' => Bin sx kx x' l r
-                     | None => glue l r
-                     end
+      : Map k a
+      := match arg_0__, arg_1__, arg_2__ with
+         | f, k, Tip => match f None with | None => Tip | Some x => singleton k x end
+         | f, k, Bin sx kx x l r =>
+             match GHC.Base.compare k kx with
+             | Lt => balance kx x (go f k l) r
+             | Gt => balance kx x l (go f k r)
+             | Eq =>
+                 match f (Some x) with
+                 | Some x' => Bin sx kx x' l r
+                 | None => glue l r
                  end
-             end in
+             end
+         end in
   go.
 
 (* Skipping definition `Data.Map.Internal.alterF' *)
@@ -1310,44 +1310,44 @@ Definition atKeyPlain {k} {a} `{GHC.Base.Ord k}
     let go {k} {a} `{GHC.Base.Ord k}
      : k -> (option a -> option a) -> Map k a -> Altered k a :=
       fix go (arg_0__ : k) (arg_1__ : (option a -> option a)) (arg_2__ : Map k a)
-            : Altered k a
-            := match arg_0__, arg_1__, arg_2__ with
-               | k, f, Tip =>
-                   match f None with
-                   | None => AltSame
-                   | Some x =>
+        : Altered k a
+        := match arg_0__, arg_1__, arg_2__ with
+           | k, f, Tip =>
+               match f None with
+               | None => AltSame
+               | Some x =>
+                   match strict with
+                   | Lazy => AltBigger (singleton k x)
+                   | Strict => GHC.Prim.seq x (AltBigger (singleton k x))
+                   end
+               end
+           | k, f, Bin sx kx x l r =>
+               match GHC.Base.compare k kx with
+               | Lt =>
+                   match go k f l with
+                   | AltSmaller l' => AltSmaller (balanceR kx x l' r)
+                   | AltBigger l' => AltBigger (balanceL kx x l' r)
+                   | AltAdj l' => AltAdj (Bin sx kx x l' r)
+                   | AltSame => AltSame
+                   end
+               | Gt =>
+                   match go k f r with
+                   | AltSmaller r' => AltSmaller (balanceL kx x l r')
+                   | AltBigger r' => AltBigger (balanceR kx x l r')
+                   | AltAdj r' => AltAdj (Bin sx kx x l r')
+                   | AltSame => AltSame
+                   end
+               | Eq =>
+                   match f (Some x) with
+                   | Some x' =>
                        match strict with
-                       | Lazy => AltBigger (singleton k x)
-                       | Strict => GHC.Prim.seq x (AltBigger (singleton k x))
+                       | Lazy => AltAdj (Bin sx kx x' l r)
+                       | Strict => GHC.Prim.seq x' (AltAdj (Bin sx kx x' l r))
                        end
+                   | None => AltSmaller (glue l r)
                    end
-               | k, f, Bin sx kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt =>
-                       match go k f l with
-                       | AltSmaller l' => AltSmaller (balanceR kx x l' r)
-                       | AltBigger l' => AltBigger (balanceL kx x l' r)
-                       | AltAdj l' => AltAdj (Bin sx kx x l' r)
-                       | AltSame => AltSame
-                       end
-                   | Gt =>
-                       match go k f r with
-                       | AltSmaller r' => AltSmaller (balanceL kx x l r')
-                       | AltBigger r' => AltBigger (balanceR kx x l r')
-                       | AltAdj r' => AltAdj (Bin sx kx x l r')
-                       | AltSame => AltSame
-                       end
-                   | Eq =>
-                       match f (Some x) with
-                       | Some x' =>
-                           match strict with
-                           | Lazy => AltAdj (Bin sx kx x' l r)
-                           | Strict => GHC.Prim.seq x' (AltAdj (Bin sx kx x' l r))
-                           end
-                       | None => AltSmaller (glue l r)
-                       end
-                   end
-               end in
+               end
+           end in
     match go k0 f0 t with
     | AltSmaller t' => t'
     | AltBigger t' => t'
@@ -1365,16 +1365,16 @@ Definition atKeyIdentity {k} {a} `{GHC.Base.Ord k}
 Definition findIndex {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> GHC.Num.Int :=
   let go {k} {a} `{GHC.Base.Ord k} : GHC.Num.Int -> k -> Map k a -> GHC.Num.Int :=
     fix go (arg_0__ : GHC.Num.Int) (arg_1__ : k) (arg_2__ : Map k a) : GHC.Num.Int
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip =>
-                 GHC.Err.error (GHC.Base.hs_string__ "Map.findIndex: element is not in the map")
-             | idx, k, Bin _ kx _ l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => go idx k l
-                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
-                 | Eq => idx GHC.Num.+ size l
-                 end
-             end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | _, _, Tip =>
+             GHC.Err.error (GHC.Base.hs_string__ "Map.findIndex: element is not in the map")
+         | idx, k, Bin _ kx _ l r =>
+             match GHC.Base.compare k kx with
+             | Lt => go idx k l
+             | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
+             | Eq => idx GHC.Num.+ size l
+             end
+         end in
   go #0.
 
 Definition lookupIndex {k} {a} `{GHC.Base.Ord k}
@@ -1383,15 +1383,15 @@ Definition lookupIndex {k} {a} `{GHC.Base.Ord k}
    : GHC.Num.Int -> k -> Map k a -> option GHC.Num.Int :=
     fix go (arg_0__ : GHC.Num.Int) (arg_1__ : k) (arg_2__ : Map k a) : option
                                                                        GHC.Num.Int
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => None
-             | idx, k, Bin _ kx _ l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => go idx k l
-                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
-                 | Eq => Some (idx GHC.Num.+ size l)
-                 end
-             end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | _, _, Tip => None
+         | idx, k, Bin _ kx _ l r =>
+             match GHC.Base.compare k kx with
+             | Lt => go idx k l
+             | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
+             | Eq => Some (idx GHC.Num.+ size l)
+             end
+         end in
   go #0.
 
 (* Skipping definition `Data.Map.Internal.elemAt' *)
@@ -1404,20 +1404,20 @@ Definition take {k} {a} : GHC.Num.Int -> Map k a -> Map k a :=
         match arg_0__, arg_1__ with
         | i0, m0 =>
             let fix go arg_2__ arg_3__
-                      := match arg_2__, arg_3__ with
-                         | i, _ =>
-                             if i GHC.Base.<= #0 : bool then Tip else
-                             match arg_2__, arg_3__ with
-                             | _, Tip => Tip
-                             | i, Bin _ kx x l r =>
-                                 let sizeL := size l in
-                                 match GHC.Base.compare i sizeL with
-                                 | Lt => go i l
-                                 | Gt => link kx x l (go ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
-                                 | Eq => l
-                                 end
-                             end
-                         end in
+              := match arg_2__, arg_3__ with
+                 | i, _ =>
+                     if i GHC.Base.<= #0 : bool then Tip else
+                     match arg_2__, arg_3__ with
+                     | _, Tip => Tip
+                     | i, Bin _ kx x l r =>
+                         let sizeL := size l in
+                         match GHC.Base.compare i sizeL with
+                         | Lt => go i l
+                         | Gt => link kx x l (go ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
+                         | Eq => l
+                         end
+                     end
+                 end in
             go i0 m0
         end
     end.
@@ -1430,20 +1430,20 @@ Definition drop {k} {a} : GHC.Num.Int -> Map k a -> Map k a :=
         match arg_0__, arg_1__ with
         | i0, m0 =>
             let fix go arg_2__ arg_3__
-                      := match arg_2__, arg_3__ with
-                         | i, m =>
-                             if i GHC.Base.<= #0 : bool then m else
-                             match arg_2__, arg_3__ with
-                             | _, Tip => Tip
-                             | i, Bin _ kx x l r =>
-                                 let sizeL := size l in
-                                 match GHC.Base.compare i sizeL with
-                                 | Lt => link kx x (go i l) r
-                                 | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
-                                 | Eq => insertMin kx x r
-                                 end
-                             end
-                         end in
+              := match arg_2__, arg_3__ with
+                 | i, m =>
+                     if i GHC.Base.<= #0 : bool then m else
+                     match arg_2__, arg_3__ with
+                     | _, Tip => Tip
+                     | i, Bin _ kx x l r =>
+                         let sizeL := size l in
+                         match GHC.Base.compare i sizeL with
+                         | Lt => link kx x (go i l) r
+                         | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
+                         | Eq => insertMin kx x r
+                         end
+                     end
+                 end in
             go i0 m0
         end
     end.
@@ -1452,56 +1452,56 @@ Definition splitAt {k} {a}
    : GHC.Num.Int -> Map k a -> (Map k a * Map k a)%type :=
   fun i0 m0 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | i, m =>
-                     if i GHC.Base.<= #0 : bool then pair Tip m else
-                     match arg_0__, arg_1__ with
-                     | _, Tip => pair Tip Tip
-                     | i, Bin _ kx x l r =>
-                         let sizeL := size l in
-                         match GHC.Base.compare i sizeL with
-                         | Lt => let 'pair ll lr := go i l in pair ll (link kx x lr r)
-                         | Gt =>
-                             let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
-                             pair (link kx x l rl) rr
-                         | Eq => pair l (insertMin kx x r)
-                         end
-                     end
-                 end in
+      := match arg_0__, arg_1__ with
+         | i, m =>
+             if i GHC.Base.<= #0 : bool then pair Tip m else
+             match arg_0__, arg_1__ with
+             | _, Tip => pair Tip Tip
+             | i, Bin _ kx x l r =>
+                 let sizeL := size l in
+                 match GHC.Base.compare i sizeL with
+                 | Lt => let 'pair ll lr := go i l in pair ll (link kx x lr r)
+                 | Gt =>
+                     let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
+                     pair (link kx x l rl) rr
+                 | Eq => pair l (insertMin kx x r)
+                 end
+             end
+         end in
     if i0 GHC.Base.>= size m0 : bool then pair m0 Tip else
     id (go i0 m0).
 
 Fixpoint updateAt {k} {a} (f : (k -> a -> option a)) (i : GHC.Num.Int) (t
                     : Map k a) : Map k a
-           := match t with
-              | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.updateAt: index out of range")
-              | Bin sx kx x l r =>
-                  let sizeL := size l in
-                  match GHC.Base.compare i sizeL with
-                  | Lt => balanceR kx x (updateAt f i l) r
-                  | Gt => balanceL kx x l (updateAt f ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
-                  | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
-                  end
-              end.
+  := match t with
+     | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.updateAt: index out of range")
+     | Bin sx kx x l r =>
+         let sizeL := size l in
+         match GHC.Base.compare i sizeL with
+         | Lt => balanceR kx x (updateAt f i l) r
+         | Gt => balanceL kx x l (updateAt f ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
+         | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
+         end
+     end.
 
 Fixpoint deleteAt {k} {a} (i : GHC.Num.Int) (t : Map k a) : Map k a
-           := match t with
-              | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.deleteAt: index out of range")
-              | Bin _ kx x l r =>
-                  let sizeL := size l in
-                  match GHC.Base.compare i sizeL with
-                  | Lt => balanceR kx x (deleteAt i l) r
-                  | Gt => balanceL kx x l (deleteAt ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
-                  | Eq => glue l r
-                  end
-              end.
+  := match t with
+     | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.deleteAt: index out of range")
+     | Bin _ kx x l r =>
+         let sizeL := size l in
+         match GHC.Base.compare i sizeL with
+         | Lt => balanceR kx x (deleteAt i l) r
+         | Gt => balanceL kx x l (deleteAt ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
+         | Eq => glue l r
+         end
+     end.
 
 Fixpoint lookupMinSure {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ : Map k a)
-           : (k * a)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | k, a, Tip => pair k a
-              | _, _, Bin _ k a l _ => lookupMinSure k a l
-              end.
+  : (k * a)%type
+  := match arg_0__, arg_1__, arg_2__ with
+     | k, a, Tip => pair k a
+     | _, _, Bin _ k a l _ => lookupMinSure k a l
+     end.
 
 Definition lookupMin {k} {a} : Map k a -> option (k * a)%type :=
   fun arg_0__ =>
@@ -1513,11 +1513,11 @@ Definition lookupMin {k} {a} : Map k a -> option (k * a)%type :=
 (* Skipping definition `Data.Map.Internal.findMin' *)
 
 Fixpoint lookupMaxSure {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ : Map k a)
-           : (k * a)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | k, a, Tip => pair k a
-              | _, _, Bin _ k a _ r => lookupMaxSure k a r
-              end.
+  : (k * a)%type
+  := match arg_0__, arg_1__, arg_2__ with
+     | k, a, Tip => pair k a
+     | _, _, Bin _ k a _ r => lookupMaxSure k a r
+     end.
 
 Definition lookupMax {k} {a} : Map k a -> option (k * a)%type :=
   fun arg_0__ =>
@@ -1529,30 +1529,30 @@ Definition lookupMax {k} {a} : Map k a -> option (k * a)%type :=
 (* Skipping definition `Data.Map.Internal.findMax' *)
 
 Fixpoint deleteMin {k} {a} (arg_0__ : Map k a) : Map k a
-           := match arg_0__ with
-              | Bin _ _ _ Tip r => r
-              | Bin _ kx x l r => balanceR kx x (deleteMin l) r
-              | Tip => Tip
-              end.
+  := match arg_0__ with
+     | Bin _ _ _ Tip r => r
+     | Bin _ kx x l r => balanceR kx x (deleteMin l) r
+     | Tip => Tip
+     end.
 
 Fixpoint deleteMax {k} {a} (arg_0__ : Map k a) : Map k a
-           := match arg_0__ with
-              | Bin _ _ _ l Tip => l
-              | Bin _ kx x l r => balanceL kx x l (deleteMax r)
-              | Tip => Tip
-              end.
+  := match arg_0__ with
+     | Bin _ _ _ l Tip => l
+     | Bin _ kx x l r => balanceL kx x l (deleteMax r)
+     | Tip => Tip
+     end.
 
 Fixpoint updateMinWithKey {k} {a} (arg_0__ : (k -> a -> option a)) (arg_1__
                             : Map k a) : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sx kx x Tip r =>
-                  match f kx x with
-                  | None => r
-                  | Some x' => Bin sx kx x' Tip r
-                  end
-              | f, Bin _ kx x l r => balanceR kx x (updateMinWithKey f l) r
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | f, Bin sx kx x Tip r =>
+         match f kx x with
+         | None => r
+         | Some x' => Bin sx kx x' Tip r
+         end
+     | f, Bin _ kx x l r => balanceR kx x (updateMinWithKey f l) r
+     end.
 
 Definition updateMin {a} {k} : (a -> option a) -> Map k a -> Map k a :=
   fun f m =>
@@ -1563,15 +1563,15 @@ Definition updateMin {a} {k} : (a -> option a) -> Map k a -> Map k a :=
 
 Fixpoint updateMaxWithKey {k} {a} (arg_0__ : (k -> a -> option a)) (arg_1__
                             : Map k a) : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sx kx x l Tip =>
-                  match f kx x with
-                  | None => l
-                  | Some x' => Bin sx kx x' l Tip
-                  end
-              | f, Bin _ kx x l r => balanceL kx x l (updateMaxWithKey f r)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | f, Bin sx kx x l Tip =>
+         match f kx x with
+         | None => l
+         | Some x' => Bin sx kx x' l Tip
+         end
+     | f, Bin _ kx x l r => balanceL kx x l (updateMaxWithKey f r)
+     end.
 
 Definition updateMax {a} {k} : (a -> option a) -> Map k a -> Map k a :=
   fun f m =>
@@ -1618,39 +1618,39 @@ Definition splitLookup {k} {a} `{GHC.Base.Ord k}
     let go {k} {a} `{GHC.Base.Ord k}
      : k -> Map k a -> StrictTriple (Map k a) (option a) (Map k a) :=
       fix go (k0 : k) (t : Map k a) : StrictTriple (Map k a) (option a) (Map k a)
-            := match t with
-               | Tip => Mk_StrictTriple Tip None Tip
-               | Bin _ kx x l r =>
-                   match GHC.Base.compare k0 kx with
-                   | Lt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 l in
-                       let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
-                   | Gt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 r in
-                       let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
-                   | Eq => Mk_StrictTriple l (Some x) r
-                   end
-               end in
+        := match t with
+           | Tip => Mk_StrictTriple Tip None Tip
+           | Bin _ kx x l r =>
+               match GHC.Base.compare k0 kx with
+               | Lt =>
+                   let 'Mk_StrictTriple lt z gt := go k0 l in
+                   let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
+               | Gt =>
+                   let 'Mk_StrictTriple lt z gt := go k0 r in
+                   let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
+               | Eq => Mk_StrictTriple l (Some x) r
+               end
+           end in
     let 'Mk_StrictTriple l mv r := go k0 m in
     pair (pair l mv) r.
 
 Fixpoint unionWith {k} {a} `{GHC.Base.Ord k} (arg_0__ : (a -> a -> a)) (arg_1__
                     arg_2__
                      : Map k a) : Map k a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, t1, Tip => t1
-              | f, t1, Bin _ k x Tip Tip => insertWithR f k x t1
-              | f, Bin _ k x Tip Tip, t2 => insertWith f k x t2
-              | _f, Tip, t2 => t2
-              | f, Bin _ k1 x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
-                  let r1r2 := unionWith f r1 r2 in
-                  let l1l2 := unionWith f l1 l2 in
-                  match mb with
-                  | None => link k1 x1 l1l2 r1r2
-                  | Some x2 => link k1 (f x1 x2) l1l2 r1r2
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _f, t1, Tip => t1
+     | f, t1, Bin _ k x Tip Tip => insertWithR f k x t1
+     | f, Bin _ k x Tip Tip, t2 => insertWith f k x t2
+     | _f, Tip, t2 => t2
+     | f, Bin _ k1 x1 l1 r1, t2 =>
+         let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
+         let r1r2 := unionWith f r1 r2 in
+         let l1l2 := unionWith f l1 l2 in
+         match mb with
+         | None => link k1 x1 l1l2 r1r2
+         | Some x2 => link k1 (f x1 x2) l1l2 r1r2
+         end
+     end.
 
 Definition unionsWith {f} {k} {a} `{Data.Foldable.Foldable f} `{GHC.Base.Ord k}
    : (a -> a -> a) -> f (Map k a) -> Map k a :=
@@ -1658,20 +1658,20 @@ Definition unionsWith {f} {k} {a} `{Data.Foldable.Foldable f} `{GHC.Base.Ord k}
 
 Fixpoint unionWithKey {k} {a} `{GHC.Base.Ord k} (arg_0__ : (k -> a -> a -> a))
                       (arg_1__ arg_2__ : Map k a) : Map k a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, t1, Tip => t1
-              | f, t1, Bin _ k x Tip Tip => insertWithKeyR f k x t1
-              | f, Bin _ k x Tip Tip, t2 => insertWithKey f k x t2
-              | _f, Tip, t2 => t2
-              | f, Bin _ k1 x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
-                  let r1r2 := unionWithKey f r1 r2 in
-                  let l1l2 := unionWithKey f l1 l2 in
-                  match mb with
-                  | None => link k1 x1 l1l2 r1r2
-                  | Some x2 => link k1 (f k1 x1 x2) l1l2 r1r2
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _f, t1, Tip => t1
+     | f, t1, Bin _ k x Tip Tip => insertWithKeyR f k x t1
+     | f, Bin _ k x Tip Tip, t2 => insertWithKey f k x t2
+     | _f, Tip, t2 => t2
+     | f, Bin _ k1 x1 l1 r1, t2 =>
+         let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
+         let r1r2 := unionWithKey f r1 r2 in
+         let l1l2 := unionWithKey f l1 l2 in
+         match mb with
+         | None => link k1 x1 l1l2 r1r2
+         | Some x2 => link k1 (f k1 x1 x2) l1l2 r1r2
+         end
+     end.
 
 Definition splitMember {k} {a} `{GHC.Base.Ord k}
    : k -> Map k a -> (Map k a * bool * Map k a)%type :=
@@ -1679,36 +1679,36 @@ Definition splitMember {k} {a} `{GHC.Base.Ord k}
     let go {k} {a} `{GHC.Base.Ord k}
      : k -> Map k a -> StrictTriple (Map k a) bool (Map k a) :=
       fix go (k0 : k) (t : Map k a) : StrictTriple (Map k a) bool (Map k a)
-            := match t with
-               | Tip => Mk_StrictTriple Tip false Tip
-               | Bin _ kx x l r =>
-                   match GHC.Base.compare k0 kx with
-                   | Lt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 l in
-                       let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
-                   | Gt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 r in
-                       let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
-                   | Eq => Mk_StrictTriple l true r
-                   end
-               end in
+        := match t with
+           | Tip => Mk_StrictTriple Tip false Tip
+           | Bin _ kx x l r =>
+               match GHC.Base.compare k0 kx with
+               | Lt =>
+                   let 'Mk_StrictTriple lt z gt := go k0 l in
+                   let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
+               | Gt =>
+                   let 'Mk_StrictTriple lt z gt := go k0 r in
+                   let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
+               | Eq => Mk_StrictTriple l true r
+               end
+           end in
     let 'Mk_StrictTriple l mv r := go k0 m in
     pair (pair l mv) r.
 
 Fixpoint withoutKeys {k} {a} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
                        : Data.Set.Internal.Set_ k) : Map k a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | m, Data.Set.Internal.Tip => m
-              | m, Data.Set.Internal.Bin _ k ls rs =>
-                  let 'pair (pair lm b) rm := splitMember k m in
-                  let rm' := withoutKeys rm rs in
-                  let lm' := withoutKeys lm ls in
-                  if andb (negb b) (andb (Utils.Containers.Internal.PtrEquality.ptrEq lm' lm)
-                                         (Utils.Containers.Internal.PtrEquality.ptrEq rm' rm)) : bool
-                  then m else
-                  link2 lm' rm'
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => Tip
+     | m, Data.Set.Internal.Tip => m
+     | m, Data.Set.Internal.Bin _ k ls rs =>
+         let 'pair (pair lm b) rm := splitMember k m in
+         let rm' := withoutKeys rm rs in
+         let lm' := withoutKeys lm ls in
+         if andb (negb b) (andb (Utils.Containers.Internal.PtrEquality.ptrEq lm' lm)
+                                (Utils.Containers.Internal.PtrEquality.ptrEq rm' rm)) : bool
+         then m else
+         link2 lm' rm'
+     end.
 
 (* Skipping definition `Data.Map.Internal.differenceWith' *)
 
@@ -1716,67 +1716,67 @@ Fixpoint withoutKeys {k} {a} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
 
 Fixpoint intersection {k} {a} {b} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
                         : Map k b) : Map k a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | _, Tip => Tip
-              | (Bin _ k x l1 r1 as t1), t2 =>
-                  let 'pair (pair l2 mb) r2 := splitMember k t2 in
-                  let l1l2 := intersection l1 l2 in
-                  let r1r2 := intersection r1 r2 in
-                  if mb : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                       then t1
-                       else link k x l1l2 r1r2 else
-                  link2 l1l2 r1r2
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => Tip
+     | _, Tip => Tip
+     | (Bin _ k x l1 r1 as t1), t2 =>
+         let 'pair (pair l2 mb) r2 := splitMember k t2 in
+         let l1l2 := intersection l1 l2 in
+         let r1r2 := intersection r1 r2 in
+         if mb : bool
+         then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                      (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+              then t1
+              else link k x l1l2 r1r2 else
+         link2 l1l2 r1r2
+     end.
 
 Fixpoint restrictKeys {k} {a} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
                         : Data.Set.Internal.Set_ k) : Map k a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | _, Data.Set.Internal.Tip => Tip
-              | (Bin _ k x l1 r1 as m), s =>
-                  let 'pair (pair l2 b) r2 := Data.Set.Internal.splitMember k s in
-                  let l1l2 := restrictKeys l1 l2 in
-                  let r1r2 := restrictKeys r1 r2 in
-                  if b : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                       then m
-                       else link k x l1l2 r1r2 else
-                  link2 l1l2 r1r2
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => Tip
+     | _, Data.Set.Internal.Tip => Tip
+     | (Bin _ k x l1 r1 as m), s =>
+         let 'pair (pair l2 b) r2 := Data.Set.Internal.splitMember k s in
+         let l1l2 := restrictKeys l1 l2 in
+         let r1r2 := restrictKeys r1 r2 in
+         if b : bool
+         then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                      (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+              then m
+              else link k x l1l2 r1r2 else
+         link2 l1l2 r1r2
+     end.
 
 Fixpoint intersectionWith {k} {a} {b} {c} `{GHC.Base.Ord k} (arg_0__
                             : (a -> b -> c)) (arg_1__ : Map k a) (arg_2__ : Map k b) : Map k c
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, Tip, _ => Tip
-              | _f, _, Tip => Tip
-              | f, Bin _ k x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k t2 in
-                  let l1l2 := intersectionWith f l1 l2 in
-                  let r1r2 := intersectionWith f r1 r2 in
-                  match mb with
-                  | Some x2 => link k (f x1 x2) l1l2 r1r2
-                  | None => link2 l1l2 r1r2
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _f, Tip, _ => Tip
+     | _f, _, Tip => Tip
+     | f, Bin _ k x1 l1 r1, t2 =>
+         let 'pair (pair l2 mb) r2 := splitLookup k t2 in
+         let l1l2 := intersectionWith f l1 l2 in
+         let r1r2 := intersectionWith f r1 r2 in
+         match mb with
+         | Some x2 => link k (f x1 x2) l1l2 r1r2
+         | None => link2 l1l2 r1r2
+         end
+     end.
 
 Fixpoint intersectionWithKey {k} {a} {b} {c} `{GHC.Base.Ord k} (arg_0__
                                : (k -> a -> b -> c)) (arg_1__ : Map k a) (arg_2__ : Map k b) : Map k c
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, Tip, _ => Tip
-              | _f, _, Tip => Tip
-              | f, Bin _ k x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k t2 in
-                  let l1l2 := intersectionWithKey f l1 l2 in
-                  let r1r2 := intersectionWithKey f r1 r2 in
-                  match mb with
-                  | Some x2 => link k (f k x1 x2) l1l2 r1r2
-                  | None => link2 l1l2 r1r2
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _f, Tip, _ => Tip
+     | _f, _, Tip => Tip
+     | f, Bin _ k x1 l1 r1, t2 =>
+         let 'pair (pair l2 mb) r2 := splitLookup k t2 in
+         let l1l2 := intersectionWithKey f l1 l2 in
+         let r1r2 := intersectionWithKey f r1 r2 in
+         match mb with
+         | Some x2 => link k (f k x1 x2) l1l2 r1r2
+         | None => link2 l1l2 r1r2
+         end
+     end.
 
 Definition mapGentlyWhenMissing {f} {a} {b} {k} {x} `{GHC.Base.Functor f}
    : (a -> b) -> WhenMissing f k x a -> WhenMissing f k x b :=
@@ -1842,11 +1842,11 @@ Definition preserveMissing {f} {k} {x} `{GHC.Base.Applicative f}
                     end).
 
 Fixpoint mapWithKey {k} {a} {b} (arg_0__ : (k -> a -> b)) (arg_1__ : Map k a)
-           : Map k b
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sx kx x l r => Bin sx kx (f kx x) (mapWithKey f l) (mapWithKey f r)
-              end.
+  : Map k b
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | f, Bin sx kx x l r => Bin sx kx (f kx x) (mapWithKey f l) (mapWithKey f r)
+     end.
 
 Definition mapMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
    : (k -> x -> y) -> WhenMissing f k x y :=
@@ -1856,14 +1856,14 @@ Definition mapMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
 
 Fixpoint mapMaybeWithKey {k} {a} {b} (arg_0__ : (k -> a -> option b)) (arg_1__
                            : Map k a) : Map k b
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin _ kx x l r =>
-                  match f kx x with
-                  | Some y => link kx y (mapMaybeWithKey f l) (mapMaybeWithKey f r)
-                  | None => link2 (mapMaybeWithKey f l) (mapMaybeWithKey f r)
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | f, Bin _ kx x l r =>
+         match f kx x with
+         | Some y => link kx y (mapMaybeWithKey f l) (mapMaybeWithKey f r)
+         | None => link2 (mapMaybeWithKey f l) (mapMaybeWithKey f r)
+         end
+     end.
 
 Definition mapMaybeMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
    : (k -> x -> option y) -> WhenMissing f k x y :=
@@ -1872,19 +1872,19 @@ Definition mapMaybeMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
                       GHC.Base.pure (f k x)).
 
 Fixpoint filterWithKey {k} {a} (arg_0__ : (k -> a -> bool)) (arg_1__ : Map k a)
-           : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, (Bin _ kx x l r as t) =>
-                  let pr := filterWithKey p r in
-                  let pl := filterWithKey p l in
-                  if p kx x : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
-                       then t
-                       else link kx x pl pr else
-                  link2 pl pr
-              end.
+  : Map k a
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | p, (Bin _ kx x l r as t) =>
+         let pr := filterWithKey p r in
+         let pl := filterWithKey p l in
+         if p kx x : bool
+         then if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
+                      (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
+              then t
+              else link kx x pl pr else
+         link2 pl pr
+     end.
 
 Definition filterMissing {f} {k} {x} `{GHC.Base.Applicative f}
    : (k -> x -> bool) -> WhenMissing f k x x :=
@@ -1901,21 +1901,21 @@ Definition boolITE {a} : a -> a -> bool -> a :=
 
 Fixpoint filterWithKeyA {f} {k} {a} `{GHC.Base.Applicative f} (arg_0__
                           : (k -> a -> f bool)) (arg_1__ : Map k a) : f (Map k a)
-           := match arg_0__, arg_1__ with
-              | _, Tip => GHC.Base.pure Tip
-              | p, (Bin _ kx x l r as t) =>
-                  let combine :=
-                    fun arg_3__ arg_4__ arg_5__ =>
-                      match arg_3__, arg_4__, arg_5__ with
-                      | true, pl, pr =>
-                          if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
-                                  (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
-                          then t else
-                          link kx x pl pr
-                      | false, pl, pr => link2 pl pr
-                      end in
-                  GHC.Base.liftA3 combine (p kx x) (filterWithKeyA p l) (filterWithKeyA p r)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => GHC.Base.pure Tip
+     | p, (Bin _ kx x l r as t) =>
+         let combine :=
+           fun arg_3__ arg_4__ arg_5__ =>
+             match arg_3__, arg_4__, arg_5__ with
+             | true, pl, pr =>
+                 if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
+                         (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
+                 then t else
+                 link kx x pl pr
+             | false, pl, pr => link2 pl pr
+             end in
+         GHC.Base.liftA3 combine (p kx x) (filterWithKeyA p l) (filterWithKeyA p r)
+     end.
 
 Definition filterAMissing {f} {k} {x} `{GHC.Base.Applicative f}
    : (k -> x -> f bool) -> WhenMissing f k x x :=
@@ -1931,19 +1931,19 @@ Definition traverseMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
 Definition traverseMaybeWithKey {f} {k} {a} {b} `{GHC.Base.Applicative f}
    : (k -> a -> f (option b)) -> Map k a -> f (Map k b) :=
   let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | _, Tip => GHC.Base.pure Tip
-               | f, Bin _ kx x Tip Tip =>
-                   Data.Maybe.maybe Tip (fun x' => Bin #1 kx x' Tip Tip) Data.Functor.<$> f kx x
-               | f, Bin _ kx x l r =>
-                   let combine :=
-                     fun l' mx r' =>
-                       match mx with
-                       | None => link2 l' r'
-                       | Some x' => link kx x' l' r'
-                       end in
-                   GHC.Base.liftA3 combine (go f l) (f kx x) (go f r)
+    := match arg_0__, arg_1__ with
+       | _, Tip => GHC.Base.pure Tip
+       | f, Bin _ kx x Tip Tip =>
+           Data.Maybe.maybe Tip (fun x' => Bin #1 kx x' Tip Tip) Data.Functor.<$> f kx x
+       | f, Bin _ kx x l r =>
+           let combine :=
+             fun l' mx r' =>
+               match mx with
+               | None => link2 l' r'
+               | Some x' => link kx x' l' r'
                end in
+           GHC.Base.liftA3 combine (go f l) (f kx x) (go f r)
+       end in
   go.
 
 Definition traverseMaybeMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
@@ -1959,22 +1959,22 @@ Definition mergeA {f} {k} {a} {c} {b} `{GHC.Base.Applicative f} `{GHC.Base.Ord
     match arg_0__, arg_1__, arg_2__ with
     | Mk_WhenMissing g1t g1k, Mk_WhenMissing g2t _, Mk_WhenMatched f =>
         let fix go arg_3__ arg_4__
-                  := match arg_3__, arg_4__ with
-                     | t1, Tip => g1t t1
-                     | Tip, t2 => g2t t2
-                     | Bin _ kx x1 l1 r1, t2 =>
-                         let 'pair (pair l2 mx2) r2 := splitLookup kx t2 in
-                         let r1r2 := go r1 r2 in
-                         let l1l2 := go l1 l2 in
-                         match mx2 with
-                         | None =>
-                             GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
-                             l1l2 (g1k kx x1) r1r2
-                         | Some x2 =>
-                             GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
-                             l1l2 (f kx x1 x2) r1r2
-                         end
-                     end in
+          := match arg_3__, arg_4__ with
+             | t1, Tip => g1t t1
+             | Tip, t2 => g2t t2
+             | Bin _ kx x1 l1 r1, t2 =>
+                 let 'pair (pair l2 mx2) r2 := splitLookup kx t2 in
+                 let r1r2 := go r1 r2 in
+                 let l1l2 := go l1 l2 in
+                 match mx2 with
+                 | None =>
+                     GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
+                     l1l2 (g1k kx x1) r1r2
+                 | Some x2 =>
+                     GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
+                     l1l2 (f kx x1 x2) r1r2
+                 end
+             end in
         go
     end.
 
@@ -1989,43 +1989,43 @@ Definition mergeWithKey {k} {a} {b} {c} `{GHC.Base.Ord k}
      (Map k a -> Map k c) -> (Map k b -> Map k c) -> Map k a -> Map k b -> Map k c :=
   fun f g1 g2 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | Tip, t2 => g2 t2
-                 | t1, Tip => g1 t1
-                 | Bin _ kx x l1 r1, t2 =>
-                     let 'pair (pair l2 found) r2 := splitLookup kx t2 in
-                     let l' := go l1 l2 in
-                     let r' := go r1 r2 in
-                     match found with
-                     | None =>
-                         match g1 (singleton kx x) with
-                         | Tip => link2 l' r'
-                         | Bin _ _ x' Tip Tip => link kx x' l' r'
-                         | _ =>
-                             GHC.Err.error (GHC.Base.hs_string__
-                                            "mergeWithKey: Given function only1 does not fulfill required conditions (see documentation)")
-                         end
-                     | Some x2 =>
-                         match f kx x x2 with
-                         | None => link2 l' r'
-                         | Some x' => link kx x' l' r'
-                         end
-                     end
-                 end in
+      := match arg_0__, arg_1__ with
+         | Tip, t2 => g2 t2
+         | t1, Tip => g1 t1
+         | Bin _ kx x l1 r1, t2 =>
+             let 'pair (pair l2 found) r2 := splitLookup kx t2 in
+             let l' := go l1 l2 in
+             let r' := go r1 r2 in
+             match found with
+             | None =>
+                 match g1 (singleton kx x) with
+                 | Tip => link2 l' r'
+                 | Bin _ _ x' Tip Tip => link kx x' l' r'
+                 | _ =>
+                     GHC.Err.error (GHC.Base.hs_string__
+                                    "mergeWithKey: Given function only1 does not fulfill required conditions (see documentation)")
+                 end
+             | Some x2 =>
+                 match f kx x x2 with
+                 | None => link2 l' r'
+                 | Some x' => link kx x' l' r'
+                 end
+             end
+         end in
     go.
 
 Fixpoint submap' {a} {b} {c} `{GHC.Base.Ord a} (arg_0__ : (b -> c -> bool))
                  (arg_1__ : Map a b) (arg_2__ : Map a c) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, Tip, _ => true
-              | _, _, Tip => false
-              | f, Bin _ kx x l r, t =>
-                  let 'pair (pair lt found) gt := splitLookup kx t in
-                  match found with
-                  | None => false
-                  | Some y => andb (f x y) (andb (submap' f l lt) (submap' f r gt))
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, Tip, _ => true
+     | _, _, Tip => false
+     | f, Bin _ kx x l r, t =>
+         let 'pair (pair lt found) gt := splitLookup kx t in
+         match found with
+         | None => false
+         | Some y => andb (f x y) (andb (submap' f l lt) (submap' f r gt))
+         end
+     end.
 
 Definition isSubmapOfBy {k} {a} {b} `{GHC.Base.Ord k}
    : (a -> b -> bool) -> Map k a -> Map k b -> bool :=
@@ -2051,55 +2051,55 @@ Definition filter {a} {k} : (a -> bool) -> Map k a -> Map k a :=
                      end) m.
 
 Fixpoint takeWhileAntitone {k} {a} (arg_0__ : (k -> bool)) (arg_1__ : Map k a)
-           : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, Bin _ kx x l r =>
-                  if p kx : bool then link kx x l (takeWhileAntitone p r) else
-                  takeWhileAntitone p l
-              end.
+  : Map k a
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | p, Bin _ kx x l r =>
+         if p kx : bool then link kx x l (takeWhileAntitone p r) else
+         takeWhileAntitone p l
+     end.
 
 Fixpoint dropWhileAntitone {k} {a} (arg_0__ : (k -> bool)) (arg_1__ : Map k a)
-           : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, Bin _ kx x l r =>
-                  if p kx : bool then dropWhileAntitone p r else
-                  link kx x (dropWhileAntitone p l) r
-              end.
+  : Map k a
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | p, Bin _ kx x l r =>
+         if p kx : bool then dropWhileAntitone p r else
+         link kx x (dropWhileAntitone p l) r
+     end.
 
 Definition spanAntitone {k} {a}
    : (k -> bool) -> Map k a -> (Map k a * Map k a)%type :=
   fun p0 m =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => pair Tip Tip
-                 | p, Bin _ kx x l r =>
-                     if p kx : bool then let 'pair u v := go p r in pair (link kx x l u) v else
-                     let 'pair u v := go p l in
-                     pair u (link kx x v r)
-                 end in
+      := match arg_0__, arg_1__ with
+         | _, Tip => pair Tip Tip
+         | p, Bin _ kx x l r =>
+             if p kx : bool then let 'pair u v := go p r in pair (link kx x l u) v else
+             let 'pair u v := go p l in
+             pair u (link kx x v r)
+         end in
     id (go p0 m).
 
 Definition partitionWithKey {k} {a}
    : (k -> a -> bool) -> Map k a -> (Map k a * Map k a)%type :=
   fun p0 t0 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => (pair Tip Tip)
-                 | p, (Bin _ kx x l r as t) =>
-                     let 'pair r1 r2 := go p r in
-                     let 'pair l1 l2 := go p l in
-                     if p kx x : bool
-                     then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
-                                        (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
-                                then t
-                                else link kx x l1 r1) (link2 l2 r2) else
-                     pair (link2 l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
-                                                 (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
-                           then t
-                           else link kx x l2 r2)
-                 end in
+      := match arg_0__, arg_1__ with
+         | _, Tip => (pair Tip Tip)
+         | p, (Bin _ kx x l r as t) =>
+             let 'pair r1 r2 := go p r in
+             let 'pair l1 l2 := go p l in
+             if p kx x : bool
+             then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
+                                (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
+                        then t
+                        else link kx x l1 r1) (link2 l2 r2) else
+             pair (link2 l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
+                                         (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
+                   then t
+                   else link kx x l2 r2)
+         end in
     id (go p0 t0).
 
 Definition partition {a} {k}
@@ -2121,16 +2121,16 @@ Definition mapEitherWithKey {k} {a} {b} {c}
    : (k -> a -> Data.Either.Either b c) -> Map k a -> (Map k b * Map k c)%type :=
   fun f0 t0 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => (pair Tip Tip)
-                 | f, Bin _ kx x l r =>
-                     let 'pair r1 r2 := go f r in
-                     let 'pair l1 l2 := go f l in
-                     match f kx x with
-                     | Data.Either.Left y => pair (link kx y l1 r1) (link2 l2 r2)
-                     | Data.Either.Right z => pair (link2 l1 r1) (link kx z l2 r2)
-                     end
-                 end in
+      := match arg_0__, arg_1__ with
+         | _, Tip => (pair Tip Tip)
+         | f, Bin _ kx x l r =>
+             let 'pair r1 r2 := go f r in
+             let 'pair l1 l2 := go f l in
+             match f kx x with
+             | Data.Either.Left y => pair (link kx y l1 r1) (link2 l2 r2)
+             | Data.Either.Right z => pair (link2 l1 r1) (link kx z l2 r2)
+             end
+         end in
     id (go f0 t0).
 
 Definition mapEither {a} {b} {c} {k}
@@ -2143,14 +2143,14 @@ Definition mapEither {a} {b} {c} {k}
 
 Fixpoint mapAccumL {a} {k} {b} {c} (arg_0__ : (a -> k -> b -> (a * c)%type))
                    (arg_1__ : a) (arg_2__ : Map k b) : (a * Map k c)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, a, Tip => pair a Tip
-              | f, a, Bin sx kx x l r =>
-                  let 'pair a1 l' := mapAccumL f a l in
-                  let 'pair a2 x' := f a1 kx x in
-                  let 'pair a3 r' := mapAccumL f a2 r in
-                  pair a3 (Bin sx kx x' l' r')
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, a, Tip => pair a Tip
+     | f, a, Bin sx kx x l r =>
+         let 'pair a1 l' := mapAccumL f a l in
+         let 'pair a2 x' := f a1 kx x in
+         let 'pair a3 r' := mapAccumL f a2 r in
+         pair a3 (Bin sx kx x' l' r')
+     end.
 
 Definition mapAccumWithKey {a} {k} {b} {c}
    : (a -> k -> b -> (a * c)%type) -> a -> Map k b -> (a * Map k c)%type :=
@@ -2167,14 +2167,14 @@ Definition mapAccum {a} {b} {c} {k}
 Fixpoint mapAccumRWithKey {a} {k} {b} {c} (arg_0__
                             : (a -> k -> b -> (a * c)%type)) (arg_1__ : a) (arg_2__ : Map k b) : (a *
                                                                                                   Map k c)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, a, Tip => pair a Tip
-              | f, a, Bin sx kx x l r =>
-                  let 'pair a1 r' := mapAccumRWithKey f a r in
-                  let 'pair a2 x' := f a1 kx x in
-                  let 'pair a3 l' := mapAccumRWithKey f a2 l in
-                  pair a3 (Bin sx kx x' l' r')
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, a, Tip => pair a Tip
+     | f, a, Bin sx kx x l r =>
+         let 'pair a1 r' := mapAccumRWithKey f a r in
+         let 'pair a2 x' := f a1 kx x in
+         let 'pair a3 l' := mapAccumRWithKey f a2 l in
+         pair a3 (Bin sx kx x' l' r')
+     end.
 
 Definition fromList {k} {a} `{GHC.Base.Ord k} : list (k * a)%type -> Map k a :=
   fun arg_0__ =>
@@ -2263,54 +2263,54 @@ Definition mapKeysWith {k2} {a} {k1} `{GHC.Base.Ord k2}
 
 Fixpoint mapKeysMonotonic {k1} {k2} {a} (arg_0__ : (k1 -> k2)) (arg_1__
                             : Map k1 a) : Map k2 a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sz k x l r =>
-                  Bin sz (f k) x (mapKeysMonotonic f l) (mapKeysMonotonic f r)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | f, Bin sz k x l r =>
+         Bin sz (f k) x (mapKeysMonotonic f l) (mapKeysMonotonic f r)
+     end.
 
 Definition foldrWithKey' {k} {a} {b}
    : (k -> a -> b -> b) -> b -> Map k a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f kx x (go z' r)) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ kx x l r => go (f kx x (go z' r)) l
+         end in
     go z.
 
 Definition foldlWithKey {a} {k} {b} : (a -> k -> b -> a) -> a -> Map k b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f (go z' l) kx x) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ kx x l r => go (f (go z' l) kx x) r
+         end in
     go z.
 
 Definition foldlWithKey' {a} {k} {b}
    : (a -> k -> b -> a) -> a -> Map k b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f (go z' l) kx x) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ kx x l r => go (f (go z' l) kx x) r
+         end in
     go z.
 
 Definition foldMapWithKey {m} {k} {a} `{GHC.Base.Monoid m}
    : (k -> a -> m) -> Map k a -> m :=
   fun f =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => GHC.Base.mempty
-                 | Bin num_1__ k v _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool then f k v else
-                     match arg_0__ with
-                     | Bin _ k v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k v) (go r))
-                     | _ => GHC.Err.patternFailure
-                     end
-                 end in
+      := match arg_0__ with
+         | Tip => GHC.Base.mempty
+         | Bin num_1__ k v _ _ =>
+             if num_1__ GHC.Base.== #1 : bool then f k v else
+             match arg_0__ with
+             | Bin _ k v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k v) (go r))
+             | _ => GHC.Err.patternFailure
+             end
+         end in
     go.
 
 Definition keys {k} {a} : Map k a -> list k :=
@@ -2323,18 +2323,18 @@ Definition assocs {k} {a} : Map k a -> list (k * a)%type :=
   fun m => toAscList m.
 
 Fixpoint keysSet {k} {a} (arg_0__ : Map k a) : Data.Set.Internal.Set_ k
-           := match arg_0__ with
-              | Tip => Data.Set.Internal.Tip
-              | Bin sz kx _ l r => Data.Set.Internal.Bin sz kx (keysSet l) (keysSet r)
-              end.
+  := match arg_0__ with
+     | Tip => Data.Set.Internal.Tip
+     | Bin sz kx _ l r => Data.Set.Internal.Bin sz kx (keysSet l) (keysSet r)
+     end.
 
 Fixpoint fromSet {k} {a} (arg_0__ : (k -> a)) (arg_1__
                    : Data.Set.Internal.Set_ k) : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Data.Set.Internal.Tip => Tip
-              | f, Data.Set.Internal.Bin sz x l r =>
-                  Bin sz x (f x) (fromSet f l) (fromSet f r)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Data.Set.Internal.Tip => Tip
+     | f, Data.Set.Internal.Bin sz x l r =>
+         Bin sz x (f x) (fromSet f l) (fromSet f r)
+     end.
 
 Definition toDescList {k} {a} : Map k a -> list (k * a)%type :=
   foldlWithKey (fun xs k x => cons (pair k x) xs) nil.
@@ -2380,12 +2380,12 @@ Definition fromAscList {k} {a} `{GHC.Base.Eq_ k}
    : list (k * a)%type -> Map k a :=
   fun xs =>
     let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz _ as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
-                     cons z (combineEq' x xs')
-                 end in
+      := match arg_0__, arg_1__ with
+         | z, nil => cons z nil
+         | (pair kz _ as z), cons (pair kx xx as x) xs' =>
+             if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
+             cons z (combineEq' x xs')
+         end in
     let combineEq :=
       fun xs' =>
         match xs' with
@@ -2430,12 +2430,12 @@ Definition fromDescList {k} {a} `{GHC.Base.Eq_ k}
    : list (k * a)%type -> Map k a :=
   fun xs =>
     let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz _ as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
-                     cons z (combineEq' x xs')
-                 end in
+      := match arg_0__, arg_1__ with
+         | z, nil => cons z nil
+         | (pair kz _ as z), cons (pair kx xx as x) xs' =>
+             if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
+             cons z (combineEq' x xs')
+         end in
     let combineEq :=
       fun xs' =>
         match xs' with
@@ -2449,13 +2449,13 @@ Definition fromAscListWithKey {k} {a} `{GHC.Base.Eq_ k}
    : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
   fun f xs =>
     let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz zz as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool
-                     then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
-                     cons z (combineEq' x xs')
-                 end in
+      := match arg_0__, arg_1__ with
+         | z, nil => cons z nil
+         | (pair kz zz as z), cons (pair kx xx as x) xs' =>
+             if kx GHC.Base.== kz : bool
+             then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
+             cons z (combineEq' x xs')
+         end in
     let combineEq :=
       fun arg_7__ arg_8__ =>
         match arg_7__, arg_8__ with
@@ -2480,13 +2480,13 @@ Definition fromDescListWithKey {k} {a} `{GHC.Base.Eq_ k}
    : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
   fun f xs =>
     let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz zz as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool
-                     then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
-                     cons z (combineEq' x xs')
-                 end in
+      := match arg_0__, arg_1__ with
+         | z, nil => cons z nil
+         | (pair kz zz as z), cons (pair kx xx as x) xs' =>
+             if kx GHC.Base.== kz : bool
+             then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
+             cons z (combineEq' x xs')
+         end in
     let combineEq :=
       fun arg_7__ arg_8__ =>
         match arg_7__, arg_8__ with

--- a/examples/containers/lib/Data/Set/Internal.v
+++ b/examples/containers/lib/Data/Set/Internal.v
@@ -34,12 +34,12 @@ Import GHC.Num.Notations.
 Definition Size :=
   GHC.Num.Int%type.
 
-Inductive Set_ a : Type
-  := | Bin : Size -> a -> (Set_ a) -> (Set_ a) -> Set_ a
-  |  Tip : Set_ a.
+Inductive Set_ a : Type :=
+  | Bin : Size -> a -> (Set_ a) -> (Set_ a) -> Set_ a
+  | Tip : Set_ a.
 
-Inductive MergeSet a : Type
-  := | Mk_MergeSet (getMergeSet : Set_ a) : MergeSet a.
+Inductive MergeSet a : Type :=
+  | Mk_MergeSet (getMergeSet : Set_ a) : MergeSet a.
 
 Arguments Bin {_} _ _ _ _.
 
@@ -171,111 +171,111 @@ Definition insert {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
   fun x0 =>
     let go {a} `{GHC.Base.Ord a} : a -> a -> Set_ a -> Set_ a :=
       fix go (arg_0__ arg_1__ : a) (arg_2__ : Set_ a) : Set_ a
-            := match arg_0__, arg_1__, arg_2__ with
-               | orig, _, Tip => singleton (orig)
-               | orig, x, (Bin sz y l r as t) =>
-                   match GHC.Base.compare x y with
-                   | Lt =>
-                       let l' := go orig x l in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                       balanceL y l' r
-                   | Gt =>
-                       let r' := go orig x r in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                       balanceR y l r'
-                   | Eq =>
-                       if (Utils.Containers.Internal.PtrEquality.ptrEq orig y) : bool then t else
-                       Bin sz (orig) l r
-                   end
-               end in
+        := match arg_0__, arg_1__, arg_2__ with
+           | orig, _, Tip => singleton (orig)
+           | orig, x, (Bin sz y l r as t) =>
+               match GHC.Base.compare x y with
+               | Lt =>
+                   let l' := go orig x l in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                   balanceL y l' r
+               | Gt =>
+                   let r' := go orig x r in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                   balanceR y l r'
+               | Eq =>
+                   if (Utils.Containers.Internal.PtrEquality.ptrEq orig y) : bool then t else
+                   Bin sz (orig) l r
+               end
+           end in
     go x0 x0.
 
 Definition insertR {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
   fun x0 =>
     let go {a} `{GHC.Base.Ord a} : a -> a -> Set_ a -> Set_ a :=
       fix go (arg_0__ arg_1__ : a) (arg_2__ : Set_ a) : Set_ a
-            := match arg_0__, arg_1__, arg_2__ with
-               | orig, _, Tip => singleton (orig)
-               | orig, x, (Bin _ y l r as t) =>
-                   match GHC.Base.compare x y with
-                   | Lt =>
-                       let l' := go orig x l in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                       balanceL y l' r
-                   | Gt =>
-                       let r' := go orig x r in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                       balanceR y l r'
-                   | Eq => t
-                   end
-               end in
+        := match arg_0__, arg_1__, arg_2__ with
+           | orig, _, Tip => singleton (orig)
+           | orig, x, (Bin _ y l r as t) =>
+               match GHC.Base.compare x y with
+               | Lt =>
+                   let l' := go orig x l in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                   balanceL y l' r
+               | Gt =>
+                   let r' := go orig x r in
+                   if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                   balanceR y l r'
+               | Eq => t
+               end
+           end in
     go x0 x0.
 
 Definition bin {a} : a -> Set_ a -> Set_ a -> Set_ a :=
   fun x l r => Bin ((size l GHC.Num.+ size r) GHC.Num.+ #1) x l r.
 
 Fixpoint insertMax {a} (x : a) (t : Set_ a) : Set_ a
-           := match t with
-              | Tip => singleton x
-              | Bin _ y l r => balanceR y l (insertMax x r)
-              end.
+  := match t with
+     | Tip => singleton x
+     | Bin _ y l r => balanceR y l (insertMax x r)
+     end.
 
 Fixpoint insertMin {a} (x : a) (t : Set_ a) : Set_ a
-           := match t with
-              | Tip => singleton x
-              | Bin _ y l r => balanceL y (insertMin x l) r
-              end.
+  := match t with
+     | Tip => singleton x
+     | Bin _ y l r => balanceL y (insertMin x l) r
+     end.
 
 Program Fixpoint link {a} (arg_0__ : a) (arg_1__ arg_2__ : Set_ a)
                       {measure (Nat.add (set_size arg_1__) (set_size arg_2__))} : Set_ a
-                   := match arg_0__, arg_1__, arg_2__ with
-                      | x, Tip, r => insertMin x r
-                      | x, l, Tip => insertMax x l
-                      | x, (Bin sizeL y ly ry as l), (Bin sizeR z lz rz as r) =>
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
-                          then balanceL z (link x l lz) rz else
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
-                          then balanceR y ly (link x ry r) else
-                          bin x l r
-                      end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | x, Tip, r => insertMin x r
+     | x, l, Tip => insertMax x l
+     | x, (Bin sizeL y ly ry as l), (Bin sizeR z lz rz as r) =>
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
+         then balanceL z (link x l lz) rz else
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
+         then balanceR y ly (link x ry r) else
+         bin x l r
+     end.
 Solve Obligations with (termination_by_omega).
 
 Fixpoint splitS {a} `{GHC.Base.Ord a} (arg_0__ : a) (arg_1__ : Set_ a) : prod
                                                                          (Set_ a) (Set_ a)
-           := match arg_0__, arg_1__ with
-              | _, Tip => (pair Tip Tip)
-              | x, Bin _ y l r =>
-                  match GHC.Base.compare x y with
-                  | Lt => let 'pair lt gt := splitS x l in (pair lt (link y gt r))
-                  | Gt => let 'pair lt gt := splitS x r in (pair (link y l lt) gt)
-                  | Eq => (pair l r)
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => (pair Tip Tip)
+     | x, Bin _ y l r =>
+         match GHC.Base.compare x y with
+         | Lt => let 'pair lt gt := splitS x l in (pair lt (link y gt r))
+         | Gt => let 'pair lt gt := splitS x r in (pair (link y l lt) gt)
+         | Eq => (pair l r)
+         end
+     end.
 
 Fixpoint union {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
-           := match arg_0__, arg_1__ with
-              | t1, Tip => t1
-              | t1, Bin num_2__ x _ _ =>
-                  if num_2__ GHC.Base.== #1 : bool then insertR x t1 else
-                  let j_11__ :=
-                    match arg_0__, arg_1__ with
-                    | Tip, t2 => t2
-                    | (Bin _ x l1 r1 as t1), t2 =>
-                        let 'pair l2 r2 := splitS x t2 in
-                        let r1r2 := union r1 r2 in
-                        let l1l2 := union l1 l2 in
-                        if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                                (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                        then t1 else
-                        link x l1l2 r1r2
-                    end in
-                  match arg_0__, arg_1__ with
-                  | Bin num_3__ x _ _, t2 =>
-                      if num_3__ GHC.Base.== #1 : bool then insert x t2 else
-                      j_11__
-                  | _, _ => j_11__
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | t1, Tip => t1
+     | t1, Bin num_2__ x _ _ =>
+         if num_2__ GHC.Base.== #1 : bool then insertR x t1 else
+         let j_11__ :=
+           match arg_0__, arg_1__ with
+           | Tip, t2 => t2
+           | (Bin _ x l1 r1 as t1), t2 =>
+               let 'pair l2 r2 := splitS x t2 in
+               let r1r2 := union r1 r2 in
+               let l1l2 := union l1 l2 in
+               if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                       (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+               then t1 else
+               link x l1l2 r1r2
+           end in
+         match arg_0__, arg_1__ with
+         | Bin num_3__ x _ _, t2 =>
+             if num_3__ GHC.Base.== #1 : bool then insert x t2 else
+             j_11__
+         | _, _ => j_11__
+         end
+     end.
 
 Local Definition Semigroup__Set__op_zlzlzgzg__ {inst_a} `{GHC.Base.Ord inst_a}
    : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
@@ -316,15 +316,15 @@ Local Definition Foldable__Set__fold
    : forall {m}, forall `{GHC.Base.Monoid m}, Set_ m -> m :=
   fun {m} `{GHC.Base.Monoid m} =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => GHC.Base.mempty
-                 | Bin num_1__ k _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool then k else
-                     match arg_0__ with
-                     | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend k (go r))
-                     | _ => GHC.Err.patternFailure
-                     end
-                 end in
+      := match arg_0__ with
+         | Tip => GHC.Base.mempty
+         | Bin num_1__ k _ _ =>
+             if num_1__ GHC.Base.== #1 : bool then k else
+             match arg_0__ with
+             | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend k (go r))
+             | _ => GHC.Err.patternFailure
+             end
+         end in
     go.
 
 Local Definition Foldable__Set__foldMap
@@ -332,24 +332,24 @@ Local Definition Foldable__Set__foldMap
   fun {m} {a} `{GHC.Base.Monoid m} =>
     fun f t =>
       let fix go arg_0__
-                := match arg_0__ with
-                   | Tip => GHC.Base.mempty
-                   | Bin num_1__ k _ _ =>
-                       if num_1__ GHC.Base.== #1 : bool then f k else
-                       match arg_0__ with
-                       | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k) (go r))
-                       | _ => GHC.Err.patternFailure
-                       end
-                   end in
+        := match arg_0__ with
+           | Tip => GHC.Base.mempty
+           | Bin num_1__ k _ _ =>
+               if num_1__ GHC.Base.== #1 : bool then f k else
+               match arg_0__ with
+               | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k) (go r))
+               | _ => GHC.Err.patternFailure
+               end
+           end in
       go t.
 
 Definition foldl {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f (go z' l) x) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ x l r => go (f (go z' l) x) r
+         end in
     go z.
 
 Local Definition Foldable__Set__foldl
@@ -359,10 +359,10 @@ Local Definition Foldable__Set__foldl
 Definition foldl' {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f (go z' l) x) r
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ x l r => go (f (go z' l) x) r
+         end in
     go z.
 
 Local Definition Foldable__Set__foldl'
@@ -372,10 +372,10 @@ Local Definition Foldable__Set__foldl'
 Definition foldr {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f x (go z' r)) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ x l r => go (f x (go z' r)) l
+         end in
     go z.
 
 Local Definition Foldable__Set__foldr
@@ -385,10 +385,10 @@ Local Definition Foldable__Set__foldr
 Definition foldr' {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f x (go z' r)) l
-                 end in
+      := match arg_0__, arg_1__ with
+         | z', Tip => z'
+         | z', Bin _ x l r => go (f x (go z' r)) l
+         end in
     go z.
 
 Local Definition Foldable__Set__foldr'
@@ -530,22 +530,22 @@ Program Instance Ord1__Set_ : Data.Functor.Classes.Ord1 Set_ :=
 
 Definition maxViewSure {a} : a -> Set_ a -> Set_ a -> prod a (Set_ a) :=
   let fix go arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | x, l, Tip => pair x l
-               | x, l, Bin _ xr rl rr =>
-                   let 'pair xm r' := go xr rl rr in
-                   pair xm (balanceL x l r')
-               end in
+    := match arg_0__, arg_1__, arg_2__ with
+       | x, l, Tip => pair x l
+       | x, l, Bin _ xr rl rr =>
+           let 'pair xm r' := go xr rl rr in
+           pair xm (balanceL x l r')
+       end in
   go.
 
 Definition minViewSure {a} : a -> Set_ a -> Set_ a -> prod a (Set_ a) :=
   let fix go arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | x, Tip, r => pair x r
-               | x, Bin _ xl ll lr, r =>
-                   let 'pair xm l' := go xl ll lr in
-                   pair xm (balanceR x l' r)
-               end in
+    := match arg_0__, arg_1__, arg_2__ with
+       | x, Tip, r => pair x r
+       | x, Bin _ xl ll lr, r =>
+           let 'pair xm l' := go xl ll lr in
+           pair xm (balanceR x l' r)
+       end in
   go.
 
 Definition glue {a} : Set_ a -> Set_ a -> Set_ a :=
@@ -563,16 +563,16 @@ Definition glue {a} : Set_ a -> Set_ a -> Set_ a :=
 
 Program Fixpoint merge {a} (arg_0__ arg_1__ : Set_ a) {measure (Nat.add
                         (set_size arg_0__) (set_size arg_1__))} : Set_ a
-                   := match arg_0__, arg_1__ with
-                      | Tip, r => r
-                      | l, Tip => l
-                      | (Bin sizeL x lx rx as l), (Bin sizeR y ly ry as r) =>
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
-                          then balanceL y (merge l ly) ry else
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
-                          then balanceR x lx (merge rx r) else
-                          glue l r
-                      end.
+  := match arg_0__, arg_1__ with
+     | Tip, r => r
+     | l, Tip => l
+     | (Bin sizeL x lx rx as l), (Bin sizeR y ly ry as r) =>
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
+         then balanceL y (merge l ly) ry else
+         if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
+         then balanceR x lx (merge rx r) else
+         glue l r
+     end.
 Solve Obligations with (termination_by_omega).
 
 Local Definition Semigroup__MergeSet_op_zlzlzgzg__ {inst_a}
@@ -608,16 +608,16 @@ Definition split {a} `{GHC.Base.Ord a}
   fun x t => id (splitS x t).
 
 Fixpoint difference {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | t1, Tip => t1
-              | t1, Bin _ x l2 r2 =>
-                  let 'pair l1 r1 := split x t1 in
-                  let r1r2 := difference r1 r2 in
-                  let l1l2 := difference l1 l2 in
-                  if (size l1l2 GHC.Num.+ size r1r2) GHC.Base.== size t1 : bool then t1 else
-                  merge l1l2 r1r2
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => Tip
+     | t1, Tip => t1
+     | t1, Bin _ x l2 r2 =>
+         let 'pair l1 r1 := split x t1 in
+         let r1r2 := difference r1 r2 in
+         let l1l2 := difference l1 l2 in
+         if (size l1l2 GHC.Num.+ size r1r2) GHC.Base.== size t1 : bool then t1 else
+         merge l1l2 r1r2
+     end.
 
 Definition op_zrzr__ {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> Set_ a :=
   fun m1 m2 => difference m1 m2.
@@ -632,15 +632,15 @@ Infix "\\" := (_\\_) (at level 99).
 
 Definition member {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
   let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | _, Tip => false
-               | x, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => go x l
-                   | Gt => go x r
-                   | Eq => true
-                   end
-               end in
+    := match arg_0__, arg_1__ with
+       | _, Tip => false
+       | x, Bin _ y l r =>
+           match GHC.Base.compare x y with
+           | Lt => go x l
+           | Gt => go x r
+           | Eq => true
+           end
+       end in
   go.
 
 Definition notMember {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
@@ -648,128 +648,128 @@ Definition notMember {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
 
 Definition lookupLT {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
   let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   if x GHC.Base.<= y : bool then goJust x best l else
-                   goJust x y r
-               end in
+    := match arg_0__, arg_1__, arg_2__ with
+       | _, best, Tip => Some best
+       | x, best, Bin _ y l r =>
+           if x GHC.Base.<= y : bool then goJust x best l else
+           goJust x y r
+       end in
   let fix goNothing arg_7__ arg_8__
-            := match arg_7__, arg_8__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   if x GHC.Base.<= y : bool then goNothing x l else
-                   goJust x y r
-               end in
+    := match arg_7__, arg_8__ with
+       | _, Tip => None
+       | x, Bin _ y l r =>
+           if x GHC.Base.<= y : bool then goNothing x l else
+           goJust x y r
+       end in
   goNothing.
 
 Definition lookupGT {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
   let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   if x GHC.Base.< y : bool then goJust x y l else
-                   goJust x best r
-               end in
+    := match arg_0__, arg_1__, arg_2__ with
+       | _, best, Tip => Some best
+       | x, best, Bin _ y l r =>
+           if x GHC.Base.< y : bool then goJust x y l else
+           goJust x best r
+       end in
   let fix goNothing arg_7__ arg_8__
-            := match arg_7__, arg_8__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   if x GHC.Base.< y : bool then goJust x y l else
-                   goNothing x r
-               end in
+    := match arg_7__, arg_8__ with
+       | _, Tip => None
+       | x, Bin _ y l r =>
+           if x GHC.Base.< y : bool then goJust x y l else
+           goNothing x r
+       end in
   goNothing.
 
 Definition lookupLE {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
   let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goJust x best l
-                   | Eq => Some y
-                   | Gt => goJust x y r
-                   end
-               end in
+    := match arg_0__, arg_1__, arg_2__ with
+       | _, best, Tip => Some best
+       | x, best, Bin _ y l r =>
+           match GHC.Base.compare x y with
+           | Lt => goJust x best l
+           | Eq => Some y
+           | Gt => goJust x y r
+           end
+       end in
   let fix goNothing arg_11__ arg_12__
-            := match arg_11__, arg_12__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goNothing x l
-                   | Eq => Some y
-                   | Gt => goJust x y r
-                   end
-               end in
+    := match arg_11__, arg_12__ with
+       | _, Tip => None
+       | x, Bin _ y l r =>
+           match GHC.Base.compare x y with
+           | Lt => goNothing x l
+           | Eq => Some y
+           | Gt => goJust x y r
+           end
+       end in
   goNothing.
 
 Definition lookupGE {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
   let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goJust x y l
-                   | Eq => Some y
-                   | Gt => goJust x best r
-                   end
-               end in
+    := match arg_0__, arg_1__, arg_2__ with
+       | _, best, Tip => Some best
+       | x, best, Bin _ y l r =>
+           match GHC.Base.compare x y with
+           | Lt => goJust x y l
+           | Eq => Some y
+           | Gt => goJust x best r
+           end
+       end in
   let fix goNothing arg_11__ arg_12__
-            := match arg_11__, arg_12__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goJust x y l
-                   | Eq => Some y
-                   | Gt => goNothing x r
-                   end
-               end in
+    := match arg_11__, arg_12__ with
+       | _, Tip => None
+       | x, Bin _ y l r =>
+           match GHC.Base.compare x y with
+           | Lt => goJust x y l
+           | Eq => Some y
+           | Gt => goNothing x r
+           end
+       end in
   goNothing.
 
 Definition delete {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
   let go {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
     fix go (arg_0__ : a) (arg_1__ : Set_ a) : Set_ a
-          := match arg_0__, arg_1__ with
-             | _, Tip => Tip
-             | x, (Bin _ y l r as t) =>
-                 match GHC.Base.compare x y with
-                 | Lt =>
-                     let l' := go x l in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                     balanceR y l' r
-                 | Gt =>
-                     let r' := go x r in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                     balanceL y l r'
-                 | Eq => glue l r
-                 end
-             end in
+      := match arg_0__, arg_1__ with
+         | _, Tip => Tip
+         | x, (Bin _ y l r as t) =>
+             match GHC.Base.compare x y with
+             | Lt =>
+                 let l' := go x l in
+                 if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                 balanceR y l' r
+             | Gt =>
+                 let r' := go x r in
+                 if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                 balanceL y l r'
+             | Eq => glue l r
+             end
+         end in
   go.
 
 Fixpoint splitMember {a} `{GHC.Base.Ord a} (arg_0__ : a) (arg_1__ : Set_ a)
-           : (Set_ a * bool * Set_ a)%type
-           := match arg_0__, arg_1__ with
-              | _, Tip => pair (pair Tip false) Tip
-              | x, Bin _ y l r =>
-                  match GHC.Base.compare x y with
-                  | Lt =>
-                      let 'pair (pair lt found) gt := splitMember x l in
-                      let gt' := link y gt r in pair (pair lt found) gt'
-                  | Gt =>
-                      let 'pair (pair lt found) gt := splitMember x r in
-                      let lt' := link y l lt in pair (pair lt' found) gt
-                  | Eq => pair (pair l true) r
-                  end
-              end.
+  : (Set_ a * bool * Set_ a)%type
+  := match arg_0__, arg_1__ with
+     | _, Tip => pair (pair Tip false) Tip
+     | x, Bin _ y l r =>
+         match GHC.Base.compare x y with
+         | Lt =>
+             let 'pair (pair lt found) gt := splitMember x l in
+             let gt' := link y gt r in pair (pair lt found) gt'
+         | Gt =>
+             let 'pair (pair lt found) gt := splitMember x r in
+             let lt' := link y l lt in pair (pair lt' found) gt
+         | Eq => pair (pair l true) r
+         end
+     end.
 
 Fixpoint isSubsetOfX {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : bool
-           := match arg_0__, arg_1__ with
-              | Tip, _ => true
-              | _, Tip => false
-              | Bin _ x l r, t =>
-                  let 'pair (pair lt found) gt := splitMember x t in
-                  andb found (andb (isSubsetOfX l lt) (isSubsetOfX r gt))
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => true
+     | _, Tip => false
+     | Bin _ x l r, t =>
+         let 'pair (pair lt found) gt := splitMember x t in
+         andb found (andb (isSubsetOfX l lt) (isSubsetOfX r gt))
+     end.
 
 Definition isSubsetOf {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> bool :=
   fun t1 t2 => andb (size t1 GHC.Base.<= size t2) (isSubsetOfX t1 t2).
@@ -778,19 +778,19 @@ Definition isProperSubsetOf {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> bool :=
   fun s1 s2 => andb (size s1 GHC.Base.< size s2) (isSubsetOf s1 s2).
 
 Fixpoint disjoint {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : bool
-           := match arg_0__, arg_1__ with
-              | Tip, _ => true
-              | _, Tip => true
-              | Bin _ x l r, t =>
-                  let 'pair (pair lt found) gt := splitMember x t in
-                  andb (negb found) (andb (disjoint l lt) (disjoint r gt))
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => true
+     | _, Tip => true
+     | Bin _ x l r, t =>
+         let 'pair (pair lt found) gt := splitMember x t in
+         andb (negb found) (andb (disjoint l lt) (disjoint r gt))
+     end.
 
 Fixpoint lookupMinSure {a} (arg_0__ : a) (arg_1__ : Set_ a) : a
-           := match arg_0__, arg_1__ with
-              | x, Tip => x
-              | _, Bin _ x l _ => lookupMinSure x l
-              end.
+  := match arg_0__, arg_1__ with
+     | x, Tip => x
+     | _, Bin _ x l _ => lookupMinSure x l
+     end.
 
 Definition lookupMin {a} : Set_ a -> option a :=
   fun arg_0__ =>
@@ -802,10 +802,10 @@ Definition lookupMin {a} : Set_ a -> option a :=
 (* Skipping definition `Data.Set.Internal.findMin' *)
 
 Fixpoint lookupMaxSure {a} (arg_0__ : a) (arg_1__ : Set_ a) : a
-           := match arg_0__, arg_1__ with
-              | x, Tip => x
-              | _, Bin _ x _ r => lookupMaxSure x r
-              end.
+  := match arg_0__, arg_1__ with
+     | x, Tip => x
+     | _, Bin _ x _ r => lookupMaxSure x r
+     end.
 
 Definition lookupMax {a} : Set_ a -> option a :=
   fun arg_0__ =>
@@ -817,66 +817,66 @@ Definition lookupMax {a} : Set_ a -> option a :=
 (* Skipping definition `Data.Set.Internal.findMax' *)
 
 Fixpoint deleteMin {a} (arg_0__ : Set_ a) : Set_ a
-           := match arg_0__ with
-              | Bin _ _ Tip r => r
-              | Bin _ x l r => balanceR x (deleteMin l) r
-              | Tip => Tip
-              end.
+  := match arg_0__ with
+     | Bin _ _ Tip r => r
+     | Bin _ x l r => balanceR x (deleteMin l) r
+     | Tip => Tip
+     end.
 
 Fixpoint deleteMax {a} (arg_0__ : Set_ a) : Set_ a
-           := match arg_0__ with
-              | Bin _ _ l Tip => l
-              | Bin _ x l r => balanceL x l (deleteMax r)
-              | Tip => Tip
-              end.
+  := match arg_0__ with
+     | Bin _ _ l Tip => l
+     | Bin _ x l r => balanceL x l (deleteMax r)
+     | Tip => Tip
+     end.
 
 Fixpoint intersection {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | _, Tip => Tip
-              | (Bin _ x l1 r1 as t1), t2 =>
-                  let 'pair (pair l2 b) r2 := splitMember x t2 in
-                  let l1l2 := intersection l1 l2 in
-                  let r1r2 := intersection r1 r2 in
-                  if b : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                       then t1
-                       else link x l1l2 r1r2 else
-                  merge l1l2 r1r2
-              end.
+  := match arg_0__, arg_1__ with
+     | Tip, _ => Tip
+     | _, Tip => Tip
+     | (Bin _ x l1 r1 as t1), t2 =>
+         let 'pair (pair l2 b) r2 := splitMember x t2 in
+         let l1l2 := intersection l1 l2 in
+         let r1r2 := intersection r1 r2 in
+         if b : bool
+         then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                      (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+              then t1
+              else link x l1l2 r1r2 else
+         merge l1l2 r1r2
+     end.
 
 Fixpoint filter {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_ a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, (Bin _ x l r as t) =>
-                  let r' := filter p r in
-                  let l' := filter p l in
-                  if p x : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l l')
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r r') : bool
-                       then t
-                       else link x l' r' else
-                  merge l' r'
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | p, (Bin _ x l r as t) =>
+         let r' := filter p r in
+         let l' := filter p l in
+         if p x : bool
+         then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l l')
+                      (Utils.Containers.Internal.PtrEquality.ptrEq r r') : bool
+              then t
+              else link x l' r' else
+         merge l' r'
+     end.
 
 Definition partition {a} : (a -> bool) -> Set_ a -> (Set_ a * Set_ a)%type :=
   fun p0 t0 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => (pair Tip Tip)
-                 | p, (Bin _ x l r as t) =>
-                     let 'pair (pair l1 l2) (pair r1 r2) := pair (go p l) (go p r) in
-                     if p x : bool
-                     then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
-                                        (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
-                                then t
-                                else link x l1 r1) (merge l2 r2) else
-                     pair (merge l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
-                                                 (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
-                           then t
-                           else link x l2 r2)
-                 end in
+      := match arg_0__, arg_1__ with
+         | _, Tip => (pair Tip Tip)
+         | p, (Bin _ x l r as t) =>
+             let 'pair (pair l1 l2) (pair r1 r2) := pair (go p l) (go p r) in
+             if p x : bool
+             then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
+                                (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
+                        then t
+                        else link x l1 r1) (merge l2 r2) else
+             pair (merge l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
+                                         (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
+                   then t
+                   else link x l2 r2)
+         end in
     id (go p0 t0).
 
 Definition fromList {a} `{GHC.Base.Ord a} : list a -> Set_ a :=
@@ -932,10 +932,10 @@ Definition map {b} {a} `{GHC.Base.Ord b} : (a -> b) -> Set_ a -> Set_ b :=
   fun f => fromList GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ toList).
 
 Fixpoint mapMonotonic {a} {b} (arg_0__ : (a -> b)) (arg_1__ : Set_ a) : Set_ b
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sz x l r => Bin sz (f x) (mapMonotonic f l) (mapMonotonic f r)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | f, Bin sz x l r => Bin sz (f x) (mapMonotonic f l) (mapMonotonic f r)
+     end.
 
 Definition fold {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
   foldr.
@@ -958,12 +958,12 @@ Definition combineEq {a} `{GHC.Base.Eq_ a} : list a -> list a :=
     | nil => nil
     | cons x xs =>
         let fix combineEq' arg_1__ arg_2__
-                  := match arg_1__, arg_2__ with
-                     | z, nil => cons z nil
-                     | z, cons y ys =>
-                         if z GHC.Base.== y : bool then combineEq' z ys else
-                         cons z (combineEq' y ys)
-                     end in
+          := match arg_1__, arg_2__ with
+             | z, nil => cons z nil
+             | z, cons y ys =>
+                 if z GHC.Base.== y : bool then combineEq' z ys else
+                 cons z (combineEq' y ys)
+             end in
         combineEq' x xs
     end.
 
@@ -1039,15 +1039,15 @@ Definition lookupIndex {a} `{GHC.Base.Ord a}
    : GHC.Num.Int -> a -> Set_ a -> option GHC.Num.Int :=
     fix go (arg_0__ : GHC.Num.Int) (arg_1__ : a) (arg_2__ : Set_ a) : option
                                                                       GHC.Num.Int
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => None
-             | idx, x, Bin _ kx l r =>
-                 match GHC.Base.compare x kx with
-                 | Lt => go idx x l
-                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) x r
-                 | Eq => Some (idx GHC.Num.+ size l)
-                 end
-             end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | _, _, Tip => None
+         | idx, x, Bin _ kx l r =>
+             match GHC.Base.compare x kx with
+             | Lt => go idx x l
+             | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) x r
+             | Eq => Some (idx GHC.Num.+ size l)
+             end
+         end in
   go #0.
 
 (* Skipping definition `Data.Set.Internal.elemAt' *)
@@ -1062,20 +1062,20 @@ Definition take {a} : GHC.Num.Int -> Set_ a -> Set_ a :=
         match arg_0__, arg_1__ with
         | i0, m0 =>
             let fix go arg_2__ arg_3__
-                      := match arg_2__, arg_3__ with
-                         | i, _ =>
-                             if i GHC.Base.<= #0 : bool then Tip else
-                             match arg_2__, arg_3__ with
-                             | _, Tip => Tip
-                             | i, Bin _ x l r =>
-                                 let sizeL := size l in
-                                 match GHC.Base.compare i sizeL with
-                                 | Lt => go i l
-                                 | Gt => link x l (go ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
-                                 | Eq => l
-                                 end
-                             end
-                         end in
+              := match arg_2__, arg_3__ with
+                 | i, _ =>
+                     if i GHC.Base.<= #0 : bool then Tip else
+                     match arg_2__, arg_3__ with
+                     | _, Tip => Tip
+                     | i, Bin _ x l r =>
+                         let sizeL := size l in
+                         match GHC.Base.compare i sizeL with
+                         | Lt => go i l
+                         | Gt => link x l (go ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
+                         | Eq => l
+                         end
+                     end
+                 end in
             go i0 m0
         end
     end.
@@ -1088,20 +1088,20 @@ Definition drop {a} : GHC.Num.Int -> Set_ a -> Set_ a :=
         match arg_0__, arg_1__ with
         | i0, m0 =>
             let fix go arg_2__ arg_3__
-                      := match arg_2__, arg_3__ with
-                         | i, m =>
-                             if i GHC.Base.<= #0 : bool then m else
-                             match arg_2__, arg_3__ with
-                             | _, Tip => Tip
-                             | i, Bin _ x l r =>
-                                 let sizeL := size l in
-                                 match GHC.Base.compare i sizeL with
-                                 | Lt => link x (go i l) r
-                                 | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
-                                 | Eq => insertMin x r
-                                 end
-                             end
-                         end in
+              := match arg_2__, arg_3__ with
+                 | i, m =>
+                     if i GHC.Base.<= #0 : bool then m else
+                     match arg_2__, arg_3__ with
+                     | _, Tip => Tip
+                     | i, Bin _ x l r =>
+                         let sizeL := size l in
+                         match GHC.Base.compare i sizeL with
+                         | Lt => link x (go i l) r
+                         | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
+                         | Eq => insertMin x r
+                         end
+                     end
+                 end in
             go i0 m0
         end
     end.
@@ -1109,53 +1109,53 @@ Definition drop {a} : GHC.Num.Int -> Set_ a -> Set_ a :=
 Definition splitAt {a} : GHC.Num.Int -> Set_ a -> (Set_ a * Set_ a)%type :=
   fun i0 m0 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | i, m =>
-                     if i GHC.Base.<= #0 : bool then pair Tip m else
-                     match arg_0__, arg_1__ with
-                     | _, Tip => pair Tip Tip
-                     | i, Bin _ x l r =>
-                         let sizeL := size l in
-                         match GHC.Base.compare i sizeL with
-                         | Lt => let 'pair ll lr := go i l in pair ll (link x lr r)
-                         | Gt =>
-                             let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
-                             pair (link x l rl) rr
-                         | Eq => pair l (insertMin x r)
-                         end
-                     end
-                 end in
+      := match arg_0__, arg_1__ with
+         | i, m =>
+             if i GHC.Base.<= #0 : bool then pair Tip m else
+             match arg_0__, arg_1__ with
+             | _, Tip => pair Tip Tip
+             | i, Bin _ x l r =>
+                 let sizeL := size l in
+                 match GHC.Base.compare i sizeL with
+                 | Lt => let 'pair ll lr := go i l in pair ll (link x lr r)
+                 | Gt =>
+                     let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
+                     pair (link x l rl) rr
+                 | Eq => pair l (insertMin x r)
+                 end
+             end
+         end in
     if i0 GHC.Base.>= size m0 : bool then pair m0 Tip else
     id (go i0 m0).
 
 Fixpoint takeWhileAntitone {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_
                                                                             a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, Bin _ x l r =>
-                  if p x : bool then link x l (takeWhileAntitone p r) else
-                  takeWhileAntitone p l
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | p, Bin _ x l r =>
+         if p x : bool then link x l (takeWhileAntitone p r) else
+         takeWhileAntitone p l
+     end.
 
 Fixpoint dropWhileAntitone {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_
                                                                             a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, Bin _ x l r =>
-                  if p x : bool then dropWhileAntitone p r else
-                  link x (dropWhileAntitone p l) r
-              end.
+  := match arg_0__, arg_1__ with
+     | _, Tip => Tip
+     | p, Bin _ x l r =>
+         if p x : bool then dropWhileAntitone p r else
+         link x (dropWhileAntitone p l) r
+     end.
 
 Definition spanAntitone {a} : (a -> bool) -> Set_ a -> (Set_ a * Set_ a)%type :=
   fun p0 m =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => pair Tip Tip
-                 | p, Bin _ x l r =>
-                     if p x : bool then let 'pair u v := go p r in pair (link x l u) v else
-                     let 'pair u v := go p l in
-                     pair u (link x v r)
-                 end in
+      := match arg_0__, arg_1__ with
+         | _, Tip => pair Tip Tip
+         | p, Bin _ x l r =>
+             if p x : bool then let 'pair u v := go p r in pair (link x l u) v else
+             let 'pair u v := go p l in
+             pair u (link x v r)
+         end in
     id (go p0 m).
 
 (* Skipping definition `Data.Set.Internal.deleteFindMin' *)
@@ -1219,40 +1219,39 @@ Definition disjointUnion {a} {b}
 (* Skipping definition `Data.Set.Internal.withEmpty' *)
 
 Fixpoint balanced {a} (t : Set_ a) : bool
-           := match t with
-              | Tip => true
-              | Bin _ _ l r =>
-                  andb (orb ((size l GHC.Num.+ size r) GHC.Base.<= #1) (andb (size l GHC.Base.<=
-                                                                              (delta GHC.Num.* size r)) (size r
-                                                                              GHC.Base.<=
-                                                                              (delta GHC.Num.* size l)))) (andb
-                        (balanced l) (balanced r))
-              end.
+  := match t with
+     | Tip => true
+     | Bin _ _ l r =>
+         andb (orb ((size l GHC.Num.+ size r) GHC.Base.<= #1) (andb (size l GHC.Base.<=
+                                                                     (delta GHC.Num.* size r)) (size r GHC.Base.<=
+                                                                     (delta GHC.Num.* size l)))) (andb (balanced l)
+                                                                                                       (balanced r))
+     end.
 
 Definition ordered {a} `{GHC.Base.Ord a} : Set_ a -> bool :=
   fun t =>
     let fix bounded lo hi t'
-              := match t' with
-                 | Tip => true
-                 | Bin _ x l r =>
-                     andb (lo x) (andb (hi x) (andb (bounded lo (fun arg_0__ => arg_0__ GHC.Base.< x)
-                                                     l) (bounded (fun arg_1__ => arg_1__ GHC.Base.> x) hi r)))
-                 end in
+      := match t' with
+         | Tip => true
+         | Bin _ x l r =>
+             andb (lo x) (andb (hi x) (andb (bounded lo (fun arg_0__ => arg_0__ GHC.Base.< x)
+                                             l) (bounded (fun arg_1__ => arg_1__ GHC.Base.> x) hi r)))
+         end in
     bounded (GHC.Base.const true) (GHC.Base.const true) t.
 
 Definition validsize {a} : Set_ a -> bool :=
   fun t =>
     let fix realsize t'
-              := match t' with
-                 | Tip => Some #0
-                 | Bin sz _ l r =>
-                     match pair (realsize l) (realsize r) with
-                     | pair (Some n) (Some m) =>
-                         if ((n GHC.Num.+ m) GHC.Num.+ #1) GHC.Base.== sz : bool then Some sz else
-                         None
-                     | _ => None
-                     end
-                 end in
+      := match t' with
+         | Tip => Some #0
+         | Bin sz _ l r =>
+             match pair (realsize l) (realsize r) with
+             | pair (Some n) (Some m) =>
+                 if ((n GHC.Num.+ m) GHC.Num.+ #1) GHC.Base.== sz : bool then Some sz else
+                 None
+             | _ => None
+             end
+         end in
     (realsize t GHC.Base.== Some (size t)).
 
 Definition valid {a} `{GHC.Base.Ord a} : Set_ a -> bool :=

--- a/examples/containers/lib/IntSetValidity.v
+++ b/examples/containers/lib/IntSetValidity.v
@@ -27,47 +27,46 @@ Import GHC.Num.Notations.
 (* Converted value declarations: *)
 
 Fixpoint commonPrefix (t : Data.IntSet.Internal.IntSet) : bool
-           := let sharedPrefix
-               : Data.IntSet.Internal.Prefix -> Coq.Numbers.BinNums.N -> bool :=
-                fun p a => p GHC.Base.== (p Data.Bits..&.(**) a) in
-              match t with
-              | Data.IntSet.Internal.Nil => true
-              | Data.IntSet.Internal.Tip _ _ => true
-              | (Data.IntSet.Internal.Bin p _ l r as b) =>
-                  andb (Data.Foldable.all (sharedPrefix p) (Data.IntSet.Internal.elems b)) (andb
-                        (commonPrefix l) (commonPrefix r))
-              end.
+  := let sharedPrefix
+      : Data.IntSet.Internal.Prefix -> Coq.Numbers.BinNums.N -> bool :=
+       fun p a => p GHC.Base.== (p Data.Bits..&.(**) a) in
+     match t with
+     | Data.IntSet.Internal.Nil => true
+     | Data.IntSet.Internal.Tip _ _ => true
+     | (Data.IntSet.Internal.Bin p _ l r as b) =>
+         andb (Data.Foldable.all (sharedPrefix p) (Data.IntSet.Internal.elems b)) (andb
+               (commonPrefix l) (commonPrefix r))
+     end.
 
 Fixpoint maskPowerOfTwo (t : Data.IntSet.Internal.IntSet) : bool
-           := match t with
-              | Data.IntSet.Internal.Nil => true
-              | Data.IntSet.Internal.Tip _ _ => true
-              | Data.IntSet.Internal.Bin _ m l r =>
-                  andb (Utils.Containers.Internal.BitUtil.bitcount #0 (m) GHC.Base.== #1) (andb
-                        (maskPowerOfTwo l) (maskPowerOfTwo r))
-              end.
+  := match t with
+     | Data.IntSet.Internal.Nil => true
+     | Data.IntSet.Internal.Tip _ _ => true
+     | Data.IntSet.Internal.Bin _ m l r =>
+         andb (Utils.Containers.Internal.BitUtil.bitcount #0 (m) GHC.Base.== #1) (andb
+               (maskPowerOfTwo l) (maskPowerOfTwo r))
+     end.
 
 Fixpoint maskRespected (t : Data.IntSet.Internal.IntSet) : bool
-           := match t with
-              | Data.IntSet.Internal.Nil => true
-              | Data.IntSet.Internal.Tip _ _ => true
-              | Data.IntSet.Internal.Bin _ binMask l r =>
-                  andb (Data.Foldable.all (fun x => Data.IntSet.Internal.zero x binMask)
-                        (Data.IntSet.Internal.elems l)) (andb (Data.Foldable.all (fun x =>
-                                                                                    negb (Data.IntSet.Internal.zero x
-                                                                                          binMask))
-                                                               (Data.IntSet.Internal.elems r)) (andb (maskRespected l)
-                                                                                                     (maskRespected r)))
-              end.
+  := match t with
+     | Data.IntSet.Internal.Nil => true
+     | Data.IntSet.Internal.Tip _ _ => true
+     | Data.IntSet.Internal.Bin _ binMask l r =>
+         andb (Data.Foldable.all (fun x => Data.IntSet.Internal.zero x binMask)
+               (Data.IntSet.Internal.elems l)) (andb (Data.Foldable.all (fun x =>
+                                                                           negb (Data.IntSet.Internal.zero x binMask))
+                                                      (Data.IntSet.Internal.elems r)) (andb (maskRespected l)
+                                                                                            (maskRespected r)))
+     end.
 
 Definition nilNeverChildOfBin : Data.IntSet.Internal.IntSet -> bool :=
   fun t =>
     let fix noNilInSet t'
-              := match t' with
-                 | Data.IntSet.Internal.Nil => false
-                 | Data.IntSet.Internal.Tip _ _ => true
-                 | Data.IntSet.Internal.Bin _ _ l' r' => andb (noNilInSet l') (noNilInSet r')
-                 end in
+      := match t' with
+         | Data.IntSet.Internal.Nil => false
+         | Data.IntSet.Internal.Tip _ _ => true
+         | Data.IntSet.Internal.Bin _ _ l' r' => andb (noNilInSet l') (noNilInSet r')
+         end in
     match t with
     | Data.IntSet.Internal.Nil => true
     | Data.IntSet.Internal.Tip _ _ => true
@@ -78,11 +77,11 @@ Definition validTipPrefix : Data.IntSet.Internal.Prefix -> bool :=
   fun p => (#63 Data.Bits..&.(**) p) GHC.Base.== #0.
 
 Fixpoint tipsValid (t : Data.IntSet.Internal.IntSet) : bool
-           := match t with
-              | Data.IntSet.Internal.Nil => true
-              | (Data.IntSet.Internal.Tip p b as tip) => validTipPrefix p
-              | Data.IntSet.Internal.Bin _ _ l r => andb (tipsValid l) (tipsValid r)
-              end.
+  := match t with
+     | Data.IntSet.Internal.Nil => true
+     | (Data.IntSet.Internal.Tip p b as tip) => validTipPrefix p
+     | Data.IntSet.Internal.Bin _ _ l r => andb (tipsValid l) (tipsValid r)
+     end.
 
 Definition valid : Data.IntSet.Internal.IntSet -> bool :=
   fun t =>

--- a/examples/ghc/lib/Bag.v
+++ b/examples/ghc/lib/Bag.v
@@ -31,11 +31,11 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Bag a : Type
-  := | EmptyBag : Bag a
-  |  UnitBag : a -> Bag a
-  |  TwoBags : (Bag a) -> (Bag a) -> Bag a
-  |  ListBag : list a -> Bag a.
+Inductive Bag a : Type :=
+  | EmptyBag : Bag a
+  | UnitBag : a -> Bag a
+  | TwoBags : (Bag a) -> (Bag a) -> Bag a
+  | ListBag : list a -> Bag a.
 
 Arguments EmptyBag {_}.
 
@@ -61,12 +61,12 @@ Instance Default_Bag {a} : GHC.Err.Default (Bag a):=
    `Bag.Data__Bag' *)
 
 Fixpoint mapBag {a} {b} (arg_0__ : (a -> b)) (arg_1__ : Bag a) : Bag b
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => EmptyBag
-              | f, UnitBag x => UnitBag (f x)
-              | f, TwoBags b1 b2 => TwoBags (mapBag f b1) (mapBag f b2)
-              | f, ListBag xs => ListBag (GHC.Base.map f xs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => EmptyBag
+     | f, UnitBag x => UnitBag (f x)
+     | f, TwoBags b1 b2 => TwoBags (mapBag f b1) (mapBag f b2)
+     | f, ListBag xs => ListBag (GHC.Base.map f xs)
+     end.
 
 Local Definition Functor__Bag_fmap
    : forall {a} {b}, (a -> b) -> Bag a -> Bag b :=
@@ -82,12 +82,12 @@ Program Instance Functor__Bag : GHC.Base.Functor Bag :=
 
 Fixpoint foldrBag {a} {r} (arg_0__ : (a -> r -> r)) (arg_1__ : r) (arg_2__
                     : Bag a) : r
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, EmptyBag => z
-              | k, z, UnitBag x => k x z
-              | k, z, TwoBags b1 b2 => foldrBag k (foldrBag k z b2) b1
-              | k, z, ListBag xs => Data.Foldable.foldr k z xs
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, z, EmptyBag => z
+     | k, z, UnitBag x => k x z
+     | k, z, TwoBags b1 b2 => foldrBag k (foldrBag k z b2) b1
+     | k, z, ListBag xs => Data.Foldable.foldr k z xs
+     end.
 
 Local Definition Foldable__Bag_foldr
    : forall {a} {b}, (a -> b -> b) -> b -> Bag a -> b :=
@@ -172,20 +172,20 @@ Definition unitBag {a} : a -> Bag a :=
   UnitBag.
 
 Fixpoint lengthBag {a} (arg_0__ : Bag a) : nat
-           := match arg_0__ with
-              | EmptyBag => #0
-              | UnitBag _ => #1
-              | TwoBags b1 b2 => lengthBag b1 GHC.Num.+ lengthBag b2
-              | ListBag xs => BinInt.Z.to_nat (Data.Foldable.length xs)
-              end.
+  := match arg_0__ with
+     | EmptyBag => #0
+     | UnitBag _ => #1
+     | TwoBags b1 b2 => lengthBag b1 GHC.Num.+ lengthBag b2
+     | ListBag xs => BinInt.Z.to_nat (Data.Foldable.length xs)
+     end.
 
 Fixpoint elemBag {a} `{GHC.Base.Eq_ a} (arg_0__ : a) (arg_1__ : Bag a) : bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => false
-              | x, UnitBag y => x GHC.Base.== y
-              | x, TwoBags b1 b2 => orb (elemBag x b1) (elemBag x b2)
-              | x, ListBag ys => Data.Foldable.any (fun arg_4__ => x GHC.Base.== arg_4__) ys
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => false
+     | x, UnitBag y => x GHC.Base.== y
+     | x, TwoBags b1 b2 => orb (elemBag x b1) (elemBag x b2)
+     | x, ListBag ys => Data.Foldable.any (fun arg_4__ => x GHC.Base.== arg_4__) ys
+     end.
 
 Definition unionBags {a} : Bag a -> Bag a -> Bag a :=
   fun arg_0__ arg_1__ =>
@@ -220,61 +220,61 @@ Definition listToBag {a} : list a -> Bag a :=
   fun arg_0__ => match arg_0__ with | nil => EmptyBag | vs => ListBag vs end.
 
 Fixpoint filterBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : Bag a
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => EmptyBag
-              | pred, (UnitBag val as b) => if pred val : bool then b else EmptyBag
-              | pred, TwoBags b1 b2 =>
-                  let sat2 := filterBag pred b2 in
-                  let sat1 := filterBag pred b1 in unionBags sat1 sat2
-              | pred, ListBag vs => listToBag (GHC.List.filter pred vs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => EmptyBag
+     | pred, (UnitBag val as b) => if pred val : bool then b else EmptyBag
+     | pred, TwoBags b1 b2 =>
+         let sat2 := filterBag pred b2 in
+         let sat1 := filterBag pred b1 in unionBags sat1 sat2
+     | pred, ListBag vs => listToBag (GHC.List.filter pred vs)
+     end.
 
 Fixpoint filterBagM {m} {a} `{GHC.Base.Monad m} (arg_0__ : (a -> m bool))
                     (arg_1__ : Bag a) : m (Bag a)
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ EmptyBag
-              | pred, (UnitBag val as b) =>
-                  pred val GHC.Base.>>=
-                  (fun flag =>
-                     if flag : bool
-                     then GHC.Base.return_ b
-                     else GHC.Base.return_ EmptyBag)
-              | pred, TwoBags b1 b2 =>
-                  filterBagM pred b1 GHC.Base.>>=
-                  (fun sat1 =>
-                     filterBagM pred b2 GHC.Base.>>=
-                     (fun sat2 => GHC.Base.return_ (unionBags sat1 sat2)))
-              | pred, ListBag vs =>
-                  Control.Monad.filterM pred vs GHC.Base.>>=
-                  (fun sat => GHC.Base.return_ (listToBag sat))
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => GHC.Base.return_ EmptyBag
+     | pred, (UnitBag val as b) =>
+         pred val GHC.Base.>>=
+         (fun flag =>
+            if flag : bool
+            then GHC.Base.return_ b
+            else GHC.Base.return_ EmptyBag)
+     | pred, TwoBags b1 b2 =>
+         filterBagM pred b1 GHC.Base.>>=
+         (fun sat1 =>
+            filterBagM pred b2 GHC.Base.>>=
+            (fun sat2 => GHC.Base.return_ (unionBags sat1 sat2)))
+     | pred, ListBag vs =>
+         Control.Monad.filterM pred vs GHC.Base.>>=
+         (fun sat => GHC.Base.return_ (listToBag sat))
+     end.
 
 Fixpoint allBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => true
-              | p, UnitBag v => p v
-              | p, TwoBags b1 b2 => andb (allBag p b1) (allBag p b2)
-              | p, ListBag xs => Data.Foldable.all p xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => true
+     | p, UnitBag v => p v
+     | p, TwoBags b1 b2 => andb (allBag p b1) (allBag p b2)
+     | p, ListBag xs => Data.Foldable.all p xs
+     end.
 
 Fixpoint anyBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => false
-              | p, UnitBag v => p v
-              | p, TwoBags b1 b2 => orb (anyBag p b1) (anyBag p b2)
-              | p, ListBag xs => Data.Foldable.any p xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => false
+     | p, UnitBag v => p v
+     | p, TwoBags b1 b2 => orb (anyBag p b1) (anyBag p b2)
+     | p, ListBag xs => Data.Foldable.any p xs
+     end.
 
 Fixpoint anyBagM {m} {a} `{GHC.Base.Monad m} (arg_0__ : (a -> m bool)) (arg_1__
                    : Bag a) : m bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ false
-              | p, UnitBag v => p v
-              | p, TwoBags b1 b2 =>
-                  anyBagM p b1 GHC.Base.>>=
-                  (fun flag => if flag : bool then GHC.Base.return_ true else anyBagM p b2)
-              | p, ListBag xs => MonadUtils.anyM p xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => GHC.Base.return_ false
+     | p, UnitBag v => p v
+     | p, TwoBags b1 b2 =>
+         anyBagM p b1 GHC.Base.>>=
+         (fun flag => if flag : bool then GHC.Base.return_ true else anyBagM p b2)
+     | p, ListBag xs => MonadUtils.anyM p xs
+     end.
 
 Definition concatBag {a} : Bag (Bag a) -> Bag a :=
   fun bss => let add := fun bs rs => unionBags bs rs in foldrBag add emptyBag bss.
@@ -291,220 +291,220 @@ Definition catBagMaybes {a} : Bag (option a) -> Bag a :=
 
 Fixpoint partitionBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : (Bag a *
                                                                        Bag a)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => pair EmptyBag EmptyBag
-              | pred, (UnitBag val as b) =>
-                  if pred val : bool
-                  then pair b EmptyBag
-                  else pair EmptyBag b
-              | pred, TwoBags b1 b2 =>
-                  let 'pair sat2 fail2 := partitionBag pred b2 in
-                  let 'pair sat1 fail1 := partitionBag pred b1 in
-                  pair (unionBags sat1 sat2) (unionBags fail1 fail2)
-              | pred, ListBag vs =>
-                  let 'pair sats fails := Data.OldList.partition pred vs in
-                  pair (listToBag sats) (listToBag fails)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => pair EmptyBag EmptyBag
+     | pred, (UnitBag val as b) =>
+         if pred val : bool
+         then pair b EmptyBag
+         else pair EmptyBag b
+     | pred, TwoBags b1 b2 =>
+         let 'pair sat2 fail2 := partitionBag pred b2 in
+         let 'pair sat1 fail1 := partitionBag pred b1 in
+         pair (unionBags sat1 sat2) (unionBags fail1 fail2)
+     | pred, ListBag vs =>
+         let 'pair sats fails := Data.OldList.partition pred vs in
+         pair (listToBag sats) (listToBag fails)
+     end.
 
 Fixpoint partitionBagWith {a} {b} {c} (arg_0__ : (a -> Data.Either.Either b c))
                           (arg_1__ : Bag a) : (Bag b * Bag c)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => pair EmptyBag EmptyBag
-              | pred, UnitBag val =>
-                  match pred val with
-                  | Data.Either.Left a => pair (UnitBag a) EmptyBag
-                  | Data.Either.Right b => pair EmptyBag (UnitBag b)
-                  end
-              | pred, TwoBags b1 b2 =>
-                  let 'pair sat2 fail2 := partitionBagWith pred b2 in
-                  let 'pair sat1 fail1 := partitionBagWith pred b1 in
-                  pair (unionBags sat1 sat2) (unionBags fail1 fail2)
-              | pred, ListBag vs =>
-                  let 'pair sats fails := Util.partitionWith pred vs in
-                  pair (listToBag sats) (listToBag fails)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => pair EmptyBag EmptyBag
+     | pred, UnitBag val =>
+         match pred val with
+         | Data.Either.Left a => pair (UnitBag a) EmptyBag
+         | Data.Either.Right b => pair EmptyBag (UnitBag b)
+         end
+     | pred, TwoBags b1 b2 =>
+         let 'pair sat2 fail2 := partitionBagWith pred b2 in
+         let 'pair sat1 fail1 := partitionBagWith pred b1 in
+         pair (unionBags sat1 sat2) (unionBags fail1 fail2)
+     | pred, ListBag vs =>
+         let 'pair sats fails := Util.partitionWith pred vs in
+         pair (listToBag sats) (listToBag fails)
+     end.
 
 Fixpoint foldBag {r} {a} (arg_0__ : (r -> r -> r)) (arg_1__ : (a -> r)) (arg_2__
                    : r) (arg_3__ : Bag a) : r
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, _, e, EmptyBag => e
-              | t, u, e, UnitBag x => t (u x) e
-              | t, u, e, TwoBags b1 b2 => foldBag t u (foldBag t u e b2) b1
-              | t, u, e, ListBag xs => Data.Foldable.foldr (t GHC.Base.∘ u) e xs
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | _, _, e, EmptyBag => e
+     | t, u, e, UnitBag x => t (u x) e
+     | t, u, e, TwoBags b1 b2 => foldBag t u (foldBag t u e b2) b1
+     | t, u, e, ListBag xs => Data.Foldable.foldr (t GHC.Base.∘ u) e xs
+     end.
 
 Fixpoint foldlBag {r} {a} (arg_0__ : (r -> a -> r)) (arg_1__ : r) (arg_2__
                     : Bag a) : r
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, EmptyBag => z
-              | k, z, UnitBag x => k z x
-              | k, z, TwoBags b1 b2 => foldlBag k (foldlBag k z b1) b2
-              | k, z, ListBag xs => Data.Foldable.foldl k z xs
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, z, EmptyBag => z
+     | k, z, UnitBag x => k z x
+     | k, z, TwoBags b1 b2 => foldlBag k (foldlBag k z b1) b2
+     | k, z, ListBag xs => Data.Foldable.foldl k z xs
+     end.
 
 Fixpoint foldrBagM {m} {a} {b} `{(GHC.Base.Monad m)} (arg_0__ : (a -> b -> m b))
                    (arg_1__ : b) (arg_2__ : Bag a) : m b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, EmptyBag => GHC.Base.return_ z
-              | k, z, UnitBag x => k x z
-              | k, z, TwoBags b1 b2 =>
-                  foldrBagM k z b2 GHC.Base.>>= (fun z' => foldrBagM k z' b1)
-              | k, z, ListBag xs => MonadUtils.foldrM k z xs
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, z, EmptyBag => GHC.Base.return_ z
+     | k, z, UnitBag x => k x z
+     | k, z, TwoBags b1 b2 =>
+         foldrBagM k z b2 GHC.Base.>>= (fun z' => foldrBagM k z' b1)
+     | k, z, ListBag xs => MonadUtils.foldrM k z xs
+     end.
 
 Fixpoint foldlBagM {m} {b} {a} `{(GHC.Base.Monad m)} (arg_0__ : (b -> a -> m b))
                    (arg_1__ : b) (arg_2__ : Bag a) : m b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, EmptyBag => GHC.Base.return_ z
-              | k, z, UnitBag x => k z x
-              | k, z, TwoBags b1 b2 =>
-                  foldlBagM k z b1 GHC.Base.>>= (fun z' => foldlBagM k z' b2)
-              | k, z, ListBag xs => MonadUtils.foldlM k z xs
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, z, EmptyBag => GHC.Base.return_ z
+     | k, z, UnitBag x => k z x
+     | k, z, TwoBags b1 b2 =>
+         foldlBagM k z b1 GHC.Base.>>= (fun z' => foldlBagM k z' b2)
+     | k, z, ListBag xs => MonadUtils.foldlM k z xs
+     end.
 
 Fixpoint concatMapBag {a} {b} (arg_0__ : (a -> Bag b)) (arg_1__ : Bag a) : Bag b
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => EmptyBag
-              | f, UnitBag x => f x
-              | f, TwoBags b1 b2 => unionBags (concatMapBag f b1) (concatMapBag f b2)
-              | f, ListBag xs => Data.Foldable.foldr (unionBags GHC.Base.∘ f) emptyBag xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => EmptyBag
+     | f, UnitBag x => f x
+     | f, TwoBags b1 b2 => unionBags (concatMapBag f b1) (concatMapBag f b2)
+     | f, ListBag xs => Data.Foldable.foldr (unionBags GHC.Base.∘ f) emptyBag xs
+     end.
 
 Fixpoint mapMaybeBag {a} {b} (arg_0__ : (a -> option b)) (arg_1__ : Bag a) : Bag
                                                                              b
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => EmptyBag
-              | f, UnitBag x => match f x with | None => EmptyBag | Some y => UnitBag y end
-              | f, TwoBags b1 b2 => unionBags (mapMaybeBag f b1) (mapMaybeBag f b2)
-              | f, ListBag xs => ListBag (Data.Maybe.mapMaybe f xs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => EmptyBag
+     | f, UnitBag x => match f x with | None => EmptyBag | Some y => UnitBag y end
+     | f, TwoBags b1 b2 => unionBags (mapMaybeBag f b1) (mapMaybeBag f b2)
+     | f, ListBag xs => ListBag (Data.Maybe.mapMaybe f xs)
+     end.
 
 Fixpoint mapBagM {m} {a} {b} `{GHC.Base.Monad m} (arg_0__ : (a -> m b)) (arg_1__
                    : Bag a) : m (Bag b)
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ EmptyBag
-              | f, UnitBag x => f x GHC.Base.>>= (fun r => GHC.Base.return_ (UnitBag r))
-              | f, TwoBags b1 b2 =>
-                  mapBagM f b1 GHC.Base.>>=
-                  (fun r1 =>
-                     mapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (TwoBags r1 r2)))
-              | f, ListBag xs =>
-                  Data.Traversable.mapM f xs GHC.Base.>>=
-                  (fun rs => GHC.Base.return_ (ListBag rs))
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => GHC.Base.return_ EmptyBag
+     | f, UnitBag x => f x GHC.Base.>>= (fun r => GHC.Base.return_ (UnitBag r))
+     | f, TwoBags b1 b2 =>
+         mapBagM f b1 GHC.Base.>>=
+         (fun r1 =>
+            mapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (TwoBags r1 r2)))
+     | f, ListBag xs =>
+         Data.Traversable.mapM f xs GHC.Base.>>=
+         (fun rs => GHC.Base.return_ (ListBag rs))
+     end.
 
 Fixpoint mapBagM_ {m} {a} {b} `{GHC.Base.Monad m} (arg_0__ : (a -> m b))
                   (arg_1__ : Bag a) : m unit
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ tt
-              | f, UnitBag x => f x GHC.Base.>> GHC.Base.return_ tt
-              | f, TwoBags b1 b2 => mapBagM_ f b1 GHC.Base.>> mapBagM_ f b2
-              | f, ListBag xs => Data.Foldable.mapM_ f xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => GHC.Base.return_ tt
+     | f, UnitBag x => f x GHC.Base.>> GHC.Base.return_ tt
+     | f, TwoBags b1 b2 => mapBagM_ f b1 GHC.Base.>> mapBagM_ f b2
+     | f, ListBag xs => Data.Foldable.mapM_ f xs
+     end.
 
 Fixpoint flatMapBagM {m} {a} {b} `{GHC.Base.Monad m} (arg_0__
                        : (a -> m (Bag b))) (arg_1__ : Bag a) : m (Bag b)
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ EmptyBag
-              | f, UnitBag x => f x
-              | f, TwoBags b1 b2 =>
-                  flatMapBagM f b1 GHC.Base.>>=
-                  (fun r1 =>
-                     flatMapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (unionBags r1 r2)))
-              | f, ListBag xs =>
-                  let k :=
-                    fun x b2 => f x GHC.Base.>>= (fun b1 => GHC.Base.return_ (unionBags b1 b2)) in
-                  MonadUtils.foldrM k EmptyBag xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => GHC.Base.return_ EmptyBag
+     | f, UnitBag x => f x
+     | f, TwoBags b1 b2 =>
+         flatMapBagM f b1 GHC.Base.>>=
+         (fun r1 =>
+            flatMapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (unionBags r1 r2)))
+     | f, ListBag xs =>
+         let k :=
+           fun x b2 => f x GHC.Base.>>= (fun b1 => GHC.Base.return_ (unionBags b1 b2)) in
+         MonadUtils.foldrM k EmptyBag xs
+     end.
 
 Fixpoint flatMapBagPairM {m} {a} {b} {c} `{GHC.Base.Monad m} (arg_0__
                            : (a -> m (Bag b * Bag c)%type)) (arg_1__ : Bag a) : m (Bag b * Bag c)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
-              | f, UnitBag x => f x
-              | f, TwoBags b1 b2 =>
-                  let cont_4__ arg_5__ :=
-                    let 'pair r1 s1 := arg_5__ in
-                    let cont_6__ arg_7__ :=
-                      let 'pair r2 s2 := arg_7__ in
-                      GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
-                    flatMapBagPairM f b2 GHC.Base.>>= cont_6__ in
-                  flatMapBagPairM f b1 GHC.Base.>>= cont_4__
-              | f, ListBag xs =>
-                  let k :=
-                    fun arg_9__ arg_10__ =>
-                      match arg_9__, arg_10__ with
-                      | x, pair r2 s2 =>
-                          let cont_11__ arg_12__ :=
-                            let 'pair r1 s1 := arg_12__ in
-                            GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
-                          f x GHC.Base.>>= cont_11__
-                      end in
-                  MonadUtils.foldrM k (pair EmptyBag EmptyBag) xs
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
+     | f, UnitBag x => f x
+     | f, TwoBags b1 b2 =>
+         let cont_4__ arg_5__ :=
+           let 'pair r1 s1 := arg_5__ in
+           let cont_6__ arg_7__ :=
+             let 'pair r2 s2 := arg_7__ in
+             GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
+           flatMapBagPairM f b2 GHC.Base.>>= cont_6__ in
+         flatMapBagPairM f b1 GHC.Base.>>= cont_4__
+     | f, ListBag xs =>
+         let k :=
+           fun arg_9__ arg_10__ =>
+             match arg_9__, arg_10__ with
+             | x, pair r2 s2 =>
+                 let cont_11__ arg_12__ :=
+                   let 'pair r1 s1 := arg_12__ in
+                   GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
+                 f x GHC.Base.>>= cont_11__
+             end in
+         MonadUtils.foldrM k (pair EmptyBag EmptyBag) xs
+     end.
 
 Fixpoint mapAndUnzipBagM {m} {a} {b} {c} `{GHC.Base.Monad m} (arg_0__
                            : (a -> m (b * c)%type)) (arg_1__ : Bag a) : m (Bag b * Bag c)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
-              | f, UnitBag x =>
-                  let cont_3__ arg_4__ :=
-                    let 'pair r s := arg_4__ in
-                    GHC.Base.return_ (pair (UnitBag r) (UnitBag s)) in
-                  f x GHC.Base.>>= cont_3__
-              | f, TwoBags b1 b2 =>
-                  let cont_6__ arg_7__ :=
-                    let 'pair r1 s1 := arg_7__ in
-                    let cont_8__ arg_9__ :=
-                      let 'pair r2 s2 := arg_9__ in
-                      GHC.Base.return_ (pair (TwoBags r1 r2) (TwoBags s1 s2)) in
-                    mapAndUnzipBagM f b2 GHC.Base.>>= cont_8__ in
-                  mapAndUnzipBagM f b1 GHC.Base.>>= cont_6__
-              | f, ListBag xs =>
-                  Data.Traversable.mapM f xs GHC.Base.>>=
-                  (fun ts =>
-                     let 'pair rs ss := GHC.List.unzip ts in
-                     GHC.Base.return_ (pair (ListBag rs) (ListBag ss)))
-              end.
+  := match arg_0__, arg_1__ with
+     | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
+     | f, UnitBag x =>
+         let cont_3__ arg_4__ :=
+           let 'pair r s := arg_4__ in
+           GHC.Base.return_ (pair (UnitBag r) (UnitBag s)) in
+         f x GHC.Base.>>= cont_3__
+     | f, TwoBags b1 b2 =>
+         let cont_6__ arg_7__ :=
+           let 'pair r1 s1 := arg_7__ in
+           let cont_8__ arg_9__ :=
+             let 'pair r2 s2 := arg_9__ in
+             GHC.Base.return_ (pair (TwoBags r1 r2) (TwoBags s1 s2)) in
+           mapAndUnzipBagM f b2 GHC.Base.>>= cont_8__ in
+         mapAndUnzipBagM f b1 GHC.Base.>>= cont_6__
+     | f, ListBag xs =>
+         Data.Traversable.mapM f xs GHC.Base.>>=
+         (fun ts =>
+            let 'pair rs ss := GHC.List.unzip ts in
+            GHC.Base.return_ (pair (ListBag rs) (ListBag ss)))
+     end.
 
 Fixpoint mapAccumBagL {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
                       (arg_1__ : acc) (arg_2__ : Bag x) : (acc * Bag y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, EmptyBag => pair s EmptyBag
-              | f, s, UnitBag x => let 'pair s1 x1 := f s x in pair s1 (UnitBag x1)
-              | f, s, TwoBags b1 b2 =>
-                  let 'pair s1 b1' := mapAccumBagL f s b1 in
-                  let 'pair s2 b2' := mapAccumBagL f s1 b2 in
-                  pair s2 (TwoBags b1' b2')
-              | f, s, ListBag xs =>
-                  let 'pair s' xs' := Data.Traversable.mapAccumL f s xs in
-                  pair s' (ListBag xs')
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, s, EmptyBag => pair s EmptyBag
+     | f, s, UnitBag x => let 'pair s1 x1 := f s x in pair s1 (UnitBag x1)
+     | f, s, TwoBags b1 b2 =>
+         let 'pair s1 b1' := mapAccumBagL f s b1 in
+         let 'pair s2 b2' := mapAccumBagL f s1 b2 in
+         pair s2 (TwoBags b1' b2')
+     | f, s, ListBag xs =>
+         let 'pair s' xs' := Data.Traversable.mapAccumL f s xs in
+         pair s' (ListBag xs')
+     end.
 
 Fixpoint mapAccumBagLM {m} {acc} {x} {y} `{GHC.Base.Monad m} (arg_0__
                          : (acc -> x -> m (acc * y)%type)) (arg_1__ : acc) (arg_2__ : Bag x) : m (acc *
                                                                                                   Bag y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, EmptyBag => GHC.Base.return_ (pair s EmptyBag)
-              | f, s, UnitBag x =>
-                  let cont_4__ arg_5__ :=
-                    let 'pair s1 x1 := arg_5__ in
-                    GHC.Base.return_ (pair s1 (UnitBag x1)) in
-                  f s x GHC.Base.>>= cont_4__
-              | f, s, TwoBags b1 b2 =>
-                  let cont_7__ arg_8__ :=
-                    let 'pair s1 b1' := arg_8__ in
-                    let cont_9__ arg_10__ :=
-                      let 'pair s2 b2' := arg_10__ in
-                      GHC.Base.return_ (pair s2 (TwoBags b1' b2')) in
-                    mapAccumBagLM f s1 b2 GHC.Base.>>= cont_9__ in
-                  mapAccumBagLM f s b1 GHC.Base.>>= cont_7__
-              | f, s, ListBag xs =>
-                  let cont_12__ arg_13__ :=
-                    let 'pair s' xs' := arg_13__ in
-                    GHC.Base.return_ (pair s' (ListBag xs')) in
-                  MonadUtils.mapAccumLM f s xs GHC.Base.>>= cont_12__
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, s, EmptyBag => GHC.Base.return_ (pair s EmptyBag)
+     | f, s, UnitBag x =>
+         let cont_4__ arg_5__ :=
+           let 'pair s1 x1 := arg_5__ in
+           GHC.Base.return_ (pair s1 (UnitBag x1)) in
+         f s x GHC.Base.>>= cont_4__
+     | f, s, TwoBags b1 b2 =>
+         let cont_7__ arg_8__ :=
+           let 'pair s1 b1' := arg_8__ in
+           let cont_9__ arg_10__ :=
+             let 'pair s2 b2' := arg_10__ in
+             GHC.Base.return_ (pair s2 (TwoBags b1' b2')) in
+           mapAccumBagLM f s1 b2 GHC.Base.>>= cont_9__ in
+         mapAccumBagLM f s b1 GHC.Base.>>= cont_7__
+     | f, s, ListBag xs =>
+         let cont_12__ arg_13__ :=
+           let 'pair s' xs' := arg_13__ in
+           GHC.Base.return_ (pair s' (ListBag xs')) in
+         MonadUtils.mapAccumLM f s xs GHC.Base.>>= cont_12__
+     end.
 
 Definition bagToList {a} : Bag a -> list a :=
   fun b => foldrBag cons nil b.

--- a/examples/ghc/lib/BasicTypes.v
+++ b/examples/ghc/lib/BasicTypes.v
@@ -30,44 +30,44 @@ Import GHC.Num.Notations.
 Definition Version :=
   GHC.Num.Int%type.
 
-Inductive TyPrec : Type
-  := | TopPrec : TyPrec
-  |  FunPrec : TyPrec
-  |  TyOpPrec : TyPrec
-  |  TyConPrec : TyPrec.
+Inductive TyPrec : Type :=
+  | TopPrec : TyPrec
+  | FunPrec : TyPrec
+  | TyOpPrec : TyPrec
+  | TyConPrec : TyPrec.
 
-Inductive TupleSort : Type
-  := | BoxedTuple : TupleSort
-  |  UnboxedTuple : TupleSort
-  |  ConstraintTuple : TupleSort.
+Inductive TupleSort : Type :=
+  | BoxedTuple : TupleSort
+  | UnboxedTuple : TupleSort
+  | ConstraintTuple : TupleSort.
 
-Inductive TopLevelFlag : Type
-  := | TopLevel : TopLevelFlag
-  |  NotTopLevel : TopLevelFlag.
+Inductive TopLevelFlag : Type :=
+  | TopLevel : TopLevelFlag
+  | NotTopLevel : TopLevelFlag.
 
-Inductive SwapFlag : Type := | NotSwapped : SwapFlag |  IsSwapped : SwapFlag.
+Inductive SwapFlag : Type := | NotSwapped : SwapFlag | IsSwapped : SwapFlag.
 
-Inductive SuccessFlag : Type
-  := | Succeeded : SuccessFlag
-  |  Failed : SuccessFlag.
+Inductive SuccessFlag : Type :=
+  | Succeeded : SuccessFlag
+  | Failed : SuccessFlag.
 
-Inductive SpliceExplicitFlag : Type
-  := | ExplicitSplice : SpliceExplicitFlag
-  |  ImplicitSplice : SpliceExplicitFlag.
+Inductive SpliceExplicitFlag : Type :=
+  | ExplicitSplice : SpliceExplicitFlag
+  | ImplicitSplice : SpliceExplicitFlag.
 
-Inductive SourceText : Type
-  := | Mk_SourceText : GHC.Base.String -> SourceText
-  |  NoSourceText : SourceText.
+Inductive SourceText : Type :=
+  | Mk_SourceText : GHC.Base.String -> SourceText
+  | NoSourceText : SourceText.
 
-Inductive StringLiteral : Type
-  := | Mk_StringLiteral (sl_st : SourceText) (sl_fs : FastString.FastString)
+Inductive StringLiteral : Type :=
+  | Mk_StringLiteral (sl_st : SourceText) (sl_fs : FastString.FastString)
    : StringLiteral.
 
-Inductive WarningTxt : Type
-  := | Mk_WarningTxt
+Inductive WarningTxt : Type :=
+  | Mk_WarningTxt
    : (SrcLoc.Located SourceText) ->
      list (SrcLoc.Located StringLiteral) -> WarningTxt
-  |  DeprecatedTxt
+  | DeprecatedTxt
    : (SrcLoc.Located SourceText) ->
      list (SrcLoc.Located StringLiteral) -> WarningTxt.
 
@@ -77,106 +77,106 @@ Definition RulesOnly :=
 Definition RuleName :=
   FastString.FastString%type.
 
-Inductive RuleMatchInfo : Type
-  := | ConLike : RuleMatchInfo
-  |  FunLike : RuleMatchInfo.
+Inductive RuleMatchInfo : Type :=
+  | ConLike : RuleMatchInfo
+  | FunLike : RuleMatchInfo.
 
 Definition RepArity :=
   nat.
 
-Inductive RecFlag : Type := | Recursive : RecFlag |  NonRecursive : RecFlag.
+Inductive RecFlag : Type := | Recursive : RecFlag | NonRecursive : RecFlag.
 
 Definition PhaseNum :=
   nat.
 
-Inductive OverlapMode : Type
-  := | NoOverlap : SourceText -> OverlapMode
-  |  Overlappable : SourceText -> OverlapMode
-  |  Overlapping : SourceText -> OverlapMode
-  |  Overlaps : SourceText -> OverlapMode
-  |  Incoherent : SourceText -> OverlapMode.
+Inductive OverlapMode : Type :=
+  | NoOverlap : SourceText -> OverlapMode
+  | Overlappable : SourceText -> OverlapMode
+  | Overlapping : SourceText -> OverlapMode
+  | Overlaps : SourceText -> OverlapMode
+  | Incoherent : SourceText -> OverlapMode.
 
-Inductive OverlapFlag : Type
-  := | Mk_OverlapFlag (overlapMode : OverlapMode) (isSafeOverlap : bool)
+Inductive OverlapFlag : Type :=
+  | Mk_OverlapFlag (overlapMode : OverlapMode) (isSafeOverlap : bool)
    : OverlapFlag.
 
-Inductive Origin : Type := | FromSource : Origin |  Generated : Origin.
+Inductive Origin : Type := | FromSource : Origin | Generated : Origin.
 
-Inductive OneShotInfo : Type
-  := | NoOneShotInfo : OneShotInfo
-  |  OneShotLam : OneShotInfo.
+Inductive OneShotInfo : Type :=
+  | NoOneShotInfo : OneShotInfo
+  | OneShotLam : OneShotInfo.
 
 Definition OneBranch :=
   bool%type.
 
-Inductive LexicalFixity : Type
-  := | Prefix : LexicalFixity
-  |  Infix : LexicalFixity.
+Inductive LexicalFixity : Type :=
+  | Prefix : LexicalFixity
+  | Infix : LexicalFixity.
 
-Inductive LeftOrRight : Type := | CLeft : LeftOrRight |  CRight : LeftOrRight.
+Inductive LeftOrRight : Type := | CLeft : LeftOrRight | CRight : LeftOrRight.
 
 Definition JoinArity :=
   nat.
 
-Inductive TailCallInfo : Type
-  := | AlwaysTailCalled : JoinArity -> TailCallInfo
-  |  NoTailCallInfo : TailCallInfo.
+Inductive TailCallInfo : Type :=
+  | AlwaysTailCalled : JoinArity -> TailCallInfo
+  | NoTailCallInfo : TailCallInfo.
 
 Definition InterestingCxt :=
   bool%type.
 
-Inductive IntegralLit : Type
-  := | IL (il_text : SourceText) (il_neg : bool) (il_value : GHC.Num.Integer)
+Inductive IntegralLit : Type :=
+  | IL (il_text : SourceText) (il_neg : bool) (il_value : GHC.Num.Integer)
    : IntegralLit.
 
-Inductive IntWithInf : Type
-  := | Int : GHC.Num.Int -> IntWithInf
-  |  Infinity : IntWithInf.
+Inductive IntWithInf : Type :=
+  | Int : GHC.Num.Int -> IntWithInf
+  | Infinity : IntWithInf.
 
 Definition InsideLam :=
   bool%type.
 
-Inductive OccInfo : Type
-  := | ManyOccs (occ_tail : TailCallInfo) : OccInfo
-  |  IAmDead : OccInfo
-  |  OneOcc (occ_in_lam : InsideLam) (occ_one_br : OneBranch) (occ_int_cxt
+Inductive OccInfo : Type :=
+  | ManyOccs (occ_tail : TailCallInfo) : OccInfo
+  | IAmDead : OccInfo
+  | OneOcc (occ_in_lam : InsideLam) (occ_one_br : OneBranch) (occ_int_cxt
     : InterestingCxt) (occ_tail : TailCallInfo)
    : OccInfo
-  |  IAmALoopBreaker (occ_rules_only : RulesOnly) (occ_tail : TailCallInfo)
+  | IAmALoopBreaker (occ_rules_only : RulesOnly) (occ_tail : TailCallInfo)
    : OccInfo.
 
-Inductive InlineSpec : Type
-  := | Inline : InlineSpec
-  |  Inlinable : InlineSpec
-  |  NoInline : InlineSpec
-  |  NoUserInline : InlineSpec.
+Inductive InlineSpec : Type :=
+  | Inline : InlineSpec
+  | Inlinable : InlineSpec
+  | NoInline : InlineSpec
+  | NoUserInline : InlineSpec.
 
-Inductive FunctionOrData : Type
-  := | IsFunction : FunctionOrData
-  |  IsData : FunctionOrData.
+Inductive FunctionOrData : Type :=
+  | IsFunction : FunctionOrData
+  | IsData : FunctionOrData.
 
-Inductive FractionalLit : Type
-  := | FL (fl_text : SourceText) (fl_neg : bool) (fl_value : GHC.Real.Rational)
+Inductive FractionalLit : Type :=
+  | FL (fl_text : SourceText) (fl_neg : bool) (fl_value : GHC.Real.Rational)
    : FractionalLit.
 
-Inductive FixityDirection : Type
-  := | InfixL : FixityDirection
-  |  InfixR : FixityDirection
-  |  InfixN : FixityDirection.
+Inductive FixityDirection : Type :=
+  | InfixL : FixityDirection
+  | InfixR : FixityDirection
+  | InfixN : FixityDirection.
 
-Inductive Fixity : Type
-  := | Mk_Fixity : SourceText -> GHC.Num.Int -> FixityDirection -> Fixity.
+Inductive Fixity : Type :=
+  | Mk_Fixity : SourceText -> GHC.Num.Int -> FixityDirection -> Fixity.
 
 Inductive EP a : Type := | Mk_EP (fromEP : a) (toEP : a) : EP a.
 
-Inductive DerivStrategy : Type
-  := | StockStrategy : DerivStrategy
-  |  AnyclassStrategy : DerivStrategy
-  |  NewtypeStrategy : DerivStrategy.
+Inductive DerivStrategy : Type :=
+  | StockStrategy : DerivStrategy
+  | AnyclassStrategy : DerivStrategy
+  | NewtypeStrategy : DerivStrategy.
 
-Inductive DefMethSpec ty : Type
-  := | VanillaDM : DefMethSpec ty
-  |  GenericDM : ty -> DefMethSpec ty.
+Inductive DefMethSpec ty : Type :=
+  | VanillaDM : DefMethSpec ty
+  | GenericDM : ty -> DefMethSpec ty.
 
 Definition ConTagZ :=
   GHC.Num.Int%type.
@@ -184,11 +184,11 @@ Definition ConTagZ :=
 Definition ConTag :=
   GHC.Num.Int%type.
 
-Inductive CompilerPhase : Type
-  := | Phase : PhaseNum -> CompilerPhase
-  |  InitialPhase : CompilerPhase.
+Inductive CompilerPhase : Type :=
+  | Phase : PhaseNum -> CompilerPhase
+  | InitialPhase : CompilerPhase.
 
-Inductive Boxity : Type := | Boxed : Boxity |  Unboxed : Boxity.
+Inductive Boxity : Type := | Boxed : Boxity | Unboxed : Boxity.
 
 Definition Arity :=
   nat.
@@ -196,14 +196,14 @@ Definition Arity :=
 Definition Alignment :=
   GHC.Num.Int%type.
 
-Inductive Activation : Type
-  := | NeverActive : Activation
-  |  AlwaysActive : Activation
-  |  ActiveBefore : SourceText -> PhaseNum -> Activation
-  |  ActiveAfter : SourceText -> PhaseNum -> Activation.
+Inductive Activation : Type :=
+  | NeverActive : Activation
+  | AlwaysActive : Activation
+  | ActiveBefore : SourceText -> PhaseNum -> Activation
+  | ActiveAfter : SourceText -> PhaseNum -> Activation.
 
-Inductive InlinePragma : Type
-  := | Mk_InlinePragma (inl_src : SourceText) (inl_inline : InlineSpec) (inl_sat
+Inductive InlinePragma : Type :=
+  | Mk_InlinePragma (inl_src : SourceText) (inl_inline : InlineSpec) (inl_sat
     : option Arity) (inl_act : Activation) (inl_rule : RuleMatchInfo)
    : InlinePragma.
 

--- a/examples/ghc/lib/BooleanFormula.v
+++ b/examples/ghc/lib/BooleanFormula.v
@@ -31,23 +31,23 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive BooleanFormula a : Type
-  := | Var : a -> BooleanFormula a
-  |  And
+Inductive BooleanFormula a : Type :=
+  | Var : a -> BooleanFormula a
+  | And
    : list ((fun a_ => (SrcLoc.Located (BooleanFormula a_))%type) a) ->
      BooleanFormula a
-  |  Or
+  | Or
    : list ((fun a_ => (SrcLoc.Located (BooleanFormula a_))%type) a) ->
      BooleanFormula a
-  |  Parens
+  | Parens
    : ((fun a_ => (SrcLoc.Located (BooleanFormula a_))%type) a) ->
      BooleanFormula a.
 
 Definition LBooleanFormula :=
   fun a_ => (SrcLoc.Located (BooleanFormula a_))%type.
 
-Inductive Clause a : Type
-  := | Mk_Clause (clauseAtoms : UniqSet.UniqSet a) (clauseExprs
+Inductive Clause a : Type :=
+  | Mk_Clause (clauseAtoms : UniqSet.UniqSet a) (clauseExprs
     : list (BooleanFormula a))
    : Clause a.
 
@@ -211,15 +211,15 @@ Local Definition Functor__BooleanFormula_fmap {a} {b}
 
 Fixpoint Functor__BooleanFormula_op_zlzd__ {a} {b} (arg_0__ : a) (arg_1__
                                              : BooleanFormula b) : BooleanFormula a
-           := match arg_0__, arg_1__ with
-              | z, Var a1 => Var ((fun b1 => z) a1)
-              | z, And a1 =>
-                  And (GHC.Base.fmap (GHC.Base.fmap (Functor__BooleanFormula_op_zlzd__ z)) a1)
-              | z, Or a1 =>
-                  Or (GHC.Base.fmap (GHC.Base.fmap (Functor__BooleanFormula_op_zlzd__ z)) a1)
-              | z, Parens a1 =>
-                  Parens (GHC.Base.fmap (Functor__BooleanFormula_op_zlzd__ z) a1)
-              end.
+  := match arg_0__, arg_1__ with
+     | z, Var a1 => Var ((fun b1 => z) a1)
+     | z, And a1 =>
+         And (GHC.Base.fmap (GHC.Base.fmap (Functor__BooleanFormula_op_zlzd__ z)) a1)
+     | z, Or a1 =>
+         Or (GHC.Base.fmap (GHC.Base.fmap (Functor__BooleanFormula_op_zlzd__ z)) a1)
+     | z, Parens a1 =>
+         Parens (GHC.Base.fmap (Functor__BooleanFormula_op_zlzd__ z) a1)
+     end.
 
 Program Instance Functor__BooleanFormula : GHC.Base.Functor BooleanFormula :=
   fun _ k__ =>
@@ -271,14 +271,14 @@ Local Definition Foldable__BooleanFormula_length
                                        end) #0.
 
 Fixpoint Foldable__BooleanFormula_null {a} (arg_0__ : BooleanFormula a) : bool
-           := match arg_0__ with
-              | Var _ => false
-              | And a1 =>
-                  Data.Foldable.all (Data.Foldable.all Foldable__BooleanFormula_null) a1
-              | Or a1 =>
-                  Data.Foldable.all (Data.Foldable.all Foldable__BooleanFormula_null) a1
-              | Parens a1 => Data.Foldable.all Foldable__BooleanFormula_null a1
-              end.
+  := match arg_0__ with
+     | Var _ => false
+     | And a1 =>
+         Data.Foldable.all (Data.Foldable.all Foldable__BooleanFormula_null) a1
+     | Or a1 =>
+         Data.Foldable.all (Data.Foldable.all Foldable__BooleanFormula_null) a1
+     | Parens a1 => Data.Foldable.all Foldable__BooleanFormula_null a1
+     end.
 
 Local Definition Foldable__BooleanFormula_product
    : forall {a}, forall `{GHC.Num.Num a}, BooleanFormula a -> a :=
@@ -413,23 +413,23 @@ Definition isTrue {a} : BooleanFormula a -> bool :=
   fun arg_0__ => match arg_0__ with | And nil => true | _ => false end.
 
 Fixpoint eval {a} (arg_0__ : (a -> bool)) (arg_1__ : BooleanFormula a) : bool
-           := match arg_0__, arg_1__ with
-              | f, Var x => f x
-              | f, And xs => Data.Foldable.all (eval f GHC.Base.∘ SrcLoc.unLoc) xs
-              | f, Or xs => Data.Foldable.any (eval f GHC.Base.∘ SrcLoc.unLoc) xs
-              | f, Parens x => eval f (SrcLoc.unLoc x)
-              end.
+  := match arg_0__, arg_1__ with
+     | f, Var x => f x
+     | f, And xs => Data.Foldable.all (eval f GHC.Base.∘ SrcLoc.unLoc) xs
+     | f, Or xs => Data.Foldable.any (eval f GHC.Base.∘ SrcLoc.unLoc) xs
+     | f, Parens x => eval f (SrcLoc.unLoc x)
+     end.
 
 Fixpoint simplify {a} `{GHC.Base.Eq_ a} (arg_0__ : (a -> option bool)) (arg_1__
                     : BooleanFormula a) : BooleanFormula a
-           := match arg_0__, arg_1__ with
-              | f, Var a => match f a with | None => Var a | Some b => mkBool b end
-              | f, And xs =>
-                  mkAnd (GHC.Base.map (fun '(SrcLoc.L l x) => SrcLoc.L l (simplify f x)) xs)
-              | f, Or xs =>
-                  mkOr (GHC.Base.map (fun '(SrcLoc.L l x) => SrcLoc.L l (simplify f x)) xs)
-              | f, Parens x => simplify f (SrcLoc.unLoc x)
-              end.
+  := match arg_0__, arg_1__ with
+     | f, Var a => match f a with | None => Var a | Some b => mkBool b end
+     | f, And xs =>
+         mkAnd (GHC.Base.map (fun '(SrcLoc.L l x) => SrcLoc.L l (simplify f x)) xs)
+     | f, Or xs =>
+         mkOr (GHC.Base.map (fun '(SrcLoc.L l x) => SrcLoc.L l (simplify f x)) xs)
+     | f, Parens x => simplify f (SrcLoc.unLoc x)
+     end.
 
 Definition isUnsatisfied {a} `{GHC.Base.Eq_ a}
    : (a -> bool) -> BooleanFormula a -> option (BooleanFormula a) :=
@@ -439,12 +439,12 @@ Definition isUnsatisfied {a} `{GHC.Base.Eq_ a}
 
 Fixpoint impliesAtom {a} `{GHC.Base.Eq_ a} (arg_0__ : BooleanFormula a) (arg_1__
                        : a) : bool
-           := match arg_0__, arg_1__ with
-              | Var x, y => x GHC.Base.== y
-              | And xs, y => Data.Foldable.any (fun x => impliesAtom (SrcLoc.unLoc x) y) xs
-              | Or xs, y => Data.Foldable.all (fun x => impliesAtom (SrcLoc.unLoc x) y) xs
-              | Parens x, y => impliesAtom (SrcLoc.unLoc x) y
-              end.
+  := match arg_0__, arg_1__ with
+     | Var x, y => x GHC.Base.== y
+     | And xs, y => Data.Foldable.any (fun x => impliesAtom (SrcLoc.unLoc x) y) xs
+     | Or xs, y => Data.Foldable.all (fun x => impliesAtom (SrcLoc.unLoc x) y) xs
+     | Parens x, y => impliesAtom (SrcLoc.unLoc x) y
+     end.
 
 Definition extendClauseAtoms {a} `{Unique.Uniquable a}
    : Clause a -> a -> Clause a :=

--- a/examples/ghc/lib/CoAxiom.v
+++ b/examples/ghc/lib/CoAxiom.v
@@ -30,9 +30,9 @@ Definition TypeEqn :=
 
 Axiom Branches : Type -> Type.
 
-Inductive BranchFlag : Type
-  := | Branched : BranchFlag
-  |  Unbranched : BranchFlag.
+Inductive BranchFlag : Type :=
+  | Branched : BranchFlag
+  | Unbranched : BranchFlag.
 
 Instance Default__BranchFlag : GHC.Err.Default BranchFlag :=
   GHC.Err.Build_Default _ Branched.

--- a/examples/ghc/lib/ConLike.v
+++ b/examples/ghc/lib/ConLike.v
@@ -22,9 +22,9 @@ Require Unique.
 
 (* Converted type declarations: *)
 
-Inductive ConLike : Type
-  := | RealDataCon : Core.DataCon -> ConLike
-  |  PatSynCon : Core.PatSyn -> ConLike.
+Inductive ConLike : Type :=
+  | RealDataCon : Core.DataCon -> ConLike
+  | PatSynCon : Core.PatSyn -> ConLike.
 
 (* Converted value declarations: *)
 

--- a/examples/ghc/lib/Core.v
+++ b/examples/ghc/lib/Core.v
@@ -61,58 +61,58 @@ Import GHC.Num.Notations.
 Definition VarEnv :=
   UniqFM.UniqFM%type.
 
-Inductive UnfoldingSource : Type
-  := | InlineRhs : UnfoldingSource
-  |  InlineStable : UnfoldingSource
-  |  InlineCompulsory : UnfoldingSource.
+Inductive UnfoldingSource : Type :=
+  | InlineRhs : UnfoldingSource
+  | InlineStable : UnfoldingSource
+  | InlineCompulsory : UnfoldingSource.
 
-Inductive UnfoldingGuidance : Type
-  := | UnfWhen (ug_arity : BasicTypes.Arity) (ug_unsat_ok : bool) (ug_boring_ok
+Inductive UnfoldingGuidance : Type :=
+  | UnfWhen (ug_arity : BasicTypes.Arity) (ug_unsat_ok : bool) (ug_boring_ok
     : bool)
    : UnfoldingGuidance
-  |  UnfIfGoodArgs (ug_args : list nat) (ug_size : nat) (ug_res : nat)
+  | UnfIfGoodArgs (ug_args : list nat) (ug_size : nat) (ug_res : nat)
    : UnfoldingGuidance
-  |  UnfNever : UnfoldingGuidance.
+  | UnfNever : UnfoldingGuidance.
 
 Inductive Unfolding : Type := | NoUnfolding : Unfolding.
 
-Inductive TypeShape : Type
-  := | TsFun : TypeShape -> TypeShape
-  |  TsProd : list TypeShape -> TypeShape
-  |  TsUnk : TypeShape.
+Inductive TypeShape : Type :=
+  | TsFun : TypeShape -> TypeShape
+  | TsProd : list TypeShape -> TypeShape
+  | TsUnk : TypeShape.
 
-Inductive TypeOrdering : Type
-  := | TLT : TypeOrdering
-  |  TEQ : TypeOrdering
-  |  TEQX : TypeOrdering
-  |  TGT : TypeOrdering.
+Inductive TypeOrdering : Type :=
+  | TLT : TypeOrdering
+  | TEQ : TypeOrdering
+  | TEQX : TypeOrdering
+  | TGT : TypeOrdering.
 
 Definition TyVarEnv :=
   VarEnv%type.
 
-Inductive TyVarBndr tyvar argf : Type
-  := | TvBndr : tyvar -> argf -> TyVarBndr tyvar argf.
+Inductive TyVarBndr tyvar argf : Type :=
+  | TvBndr : tyvar -> argf -> TyVarBndr tyvar argf.
 
-Inductive TyLit : Type
-  := | NumTyLit : GHC.Num.Integer -> TyLit
-  |  StrTyLit : FastString.FastString -> TyLit.
+Inductive TyLit : Type :=
+  | NumTyLit : GHC.Num.Integer -> TyLit
+  | StrTyLit : FastString.FastString -> TyLit.
 
 Definition TyConRepName :=
   Name.Name%type.
 
-Inductive TyConFlavour : Type
-  := | ClassFlavour : TyConFlavour
-  |  TupleFlavour : BasicTypes.Boxity -> TyConFlavour
-  |  SumFlavour : TyConFlavour
-  |  DataTypeFlavour : TyConFlavour
-  |  NewtypeFlavour : TyConFlavour
-  |  AbstractTypeFlavour : TyConFlavour
-  |  DataFamilyFlavour : TyConFlavour
-  |  OpenTypeFamilyFlavour : TyConFlavour
-  |  ClosedTypeFamilyFlavour : TyConFlavour
-  |  TypeSynonymFlavour : TyConFlavour
-  |  BuiltInTypeFlavour : TyConFlavour
-  |  PromotedDataConFlavour : TyConFlavour.
+Inductive TyConFlavour : Type :=
+  | ClassFlavour : TyConFlavour
+  | TupleFlavour : BasicTypes.Boxity -> TyConFlavour
+  | SumFlavour : TyConFlavour
+  | DataTypeFlavour : TyConFlavour
+  | NewtypeFlavour : TyConFlavour
+  | AbstractTypeFlavour : TyConFlavour
+  | DataFamilyFlavour : TyConFlavour
+  | OpenTypeFamilyFlavour : TyConFlavour
+  | ClosedTypeFamilyFlavour : TyConFlavour
+  | TypeSynonymFlavour : TyConFlavour
+  | BuiltInTypeFlavour : TyConFlavour
+  | PromotedDataConFlavour : TyConFlavour.
 
 Definition TyCoVarEnv :=
   VarEnv%type.
@@ -120,85 +120,85 @@ Definition TyCoVarEnv :=
 Definition TvSubstEnv :=
   (TyVarEnv Type_)%type.
 
-Inductive TickishScoping : Type
-  := | NoScope : TickishScoping
-  |  SoftScope : TickishScoping
-  |  CostCentreScope : TickishScoping.
+Inductive TickishScoping : Type :=
+  | NoScope : TickishScoping
+  | SoftScope : TickishScoping
+  | CostCentreScope : TickishScoping.
 
-Inductive TickishPlacement : Type
-  := | PlaceRuntime : TickishPlacement
-  |  PlaceNonLam : TickishPlacement
-  |  PlaceCostCentre : TickishPlacement.
+Inductive TickishPlacement : Type :=
+  | PlaceRuntime : TickishPlacement
+  | PlaceNonLam : TickishPlacement
+  | PlaceCostCentre : TickishPlacement.
 
-Inductive Tickish id : Type
-  := | ProfNote (profNoteCC : CostCentre) (profNoteCount : bool) (profNoteScope
+Inductive Tickish id : Type :=
+  | ProfNote (profNoteCC : CostCentre) (profNoteCount : bool) (profNoteScope
     : bool)
    : Tickish id
-  |  HpcTick (tickModule : Module.Module) (tickId : nat) : Tickish id
-  |  Breakpoint (breakpointId : nat) (breakpointFVs : list id) : Tickish id
-  |  SourceNote (sourceSpan : SrcLoc.RealSrcSpan) (sourceName : GHC.Base.String)
+  | HpcTick (tickModule : Module.Module) (tickId : nat) : Tickish id
+  | Breakpoint (breakpointId : nat) (breakpointFVs : list id) : Tickish id
+  | SourceNote (sourceSpan : SrcLoc.RealSrcSpan) (sourceName : GHC.Base.String)
    : Tickish id.
 
 Definition TickBoxId :=
   nat%type.
 
-Inductive TickBoxOp : Type
-  := | TickBox : Module.Module -> TickBoxId -> TickBoxOp.
+Inductive TickBoxOp : Type :=
+  | TickBox : Module.Module -> TickBoxId -> TickBoxOp.
 
-Inductive Termination r : Type
-  := | Diverges : Termination r
-  |  ThrowsExn : Termination r
-  |  Dunno : r -> Termination r.
+Inductive Termination r : Type :=
+  | Diverges : Termination r
+  | ThrowsExn : Termination r
+  | Dunno : r -> Termination r.
 
-Inductive StrictnessMark : Type
-  := | MarkedStrict : StrictnessMark
-  |  NotMarkedStrict : StrictnessMark.
+Inductive StrictnessMark : Type :=
+  | MarkedStrict : StrictnessMark
+  | NotMarkedStrict : StrictnessMark.
 
-Inductive SrcUnpackedness : Type
-  := | SrcUnpack : SrcUnpackedness
-  |  SrcNoUnpack : SrcUnpackedness
-  |  NoSrcUnpack : SrcUnpackedness.
+Inductive SrcUnpackedness : Type :=
+  | SrcUnpack : SrcUnpackedness
+  | SrcNoUnpack : SrcUnpackedness
+  | NoSrcUnpack : SrcUnpackedness.
 
-Inductive SrcStrictness : Type
-  := | SrcLazy : SrcStrictness
-  |  SrcStrict : SrcStrictness
-  |  NoSrcStrict : SrcStrictness.
+Inductive SrcStrictness : Type :=
+  | SrcLazy : SrcStrictness
+  | SrcStrict : SrcStrictness
+  | NoSrcStrict : SrcStrictness.
 
 Inductive RuleInfo : Type := | EmptyRuleInfo.
 
-Inductive RecTcChecker : Type
-  := | RC : nat -> (NameEnv.NameEnv nat) -> RecTcChecker.
+Inductive RecTcChecker : Type :=
+  | RC : nat -> (NameEnv.NameEnv nat) -> RecTcChecker.
 
-Inductive PrimElemRep : Type
-  := | Int8ElemRep : PrimElemRep
-  |  Int16ElemRep : PrimElemRep
-  |  Int32ElemRep : PrimElemRep
-  |  Int64ElemRep : PrimElemRep
-  |  Word8ElemRep : PrimElemRep
-  |  Word16ElemRep : PrimElemRep
-  |  Word32ElemRep : PrimElemRep
-  |  Word64ElemRep : PrimElemRep
-  |  FloatElemRep : PrimElemRep
-  |  DoubleElemRep : PrimElemRep.
+Inductive PrimElemRep : Type :=
+  | Int8ElemRep : PrimElemRep
+  | Int16ElemRep : PrimElemRep
+  | Int32ElemRep : PrimElemRep
+  | Int64ElemRep : PrimElemRep
+  | Word8ElemRep : PrimElemRep
+  | Word16ElemRep : PrimElemRep
+  | Word32ElemRep : PrimElemRep
+  | Word64ElemRep : PrimElemRep
+  | FloatElemRep : PrimElemRep
+  | DoubleElemRep : PrimElemRep.
 
-Inductive PrimRep : Type
-  := | VoidRep : PrimRep
-  |  LiftedRep : PrimRep
-  |  UnliftedRep : PrimRep
-  |  IntRep : PrimRep
-  |  WordRep : PrimRep
-  |  Int64Rep : PrimRep
-  |  Word64Rep : PrimRep
-  |  AddrRep : PrimRep
-  |  FloatRep : PrimRep
-  |  DoubleRep : PrimRep
-  |  VecRep : nat -> PrimElemRep -> PrimRep.
+Inductive PrimRep : Type :=
+  | VoidRep : PrimRep
+  | LiftedRep : PrimRep
+  | UnliftedRep : PrimRep
+  | IntRep : PrimRep
+  | WordRep : PrimRep
+  | Int64Rep : PrimRep
+  | Word64Rep : PrimRep
+  | AddrRep : PrimRep
+  | FloatRep : PrimRep
+  | DoubleRep : PrimRep
+  | VecRep : nat -> PrimElemRep -> PrimRep.
 
-Inductive RuntimeRepInfo : Type
-  := | NoRRI : RuntimeRepInfo
-  |  RuntimeRep : (list Type_ -> list PrimRep) -> RuntimeRepInfo
-  |  VecCount : nat -> RuntimeRepInfo
-  |  VecElem : PrimElemRep -> RuntimeRepInfo.
+Inductive RuntimeRepInfo : Type :=
+  | NoRRI : RuntimeRepInfo
+  | RuntimeRep : (list Type_ -> list PrimRep) -> RuntimeRepInfo
+  | VecCount : nat -> RuntimeRepInfo
+  | VecElem : PrimElemRep -> RuntimeRepInfo.
 
 Definition OutType :=
   Type_%type.
@@ -209,37 +209,37 @@ Definition OutKind :=
 Definition OutCoercion :=
   Coercion%type.
 
-Inductive NormaliseStepResult ev : Type
-  := | NS_Done : NormaliseStepResult ev
-  |  NS_Abort : NormaliseStepResult ev
-  |  NS_Step : RecTcChecker -> Type_ -> ev -> NormaliseStepResult ev.
+Inductive NormaliseStepResult ev : Type :=
+  | NS_Done : NormaliseStepResult ev
+  | NS_Abort : NormaliseStepResult ev
+  | NS_Step : RecTcChecker -> Type_ -> ev -> NormaliseStepResult ev.
 
 Definition LiftCoEnv :=
   (VarEnv Coercion)%type.
 
-Inductive LevityInfo : Type
-  := | NoLevityInfo : LevityInfo
-  |  NeverLevityPolymorphic : LevityInfo.
+Inductive LevityInfo : Type :=
+  | NoLevityInfo : LevityInfo
+  | NeverLevityPolymorphic : LevityInfo.
 
 Definition KindOrType :=
   Type_%type.
 
-Inductive KillFlags : Type
-  := | Mk_KillFlags (kf_abs : bool) (kf_used_once : bool) (kf_called_once : bool)
+Inductive KillFlags : Type :=
+  | Mk_KillFlags (kf_abs : bool) (kf_used_once : bool) (kf_called_once : bool)
    : KillFlags.
 
 Inductive JointDmd s u : Type := | JD (sd : s) (ud : u) : JointDmd s u.
 
-Inductive IsOrphan : Type
-  := | Mk_IsOrphan : IsOrphan
-  |  NotOrphan : OccName.OccName -> IsOrphan.
+Inductive IsOrphan : Type :=
+  | Mk_IsOrphan : IsOrphan
+  | NotOrphan : OccName.OccName -> IsOrphan.
 
 Definition InlinePragInfo :=
   BasicTypes.InlinePragma%type.
 
-Inductive Injectivity : Type
-  := | NotInjective : Injectivity
-  |  Injective : list bool -> Injectivity.
+Inductive Injectivity : Type :=
+  | NotInjective : Injectivity
+  | Injective : list bool -> Injectivity.
 
 Definition InType :=
   Type_%type.
@@ -253,38 +253,38 @@ Definition InCoercion :=
 Definition IdEnv :=
   VarEnv%type.
 
-Inductive HsSrcBang : Type
-  := | Mk_HsSrcBang
+Inductive HsSrcBang : Type :=
+  | Mk_HsSrcBang
    : BasicTypes.SourceText -> SrcUnpackedness -> SrcStrictness -> HsSrcBang.
 
-Inductive HsImplBang : Type
-  := | HsLazy : HsImplBang
-  |  HsStrict : HsImplBang
-  |  HsUnpack : (option Coercion) -> HsImplBang.
+Inductive HsImplBang : Type :=
+  | HsLazy : HsImplBang
+  | HsStrict : HsImplBang
+  | HsUnpack : (option Coercion) -> HsImplBang.
 
 Definition FunDep a :=
   (list a * list a)%type%type.
 
-Inductive FamTyConFlav : Type
-  := | DataFamilyTyCon : TyConRepName -> FamTyConFlav
-  |  OpenSynFamilyTyCon : FamTyConFlav
-  |  ClosedSynFamilyTyCon : (option (CoAxiom Branched)) -> FamTyConFlav
-  |  AbstractClosedSynFamilyTyCon : FamTyConFlav
-  |  BuiltInSynFamTyCon : BuiltInSynFamily -> FamTyConFlav.
+Inductive FamTyConFlav : Type :=
+  | DataFamilyTyCon : TyConRepName -> FamTyConFlav
+  | OpenSynFamilyTyCon : FamTyConFlav
+  | ClosedSynFamilyTyCon : (option (CoAxiom Branched)) -> FamTyConFlav
+  | AbstractClosedSynFamilyTyCon : FamTyConFlav
+  | BuiltInSynFamTyCon : BuiltInSynFamily -> FamTyConFlav.
 
-Inductive ExportFlag : Type
-  := | NotExported : ExportFlag
-  |  Exported : ExportFlag.
+Inductive ExportFlag : Type :=
+  | NotExported : ExportFlag
+  | Exported : ExportFlag.
 
-Inductive IdScope : Type
-  := | GlobalId : IdScope
-  |  LocalId : ExportFlag -> IdScope.
+Inductive IdScope : Type :=
+  | GlobalId : IdScope
+  | LocalId : ExportFlag -> IdScope.
 
-Inductive ExnStr : Type := | VanStr : ExnStr |  Mk_ExnStr : ExnStr.
+Inductive ExnStr : Type := | VanStr : ExnStr | Mk_ExnStr : ExnStr.
 
-Inductive Str s : Type := | Lazy : Str s |  Mk_Str : ExnStr -> s -> Str s.
+Inductive Str s : Type := | Lazy : Str s | Mk_Str : ExnStr -> s -> Str s.
 
-Inductive EqRel : Type := | NomEq : EqRel |  ReprEq : EqRel.
+Inductive EqRel : Type := | NomEq : EqRel | ReprEq : EqRel.
 
 Definition DefMethInfo :=
   (option (Name.Name * BasicTypes.DefMethSpec Type_)%type)%type.
@@ -298,9 +298,9 @@ Definition DTyVarEnv :=
 Definition DIdEnv :=
   DVarEnv%type.
 
-Inductive Count : Type := | One : Count |  Many : Count.
+Inductive Count : Type := | One : Count | Many : Count.
 
-Inductive Use u : Type := | Abs : Use u |  Mk_Use : Count -> u -> Use u.
+Inductive Use u : Type := | Abs : Use u | Mk_Use : Count -> u -> Use u.
 
 Definition DmdShell :=
   (JointDmd (Str unit) (Use unit))%type.
@@ -317,11 +317,11 @@ Definition CoercionN :=
 Definition KindCoercion :=
   CoercionN%type.
 
-Inductive UnivCoProvenance : Type
-  := | UnsafeCoerceProv : UnivCoProvenance
-  |  PhantomProv : KindCoercion -> UnivCoProvenance
-  |  ProofIrrelProv : KindCoercion -> UnivCoProvenance
-  |  PluginProv : GHC.Base.String -> UnivCoProvenance.
+Inductive UnivCoProvenance : Type :=
+  | UnsafeCoerceProv : UnivCoProvenance
+  | PhantomProv : KindCoercion -> UnivCoProvenance
+  | ProofIrrelProv : KindCoercion -> UnivCoProvenance
+  | PluginProv : GHC.Base.String -> UnivCoProvenance.
 
 Axiom CoercionHole : Type.
 
@@ -334,12 +334,12 @@ Definition CvSubstEnv :=
 Definition ClassMinimalDef :=
   (BooleanFormula.BooleanFormula Name.Name)%type.
 
-Inductive CafInfo : Type := | MayHaveCafRefs : CafInfo |  NoCafRefs : CafInfo.
+Inductive CafInfo : Type := | MayHaveCafRefs : CafInfo | NoCafRefs : CafInfo.
 
-Inductive CPRResult : Type
-  := | NoCPR : CPRResult
-  |  RetProd : CPRResult
-  |  RetSum : BasicTypes.ConTag -> CPRResult.
+Inductive CPRResult : Type :=
+  | NoCPR : CPRResult
+  | RetProd : CPRResult
+  | RetSum : BasicTypes.ConTag -> CPRResult.
 
 Definition DmdResult :=
   (Termination CPRResult)%type.
@@ -347,20 +347,20 @@ Definition DmdResult :=
 Definition ArityInfo :=
   BasicTypes.Arity%type.
 
-Inductive UseDmd : Type
-  := | UCall : Count -> UseDmd -> UseDmd
-  |  UProd : list (Use UseDmd)%type -> UseDmd
-  |  UHead : UseDmd
-  |  Used : UseDmd.
+Inductive UseDmd : Type :=
+  | UCall : Count -> UseDmd -> UseDmd
+  | UProd : list (Use UseDmd)%type -> UseDmd
+  | UHead : UseDmd
+  | Used : UseDmd.
 
 Definition ArgUse :=
   (Use UseDmd)%type.
 
-Inductive StrDmd : Type
-  := | HyperStr : StrDmd
-  |  SCall : StrDmd -> StrDmd
-  |  SProd : list (Str StrDmd)%type -> StrDmd
-  |  HeadStr : StrDmd.
+Inductive StrDmd : Type :=
+  | HyperStr : StrDmd
+  | SCall : StrDmd -> StrDmd
+  | SProd : list (Str StrDmd)%type -> StrDmd
+  | HeadStr : StrDmd.
 
 Definition ArgStr :=
   (Str StrDmd)%type.
@@ -374,13 +374,13 @@ Definition DmdEnv :=
 Definition BothDmdArg :=
   (DmdEnv * Termination unit)%type%type.
 
-Inductive DmdType : Type
-  := | Mk_DmdType : DmdEnv -> list Demand -> DmdResult -> DmdType.
+Inductive DmdType : Type :=
+  | Mk_DmdType : DmdEnv -> list Demand -> DmdResult -> DmdType.
 
 Inductive StrictSig : Type := | Mk_StrictSig : DmdType -> StrictSig.
 
-Inductive IdInfo : Type
-  := | Mk_IdInfo (arityInfo : ArityInfo) (ruleInfo : RuleInfo) (unfoldingInfo
+Inductive IdInfo : Type :=
+  | Mk_IdInfo (arityInfo : ArityInfo) (ruleInfo : RuleInfo) (unfoldingInfo
     : Unfolding) (cafInfo : CafInfo) (oneShotInfo : BasicTypes.OneShotInfo)
   (inlinePragInfo : BasicTypes.InlinePragma) (occInfo : BasicTypes.OccInfo)
   (strictnessInfo : StrictSig) (demandInfo : Demand) (callArityInfo : ArityInfo)
@@ -390,88 +390,86 @@ Inductive IdInfo : Type
 Definition CleanDemand :=
   (JointDmd StrDmd UseDmd)%type.
 
-Inductive ArgFlag : Type
-  := | Required : ArgFlag
-  |  Specified : ArgFlag
-  |  Inferred : ArgFlag.
+Inductive ArgFlag : Type :=
+  | Required : ArgFlag
+  | Specified : ArgFlag
+  | Inferred : ArgFlag.
 
-Inductive TyConBndrVis : Type
-  := | NamedTCB : ArgFlag -> TyConBndrVis
-  |  AnonTCB : TyConBndrVis.
+Inductive TyConBndrVis : Type :=
+  | NamedTCB : ArgFlag -> TyConBndrVis
+  | AnonTCB : TyConBndrVis.
 
-Inductive AlgTyConFlav : Type
-  := | VanillaAlgTyCon : TyConRepName -> AlgTyConFlav
-  |  UnboxedAlgTyCon : (option TyConRepName) -> AlgTyConFlav
-  |  ClassTyCon : Class -> TyConRepName -> AlgTyConFlav
-  |  DataFamInstTyCon
-   : (CoAxiom Unbranched) -> TyCon -> list Type_ -> AlgTyConFlav
-with Class : Type
-  := | Mk_Class (classTyCon : TyCon) (className : Name.Name) (classKey
+Inductive AlgTyConFlav : Type :=
+  | VanillaAlgTyCon : TyConRepName -> AlgTyConFlav
+  | UnboxedAlgTyCon : (option TyConRepName) -> AlgTyConFlav
+  | ClassTyCon : Class -> TyConRepName -> AlgTyConFlav
+  | DataFamInstTyCon : (CoAxiom Unbranched) -> TyCon -> list Type_ -> AlgTyConFlav
+with Class : Type :=
+  | Mk_Class (classTyCon : TyCon) (className : Name.Name) (classKey
     : Unique.Unique) (classTyVars : list Var%type) (classFunDeps
     : list (FunDep Var%type)) (classBody : ClassBody)
    : Class
-with ClassBody : Type
-  := | AbstractClass : ClassBody
-  |  ConcreteClass (classSCThetaStuff : list PredType) (classSCSels
+with ClassBody : Type :=
+  | AbstractClass : ClassBody
+  | ConcreteClass (classSCThetaStuff : list PredType) (classSCSels
     : list Var%type) (classATStuff : list ClassATItem) (classOpStuff
     : list (Var%type * DefMethInfo)%type%type) (classMinimalDefStuff
     : ClassMinimalDef)
    : ClassBody
-with ClassATItem : Type
-  := | ATI : TyCon -> (option (Type_ * SrcLoc.SrcSpan)%type) -> ClassATItem
-with TyCon : Type
-  := | FunTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name)
-  (tyConBinders : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConResKind
-    : Kind) (tyConKind : Kind) (tyConArity : BasicTypes.Arity) (tcRepName
-    : TyConRepName)
+with ClassATItem : Type :=
+  | ATI : TyCon -> (option (Type_ * SrcLoc.SrcSpan)%type) -> ClassATItem
+with TyCon : Type :=
+  | FunTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name) (tyConBinders
+    : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConResKind : Kind) (tyConKind
+    : Kind) (tyConArity : BasicTypes.Arity) (tcRepName : TyConRepName)
    : TyCon
-  |  AlgTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name) (tyConBinders
+  | AlgTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name) (tyConBinders
     : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConTyVars : list Var%type)
   (tyConResKind : Kind) (tyConKind : Kind) (tyConArity : BasicTypes.Arity)
   (tcRoles : list Role) (tyConCType : option CType) (algTcGadtSyntax : bool)
   (algTcStupidTheta : list PredType) (algTcRhs : AlgTyConRhs) (algTcFields
     : FieldLabel.FieldLabelEnv) (algTcParent : AlgTyConFlav)
    : TyCon
-  |  SynonymTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name)
+  | SynonymTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name)
   (tyConBinders : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConTyVars
     : list Var%type) (tyConResKind : Kind) (tyConKind : Kind) (tyConArity
     : BasicTypes.Arity) (tcRoles : list Role) (synTcRhs : Type_) (synIsTau : bool)
   (synIsFamFree : bool)
    : TyCon
-  |  FamilyTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name)
+  | FamilyTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name)
   (tyConBinders : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConTyVars
     : list Var%type) (tyConResKind : Kind) (tyConKind : Kind) (tyConArity
     : BasicTypes.Arity) (famTcResVar : option Name.Name) (famTcFlav : FamTyConFlav)
   (famTcParent : option Class) (famTcInj : Injectivity)
    : TyCon
-  |  PrimTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name) (tyConBinders
+  | PrimTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name) (tyConBinders
     : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConResKind : Kind) (tyConKind
     : Kind) (tyConArity : BasicTypes.Arity) (tcRoles : list Role) (isUnlifted
     : bool) (primRepName : option TyConRepName)
    : TyCon
-  |  PromotedDataCon (tyConUnique : Unique.Unique) (tyConName : Name.Name)
+  | PromotedDataCon (tyConUnique : Unique.Unique) (tyConName : Name.Name)
   (tyConBinders : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConResKind
     : Kind) (tyConKind : Kind) (tyConArity : BasicTypes.Arity) (tcRoles
     : list Role) (dataCon : DataCon) (tcRepName : TyConRepName) (promDcRepInfo
     : RuntimeRepInfo)
    : TyCon
-  |  TcTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name) (tyConBinders
+  | TcTyCon (tyConUnique : Unique.Unique) (tyConName : Name.Name) (tyConBinders
     : list (TyVarBndr Var%type TyConBndrVis)%type) (tyConTyVars : list Var%type)
   (tyConResKind : Kind) (tyConKind : Kind) (tyConArity : BasicTypes.Arity)
   (tcTyConScopedTyVars : list (Name.Name * Var%type)%type) (tcTyConFlavour
     : TyConFlavour)
    : TyCon
-with AlgTyConRhs : Type
-  := | AbstractTyCon : AlgTyConRhs
-  |  DataTyCon (data_cons : list DataCon) (is_enum : bool) : AlgTyConRhs
-  |  TupleTyCon (data_con : DataCon) (tup_sort : BasicTypes.TupleSort)
+with AlgTyConRhs : Type :=
+  | AbstractTyCon : AlgTyConRhs
+  | DataTyCon (data_cons : list DataCon) (is_enum : bool) : AlgTyConRhs
+  | TupleTyCon (data_con : DataCon) (tup_sort : BasicTypes.TupleSort)
    : AlgTyConRhs
-  |  SumTyCon (data_cons : list DataCon) : AlgTyConRhs
-  |  NewTyCon (data_con : DataCon) (nt_rhs : Type_) (nt_etad_rhs
+  | SumTyCon (data_cons : list DataCon) : AlgTyConRhs
+  | NewTyCon (data_con : DataCon) (nt_rhs : Type_) (nt_etad_rhs
     : (list Var%type * Type_)%type) (nt_co : CoAxiom Unbranched)
    : AlgTyConRhs
-with DataCon : Type
-  := | MkData (dcName : Name.Name) (dcUnique : Unique.Unique) (dcTag
+with DataCon : Type :=
+  | MkData (dcName : Name.Name) (dcUnique : Unique.Unique) (dcTag
     : BasicTypes.ConTag) (dcVanilla : bool) (dcUnivTyVars : list Var%type)
   (dcExTyVars : list Var%type) (dcUserTyVarBinders
     : list (TyVarBndr Var%type ArgFlag)%type) (dcEqSpec : list EqSpec)
@@ -481,32 +479,32 @@ with DataCon : Type
   (dcRepArity : BasicTypes.Arity) (dcSourceArity : BasicTypes.Arity) (dcRepTyCon
     : TyCon) (dcRepType : Type_) (dcInfix : bool) (dcPromoted : TyCon)
    : DataCon
-with DataConRep : Type
-  := | NoDataConRep : DataConRep
-  |  DCR (dcr_wrap_id : Var%type) (dcr_boxer : DataConBoxer) (dcr_arg_tys
+with DataConRep : Type :=
+  | NoDataConRep : DataConRep
+  | DCR (dcr_wrap_id : Var%type) (dcr_boxer : DataConBoxer) (dcr_arg_tys
     : list Type_) (dcr_stricts : list StrictnessMark) (dcr_bangs : list HsImplBang)
    : DataConRep
-with Var : Type
-  := | Mk_Id (varName : Name.Name) (realUnique : BinNums.N) (varType : Type_)
+with Var : Type :=
+  | Mk_Id (varName : Name.Name) (realUnique : BinNums.N) (varType : Type_)
   (idScope : IdScope) (id_details : IdDetails) (id_info : IdInfo)
    : Var
-with IdDetails : Type
-  := | VanillaId : IdDetails
-  |  RecSelId (sel_tycon : RecSelParent) (sel_naughty : bool) : IdDetails
-  |  DataConWorkId : DataCon -> IdDetails
-  |  DataConWrapId : DataCon -> IdDetails
-  |  ClassOpId : Class -> IdDetails
-  |  PrimOpId : PrimOp -> IdDetails
-  |  FCallId : ForeignCall -> IdDetails
-  |  TickBoxOpId : TickBoxOp -> IdDetails
-  |  Mk_DFunId : bool -> IdDetails
-  |  Mk_JoinId : BasicTypes.JoinArity -> IdDetails
-with RecSelParent : Type
-  := | RecSelData : TyCon -> RecSelParent
-  |  RecSelPatSyn : PatSyn -> RecSelParent
-with PatSyn : Type
-  := | MkPatSyn (psName : Name.Name) (psUnique : Unique.Unique) (psArgs
-    : list Type_) (psArity : BasicTypes.Arity) (psInfix : bool) (psFieldLabels
+with IdDetails : Type :=
+  | VanillaId : IdDetails
+  | RecSelId (sel_tycon : RecSelParent) (sel_naughty : bool) : IdDetails
+  | DataConWorkId : DataCon -> IdDetails
+  | DataConWrapId : DataCon -> IdDetails
+  | ClassOpId : Class -> IdDetails
+  | PrimOpId : PrimOp -> IdDetails
+  | FCallId : ForeignCall -> IdDetails
+  | TickBoxOpId : TickBoxOp -> IdDetails
+  | Mk_DFunId : bool -> IdDetails
+  | Mk_JoinId : BasicTypes.JoinArity -> IdDetails
+with RecSelParent : Type :=
+  | RecSelData : TyCon -> RecSelParent
+  | RecSelPatSyn : PatSyn -> RecSelParent
+with PatSyn : Type :=
+  | MkPatSyn (psName : Name.Name) (psUnique : Unique.Unique) (psArgs : list Type_)
+  (psArity : BasicTypes.Arity) (psInfix : bool) (psFieldLabels
     : list FieldLabel.FieldLabel) (psUnivTyVars
     : list (TyVarBndr Var%type ArgFlag)%type) (psReqTheta : ThetaType) (psExTyVars
     : list (TyVarBndr Var%type ArgFlag)%type) (psProvTheta : ThetaType) (psResultTy
@@ -622,10 +620,10 @@ Definition TKVar :=
 Definition TidyEnv :=
   (OccName.TidyOccEnv * VarEnv Var)%type%type.
 
-Inductive PredTree : Type
-  := | ClassPred : Class -> list Type_ -> PredTree
-  |  EqPred : EqRel -> Type_ -> Type_ -> PredTree
-  |  IrredPred : PredType -> PredTree.
+Inductive PredTree : Type :=
+  | ClassPred : Class -> list Type_ -> PredTree
+  | EqPred : EqRel -> Type_ -> Type_ -> PredTree
+  | IrredPred : PredType -> PredTree.
 
 Definition DTyVarSet :=
   (UniqSet.UniqSet TyVar)%type.
@@ -636,34 +634,34 @@ Definition InTyVar :=
 Definition OutTyVar :=
   TyVar%type.
 
-Inductive TyCoMapper env m : Type
-  := | Mk_TyCoMapper (tcm_smart : bool) (tcm_tyvar : env -> TyVar -> m Type_)
+Inductive TyCoMapper env m : Type :=
+  | Mk_TyCoMapper (tcm_smart : bool) (tcm_tyvar : env -> TyVar -> m Type_)
   (tcm_covar : env -> CoVar -> m Coercion) (tcm_hole
     : env -> CoercionHole -> m Coercion) (tcm_tybinder
     : env -> TyVar -> ArgFlag -> m (env * TyVar)%type)
    : TyCoMapper env m.
 
-Inductive AltCon : Type
-  := | DataAlt : DataCon -> AltCon
-  |  LitAlt : Literal -> AltCon
-  |  DEFAULT : AltCon.
+Inductive AltCon : Type :=
+  | DataAlt : DataCon -> AltCon
+  | LitAlt : Literal -> AltCon
+  | DEFAULT : AltCon.
 
-Inductive Expr b : Type
-  := | Mk_Var : Id -> Expr b
-  |  Lit : Literal -> Expr b
-  |  App : (Expr b) -> (Expr%type b) -> Expr b
-  |  Lam : b -> (Expr b) -> Expr b
-  |  Let : (Bind b) -> (Expr b) -> Expr b
-  |  Case
+Inductive Expr b : Type :=
+  | Mk_Var : Id -> Expr b
+  | Lit : Literal -> Expr b
+  | App : (Expr b) -> (Expr%type b) -> Expr b
+  | Lam : b -> (Expr b) -> Expr b
+  | Let : (Bind b) -> (Expr b) -> Expr b
+  | Case
    : (Expr b) ->
      b ->
      Type_ -> list ((fun b_ => (AltCon * list b_ * Expr b_)%type%type) b) -> Expr b
-  |  Cast : (Expr b) -> Coercion -> Expr b
-  |  Mk_Type : Type_ -> Expr b
-  |  Mk_Coercion : Coercion -> Expr b
-with Bind b : Type
-  := | NonRec : b -> (Expr b) -> Bind b
-  |  Rec : list (b * (Expr b))%type -> Bind b.
+  | Cast : (Expr b) -> Coercion -> Expr b
+  | Mk_Type : Type_ -> Expr b
+  | Mk_Coercion : Coercion -> Expr b
+with Bind b : Type :=
+  | NonRec : b -> (Expr b) -> Bind b
+  | Rec : list (b * (Expr b))%type -> Bind b.
 
 Definition Arg :=
   Expr%type.
@@ -710,12 +708,12 @@ Definition TaggedBind t :=
 Definition CoreExpr :=
   (Expr CoreBndr)%type.
 
-Inductive CoreVect : Type
-  := | Vect : Id -> CoreExpr -> CoreVect
-  |  NoVect : Id -> CoreVect
-  |  VectType : bool -> TyCon -> (option TyCon) -> CoreVect
-  |  VectClass : TyCon -> CoreVect
-  |  VectInst : Id -> CoreVect.
+Inductive CoreVect : Type :=
+  | Vect : Id -> CoreExpr -> CoreVect
+  | NoVect : Id -> CoreVect
+  | VectType : bool -> TyCon -> (option TyCon) -> CoreVect
+  | VectClass : TyCon -> CoreVect
+  | VectInst : Id -> CoreVect.
 
 Definition InExpr :=
   CoreExpr%type.
@@ -729,19 +727,19 @@ Definition TaggedExpr t :=
 Definition TaggedAlt t :=
   (Alt (TaggedBndr t))%type.
 
-Inductive AnnExpr' bndr annot : Type
-  := | AnnVar : Id -> AnnExpr' bndr annot
-  |  AnnLit : Literal -> AnnExpr' bndr annot
-  |  AnnLam
+Inductive AnnExpr' bndr annot : Type :=
+  | AnnVar : Id -> AnnExpr' bndr annot
+  | AnnLit : Literal -> AnnExpr' bndr annot
+  | AnnLam
    : bndr ->
      ((fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr annot) ->
      AnnExpr' bndr annot
-  |  AnnApp
+  | AnnApp
    : ((fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr
       annot) ->
      ((fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr annot) ->
      AnnExpr' bndr annot
-  |  AnnCase
+  | AnnCase
    : ((fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr
       annot) ->
      bndr ->
@@ -751,22 +749,22 @@ Inductive AnnExpr' bndr annot : Type
                (fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr_
                annot_)%type%type) bndr annot) ->
      AnnExpr' bndr annot
-  |  AnnLet
+  | AnnLet
    : (AnnBind bndr annot) ->
      ((fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr annot) ->
      AnnExpr' bndr annot
-  |  AnnCast
+  | AnnCast
    : ((fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr
       annot) ->
      (annot * Coercion)%type -> AnnExpr' bndr annot
-  |  AnnType : Type_ -> AnnExpr' bndr annot
-  |  AnnCoercion : Coercion -> AnnExpr' bndr annot
-with AnnBind bndr annot : Type
-  := | AnnNonRec
+  | AnnType : Type_ -> AnnExpr' bndr annot
+  | AnnCoercion : Coercion -> AnnExpr' bndr annot
+with AnnBind bndr annot : Type :=
+  | AnnNonRec
    : bndr ->
      ((fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr annot) ->
      AnnBind bndr annot
-  |  AnnRec
+  | AnnRec
    : list (bndr *
            (fun bndr_ annot_ => (annot_ * AnnExpr' bndr_ annot_)%type%type) bndr
            annot)%type ->
@@ -796,32 +794,31 @@ Definition RuleFun :=
   (DynFlags.DynFlags ->
    InScopeEnv -> Id -> list CoreExpr -> option CoreExpr)%type.
 
-Inductive CoreRule : Type
-  := | Rule (ru_name : BasicTypes.RuleName) (ru_act : BasicTypes.Activation)
-  (ru_fn : Name.Name) (ru_rough : list (option Name.Name)) (ru_bndrs
-    : list CoreBndr) (ru_args : list CoreExpr) (ru_rhs : CoreExpr) (ru_auto : bool)
-  (ru_origin : Module.Module) (ru_orphan : IsOrphan) (ru_local : bool)
+Inductive CoreRule : Type :=
+  | Rule (ru_name : BasicTypes.RuleName) (ru_act : BasicTypes.Activation) (ru_fn
+    : Name.Name) (ru_rough : list (option Name.Name)) (ru_bndrs : list CoreBndr)
+  (ru_args : list CoreExpr) (ru_rhs : CoreExpr) (ru_auto : bool) (ru_origin
+    : Module.Module) (ru_orphan : IsOrphan) (ru_local : bool)
    : CoreRule
-  |  BuiltinRule (ru_name : BasicTypes.RuleName) (ru_fn : Name.Name) (ru_nargs
+  | BuiltinRule (ru_name : BasicTypes.RuleName) (ru_fn : Name.Name) (ru_nargs
     : nat) (ru_try : RuleFun)
    : CoreRule.
 
 Definition RuleBase :=
   (NameEnv.NameEnv (list CoreRule))%type.
 
-Inductive RuleEnv : Type
-  := | Mk_RuleEnv (re_base : RuleBase) (re_visible_orphs : Module.ModuleSet)
+Inductive RuleEnv : Type :=
+  | Mk_RuleEnv (re_base : RuleBase) (re_visible_orphs : Module.ModuleSet)
    : RuleEnv.
 
-Inductive RnEnv2 : Type
-  := | RV2 (envL : VarEnv Var) (envR : VarEnv Var) (in_scope : InScopeSet)
-   : RnEnv2.
+Inductive RnEnv2 : Type :=
+  | RV2 (envL : VarEnv Var) (envR : VarEnv Var) (in_scope : InScopeSet) : RnEnv2.
 
-Inductive TCvSubst : Type
-  := | Mk_TCvSubst : InScopeSet -> TvSubstEnv -> CvSubstEnv -> TCvSubst.
+Inductive TCvSubst : Type :=
+  | Mk_TCvSubst : InScopeSet -> TvSubstEnv -> CvSubstEnv -> TCvSubst.
 
-Inductive LiftingContext : Type
-  := | LC : TCvSubst -> LiftCoEnv -> LiftingContext.
+Inductive LiftingContext : Type :=
+  | LC : TCvSubst -> LiftCoEnv -> LiftingContext.
 
 Arguments TvBndr {_} {_} _ _.
 
@@ -3046,14 +3043,14 @@ Program Instance Eq___Str {s} `{GHC.Base.Eq_ s} : GHC.Base.Eq_ (Str s) :=
 
 Local Definition Eq___StrDmd_op_zeze__ : StrDmd -> StrDmd -> bool :=
   fix StrDmd_eq x y
-        := let eq' : GHC.Base.Eq_ StrDmd := GHC.Base.eq_default StrDmd_eq in
-           match x, y with
-           | HyperStr, HyperStr => true
-           | SCall a1, SCall b1 => a1 GHC.Base.== b1
-           | SProd a1, SProd b1 => a1 GHC.Base.== b1
-           | HeadStr, HeadStr => true
-           | _, _ => false
-           end.
+    := let eq' : GHC.Base.Eq_ StrDmd := GHC.Base.eq_default StrDmd_eq in
+       match x, y with
+       | HyperStr, HyperStr => true
+       | SCall a1, SCall b1 => a1 GHC.Base.== b1
+       | SProd a1, SProd b1 => a1 GHC.Base.== b1
+       | HeadStr, HeadStr => true
+       | _, _ => false
+       end.
 
 Local Definition Eq___StrDmd_op_zsze__ : StrDmd -> StrDmd -> bool :=
   fun x y => negb (Eq___StrDmd_op_zeze__ x y).
@@ -3124,14 +3121,14 @@ Program Instance Eq___Use {u} `{GHC.Base.Eq_ u} : GHC.Base.Eq_ (Use u) :=
 
 Local Definition Eq___UseDmd_op_zeze__ : UseDmd -> UseDmd -> bool :=
   fix UseDmd_eq x y
-        := let eq' : GHC.Base.Eq_ UseDmd := GHC.Base.eq_default UseDmd_eq in
-           match x, y with
-           | UCall a1 a2, UCall b1 b2 => andb (a1 GHC.Base.== b1) (a2 GHC.Base.== b2)
-           | UProd a1, UProd b1 => a1 GHC.Base.== b1
-           | UHead, UHead => true
-           | Used, Used => true
-           | _, _ => false
-           end.
+    := let eq' : GHC.Base.Eq_ UseDmd := GHC.Base.eq_default UseDmd_eq in
+       match x, y with
+       | UCall a1 a2, UCall b1 b2 => andb (a1 GHC.Base.== b1) (a2 GHC.Base.== b2)
+       | UProd a1, UProd b1 => a1 GHC.Base.== b1
+       | UHead, UHead => true
+       | Used, Used => true
+       | _, _ => false
+       end.
 
 Local Definition Eq___UseDmd_op_zsze__ : UseDmd -> UseDmd -> bool :=
   fun x y => negb (Eq___UseDmd_op_zeze__ x y).
@@ -7101,31 +7098,31 @@ Definition ltAlt {a} {b}
   fun a1 a2 => (cmpAlt a1 a2) GHC.Base.== Lt.
 
 Fixpoint deTagExpr {t} (arg_0__ : TaggedExpr t) : CoreExpr
-           := let deTagBind (arg_0__ : TaggedBind t) : CoreBind :=
-                match arg_0__ with
-                | NonRec (TB b _) rhs => NonRec b (deTagExpr rhs)
-                | Rec prs =>
-                    Rec (let cont_2__ arg_3__ :=
-                           let 'pair (TB b _) rhs := arg_3__ in
-                           cons (pair b (deTagExpr rhs)) nil in
-                         Coq.Lists.List.flat_map cont_2__ prs)
-                end in
-              let deTagAlt (arg_0__ : TaggedAlt t) : CoreAlt :=
-                let 'pair (pair con bndrs) rhs := arg_0__ in
-                pair (pair con (let cont_1__ arg_2__ := let 'TB b _ := arg_2__ in cons b nil in
-                            Coq.Lists.List.flat_map cont_1__ bndrs)) (deTagExpr rhs) in
-              match arg_0__ with
-              | Mk_Var v => Mk_Var v
-              | Lit l => Lit l
-              | Mk_Type ty => Mk_Type ty
-              | Mk_Coercion co => Mk_Coercion co
-              | App e1 e2 => App (deTagExpr e1) (deTagExpr e2)
-              | Lam (TB b _) e => Lam b (deTagExpr e)
-              | Let bind body => Let (deTagBind bind) (deTagExpr body)
-              | Case e (TB b _) ty alts =>
-                  Case (deTagExpr e) b ty (GHC.Base.map deTagAlt alts)
-              | Cast e co => Cast (deTagExpr e) co
-              end.
+  := let deTagBind (arg_0__ : TaggedBind t) : CoreBind :=
+       match arg_0__ with
+       | NonRec (TB b _) rhs => NonRec b (deTagExpr rhs)
+       | Rec prs =>
+           Rec (let cont_2__ arg_3__ :=
+                  let 'pair (TB b _) rhs := arg_3__ in
+                  cons (pair b (deTagExpr rhs)) nil in
+                Coq.Lists.List.flat_map cont_2__ prs)
+       end in
+     let deTagAlt (arg_0__ : TaggedAlt t) : CoreAlt :=
+       let 'pair (pair con bndrs) rhs := arg_0__ in
+       pair (pair con (let cont_1__ arg_2__ := let 'TB b _ := arg_2__ in cons b nil in
+                   Coq.Lists.List.flat_map cont_1__ bndrs)) (deTagExpr rhs) in
+     match arg_0__ with
+     | Mk_Var v => Mk_Var v
+     | Lit l => Lit l
+     | Mk_Type ty => Mk_Type ty
+     | Mk_Coercion co => Mk_Coercion co
+     | App e1 e2 => App (deTagExpr e1) (deTagExpr e2)
+     | Lam (TB b _) e => Lam b (deTagExpr e)
+     | Let bind body => Let (deTagBind bind) (deTagExpr body)
+     | Case e (TB b _) ty alts =>
+         Case (deTagExpr e) b ty (GHC.Base.map deTagAlt alts)
+     | Cast e co => Cast (deTagExpr e) co
+     end.
 
 Definition deTagBind {t} : TaggedBind t -> CoreBind :=
   fun arg_0__ =>
@@ -7272,45 +7269,45 @@ Definition rhssOfAlts {b} : list (Alt b) -> list (Expr b) :=
     Coq.Lists.List.flat_map cont_0__ alts.
 
 Fixpoint flattenBinds {b} (arg_0__ : list (Bind b)) : list (b * Expr b)%type
-           := match arg_0__ with
-              | cons (NonRec b r) binds => cons (pair b r) (flattenBinds binds)
-              | cons (Rec prs1) binds => Coq.Init.Datatypes.app prs1 (flattenBinds binds)
-              | nil => nil
-              end.
+  := match arg_0__ with
+     | cons (NonRec b r) binds => cons (pair b r) (flattenBinds binds)
+     | cons (Rec prs1) binds => Coq.Init.Datatypes.app prs1 (flattenBinds binds)
+     | nil => nil
+     end.
 
 Definition collectBinders {b} : Expr b -> (list b * Expr b)%type :=
   fun expr =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | bs, Lam b e => go (cons b bs) e
-                 | bs, e => pair (GHC.List.reverse bs) e
-                 end in
+      := match arg_0__, arg_1__ with
+         | bs, Lam b e => go (cons b bs) e
+         | bs, e => pair (GHC.List.reverse bs) e
+         end in
     go nil expr.
 
 Definition collectTyBinders : CoreExpr -> (list TyVar * CoreExpr)%type :=
   fun expr =>
     let fix go arg_0__ arg_1__
-              := let j_3__ :=
-                   match arg_0__, arg_1__ with
-                   | tvs, e => pair (GHC.List.reverse tvs) e
-                   end in
-                 match arg_0__, arg_1__ with
-                 | tvs, Lam b e => if isTyVar b : bool then go (cons b tvs) e else j_3__
-                 | _, _ => j_3__
-                 end in
+      := let j_3__ :=
+           match arg_0__, arg_1__ with
+           | tvs, e => pair (GHC.List.reverse tvs) e
+           end in
+         match arg_0__, arg_1__ with
+         | tvs, Lam b e => if isTyVar b : bool then go (cons b tvs) e else j_3__
+         | _, _ => j_3__
+         end in
     go nil expr.
 
 Definition collectValBinders : CoreExpr -> (list Id * CoreExpr)%type :=
   fun expr =>
     let fix go arg_0__ arg_1__
-              := let j_3__ :=
-                   match arg_0__, arg_1__ with
-                   | ids, body => pair (GHC.List.reverse ids) body
-                   end in
-                 match arg_0__, arg_1__ with
-                 | ids, Lam b e => if isId b : bool then go (cons b ids) e else j_3__
-                 | _, _ => j_3__
-                 end in
+      := let j_3__ :=
+           match arg_0__, arg_1__ with
+           | ids, body => pair (GHC.List.reverse ids) body
+           end in
+         match arg_0__, arg_1__ with
+         | ids, Lam b e => if isId b : bool then go (cons b ids) e else j_3__
+         | _, _ => j_3__
+         end in
     go nil expr.
 
 Definition collectTyAndValBinders
@@ -7323,24 +7320,24 @@ Definition collectTyAndValBinders
 Definition collectNBinders {b} : nat -> Expr b -> (list b * Expr b)%type :=
   fun orig_n orig_expr =>
     let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | num_3__, bs, expr =>
-                     if num_3__ GHC.Base.== #0 : bool then pair (GHC.List.reverse bs) expr else
-                     match arg_0__, arg_1__, arg_2__ with
-                     | n, bs, Lam b e => go (n GHC.Num.- #1) (cons b bs) e
-                     | _, _, _ =>
-                         Panic.panicStr (GHC.Base.hs_string__ "collectNBinders") Panic.someSDoc
-                     end
-                 end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | num_3__, bs, expr =>
+             if num_3__ GHC.Base.== #0 : bool then pair (GHC.List.reverse bs) expr else
+             match arg_0__, arg_1__, arg_2__ with
+             | n, bs, Lam b e => go (n GHC.Num.- #1) (cons b bs) e
+             | _, _, _ =>
+                 Panic.panicStr (GHC.Base.hs_string__ "collectNBinders") Panic.someSDoc
+             end
+         end in
     go orig_n nil orig_expr.
 
 Definition collectArgs {b} : Expr b -> (Expr b * list (Arg b))%type :=
   fun expr =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | App f a, as_ => go f (cons a as_)
-                 | e, as_ => pair e as_
-                 end in
+      := match arg_0__, arg_1__ with
+         | App f a, as_ => go f (cons a as_)
+         | e, as_ => pair e as_
+         end in
     go expr nil.
 
 Definition collectArgsTicks {b}
@@ -7348,10 +7345,10 @@ Definition collectArgsTicks {b}
      Expr b -> (Expr b * list (Arg b) * list (Tickish Id))%type :=
   fun skipTick expr =>
     let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | App f a, as_, ts => go f (cons a as_) ts
-                 | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
-                 end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | App f a, as_, ts => go f (cons a as_) ts
+         | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
+         end in
     go expr nil nil.
 
 Definition isRuntimeVar : Var -> bool :=
@@ -7381,64 +7378,65 @@ Definition valArgCount {b} : list (Arg b) -> nat :=
   Util.count isValArg.
 
 Program Definition collectAnnArgs {b} {a}
-           : AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a))%type :=
-          fun expr =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | pair _ (AnnApp f a), as_ => go f (cons a as_)
-                               | e, as_ => pair e as_
-                               end) in
-            go expr nil.
+   : AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a))%type :=
+  fun expr =>
+    let go :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ go =>
+                       match arg_0__, arg_1__ with
+                       | pair _ (AnnApp f a), as_ => go f (cons a as_)
+                       | e, as_ => pair e as_
+                       end) in
+    go expr nil.
 Solve Obligations with (solve_collectAnnArgsTicks).
 
 Program Definition collectAnnArgsTicks {b} {a}
-           : (Tickish Var -> bool) ->
-             AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a) * list (Tickish Var))%type :=
-          fun tickishOk expr =>
-            let go :=
-              GHC.Wf.wfFix3 Coq.Init.Peano.lt (fun arg_0__ arg_1__ arg_2__ =>
-                               size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ arg_2__ go =>
-                               match arg_0__, arg_1__, arg_2__ with
-                               | pair _ (AnnApp f a), as_, ts => go f (cons a as_) ts
-                               | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
-                               end) in
-            go expr nil nil.
+   : (Tickish Var -> bool) ->
+     AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a) * list (Tickish Var))%type :=
+  fun tickishOk expr =>
+    let go :=
+      GHC.Wf.wfFix3 Coq.Init.Peano.lt (fun arg_0__ arg_1__ arg_2__ =>
+                       size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ arg_2__ go =>
+                       match arg_0__, arg_1__, arg_2__ with
+                       | pair _ (AnnApp f a), as_, ts => go f (cons a as_) ts
+                       | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
+                       end) in
+    go expr nil nil.
 Solve Obligations with (solve_collectAnnArgsTicks).
 
 Definition deAnnotate'
    : forall {bndr} {annot}, AnnExpr' bndr annot -> Expr bndr :=
   fix deAnnotate' {bndr} {annot} (arg_0__ : AnnExpr' bndr annot) : Expr bndr
-        := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-             let 'pair _ e := arg_0__ in
-             deAnnotate' e in
-           let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
-             let 'pair (pair con args) rhs := arg_0__ in
-             pair (pair con args) (deAnnotate rhs) in
-           match arg_0__ with
-           | AnnType t => Mk_Type t
-           | AnnCoercion co => Mk_Coercion co
-           | AnnVar v => Mk_Var v
-           | AnnLit lit => Lit lit
-           | AnnLam binder body => Lam binder (deAnnotate body)
-           | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
-           | AnnCast e (pair _ co) => Cast (deAnnotate e) co
-           | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
-           | AnnCase scrut v t alts =>
-               Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
-           end with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
-                      := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-                           let 'pair _ e := arg_0__ in
-                           deAnnotate' e in
-                         match arg_0__ with
-                         | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
-                         | AnnRec pairs =>
-                             Rec (let cont_2__ arg_3__ :=
-                                    let 'pair v rhs := arg_3__ in
-                                    cons (pair v (deAnnotate rhs)) nil in
-                                  Coq.Lists.List.flat_map cont_2__ pairs)
-                         end for deAnnotate'.
+    := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+         let 'pair _ e := arg_0__ in
+         deAnnotate' e in
+       let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
+         let 'pair (pair con args) rhs := arg_0__ in
+         pair (pair con args) (deAnnotate rhs) in
+       match arg_0__ with
+       | AnnType t => Mk_Type t
+       | AnnCoercion co => Mk_Coercion co
+       | AnnVar v => Mk_Var v
+       | AnnLit lit => Lit lit
+       | AnnLam binder body => Lam binder (deAnnotate body)
+       | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
+       | AnnCast e (pair _ co) => Cast (deAnnotate e) co
+       | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
+       | AnnCase scrut v t alts =>
+           Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
+       end
+  with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
+    := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+         let 'pair _ e := arg_0__ in
+         deAnnotate' e in
+       match arg_0__ with
+       | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
+       | AnnRec pairs =>
+           Rec (let cont_2__ arg_3__ :=
+                  let 'pair v rhs := arg_3__ in
+                  cons (pair v (deAnnotate rhs)) nil in
+                Coq.Lists.List.flat_map cont_2__ pairs)
+       end for deAnnotate'.
 
 Definition deAnnotate {bndr} {annot} : AnnExpr bndr annot -> Expr bndr :=
   fun '(pair _ e) => deAnnotate' e.
@@ -7448,47 +7446,48 @@ Definition deAnnAlt {bndr} {annot} : AnnAlt bndr annot -> Alt bndr :=
 
 Definition deAnnBind : forall {b} {annot}, AnnBind b annot -> Bind b :=
   fix deAnnotate' {bndr} {annot} (arg_0__ : AnnExpr' bndr annot) : Expr bndr
-        := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-             let 'pair _ e := arg_0__ in
-             deAnnotate' e in
-           let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
-             let 'pair (pair con args) rhs := arg_0__ in
-             pair (pair con args) (deAnnotate rhs) in
-           match arg_0__ with
-           | AnnType t => Mk_Type t
-           | AnnCoercion co => Mk_Coercion co
-           | AnnVar v => Mk_Var v
-           | AnnLit lit => Lit lit
-           | AnnLam binder body => Lam binder (deAnnotate body)
-           | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
-           | AnnCast e (pair _ co) => Cast (deAnnotate e) co
-           | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
-           | AnnCase scrut v t alts =>
-               Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
-           end with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
-                      := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-                           let 'pair _ e := arg_0__ in
-                           deAnnotate' e in
-                         match arg_0__ with
-                         | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
-                         | AnnRec pairs =>
-                             Rec (let cont_2__ arg_3__ :=
-                                    let 'pair v rhs := arg_3__ in
-                                    cons (pair v (deAnnotate rhs)) nil in
-                                  Coq.Lists.List.flat_map cont_2__ pairs)
-                         end for deAnnBind.
+    := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+         let 'pair _ e := arg_0__ in
+         deAnnotate' e in
+       let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
+         let 'pair (pair con args) rhs := arg_0__ in
+         pair (pair con args) (deAnnotate rhs) in
+       match arg_0__ with
+       | AnnType t => Mk_Type t
+       | AnnCoercion co => Mk_Coercion co
+       | AnnVar v => Mk_Var v
+       | AnnLit lit => Lit lit
+       | AnnLam binder body => Lam binder (deAnnotate body)
+       | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
+       | AnnCast e (pair _ co) => Cast (deAnnotate e) co
+       | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
+       | AnnCase scrut v t alts =>
+           Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
+       end
+  with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
+    := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+         let 'pair _ e := arg_0__ in
+         deAnnotate' e in
+       match arg_0__ with
+       | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
+       | AnnRec pairs =>
+           Rec (let cont_2__ arg_3__ :=
+                  let 'pair v rhs := arg_3__ in
+                  cons (pair v (deAnnotate rhs)) nil in
+                Coq.Lists.List.flat_map cont_2__ pairs)
+       end for deAnnBind.
 
 Program Definition collectAnnBndrs {bndr} {annot}
-           : AnnExpr bndr annot -> (list bndr * AnnExpr bndr annot)%type :=
-          fun e =>
-            let collect :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               size_AnnExpr' (snd arg_1__)) _ (fun arg_0__ arg_1__ collect =>
-                               match arg_0__, arg_1__ with
-                               | bs, pair _ (AnnLam b body) => collect (cons b bs) body
-                               | bs, body => pair (GHC.List.reverse bs) body
-                               end) in
-            collect nil e.
+   : AnnExpr bndr annot -> (list bndr * AnnExpr bndr annot)%type :=
+  fun e =>
+    let collect :=
+      GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                       size_AnnExpr' (snd arg_1__)) _ (fun arg_0__ arg_1__ collect =>
+                       match arg_0__, arg_1__ with
+                       | bs, pair _ (AnnLam b body) => collect (cons b bs) body
+                       | bs, body => pair (GHC.List.reverse bs) body
+                       end) in
+    collect nil e.
 
 (* Skipping definition `Core.collectNAnnBndrs' *)
 

--- a/examples/ghc/lib/CoreArity.v
+++ b/examples/ghc/lib/CoreArity.v
@@ -22,19 +22,19 @@ Require GHC.Err.
 
 (* Converted type declarations: *)
 
-Inductive EtaInfo : Type
-  := | EtaVar : Core.Var -> EtaInfo
-  |  EtaCo : AxiomatizedTypes.Coercion -> EtaInfo.
+Inductive EtaInfo : Type :=
+  | EtaVar : Core.Var -> EtaInfo
+  | EtaCo : AxiomatizedTypes.Coercion -> EtaInfo.
 
 Definition CheapFun :=
   (Core.CoreExpr -> option AxiomatizedTypes.Type_ -> bool)%type.
 
-Inductive ArityType : Type
-  := | ATop : list BasicTypes.OneShotInfo -> ArityType
-  |  ABot : BasicTypes.Arity -> ArityType.
+Inductive ArityType : Type :=
+  | ATop : list BasicTypes.OneShotInfo -> ArityType
+  | ABot : BasicTypes.Arity -> ArityType.
 
-Inductive ArityEnv : Type
-  := | AE (ae_cheap_fn : CheapFun) (ae_ped_bot : bool) : ArityEnv.
+Inductive ArityEnv : Type :=
+  | AE (ae_cheap_fn : CheapFun) (ae_ped_bot : bool) : ArityEnv.
 
 Instance Default__ArityEnv : GHC.Err.Default ArityEnv :=
   GHC.Err.Build_Default _ (AE GHC.Err.default GHC.Err.default).

--- a/examples/ghc/lib/CoreFVs.v
+++ b/examples/ghc/lib/CoreFVs.v
@@ -76,36 +76,35 @@ Definition bndrRuleAndUnfoldingFVs : Core.Id -> FV.FV :=
     FV.emptyFV.
 
 Fixpoint expr_fvs `(arg_0__ : Core.CoreExpr) arg_1__ arg_2__ arg_3__
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | Core.Mk_Type ty, fv_cand, in_scope, acc => FV.emptyFV fv_cand in_scope acc
-              | Core.Mk_Coercion co, fv_cand, in_scope, acc => FV.emptyFV fv_cand in_scope acc
-              | Core.Mk_Var var, fv_cand, in_scope, acc => FV.unitFV var fv_cand in_scope acc
-              | Core.Lit _, fv_cand, in_scope, acc => FV.emptyFV fv_cand in_scope acc
-              | Core.App fun_ arg, fv_cand, in_scope, acc =>
-                  (FV.unionFV (expr_fvs fun_) (expr_fvs arg)) fv_cand in_scope acc
-              | Core.Lam bndr body, fv_cand, in_scope, acc =>
-                  addBndr bndr (expr_fvs body) fv_cand in_scope acc
-              | Core.Cast expr co, fv_cand, in_scope, acc =>
-                  (FV.unionFV (expr_fvs expr) FV.emptyFV) fv_cand in_scope acc
-              | Core.Case scrut bndr ty alts, fv_cand, in_scope, acc =>
-                  let alt_fvs :=
-                    fun '(pair (pair _ bndrs) rhs) => addBndrs bndrs (expr_fvs rhs) in
-                  (FV.unionFV (FV.unionFV (expr_fvs scrut) FV.emptyFV) (addBndr bndr (FV.unionsFV
-                                                                                      (Lists.List.map alt_fvs alts))))
-                  fv_cand in_scope acc
-              | Core.Let (Core.NonRec bndr rhs) body, fv_cand, in_scope, acc =>
-                  (FV.unionFV (let 'pair bndr rhs := pair bndr rhs in
-                               FV.unionFV (expr_fvs rhs) (bndrRuleAndUnfoldingFVs bndr)) (addBndr bndr
-                               (expr_fvs body))) fv_cand in_scope acc
-              | Core.Let (Core.Rec pairs) body, fv_cand, in_scope, acc =>
-                  addBndrs (GHC.Base.map Data.Tuple.fst pairs) (FV.unionFV (FV.unionsFV
-                                                                            (Lists.List.map (fun '(pair bndr rhs) =>
-                                                                                               FV.unionFV (expr_fvs rhs)
-                                                                                                          (bndrRuleAndUnfoldingFVs
-                                                                                                           bndr))
-                                                                                            pairs)) (expr_fvs body))
-                  fv_cand in_scope acc
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | Core.Mk_Type ty, fv_cand, in_scope, acc => FV.emptyFV fv_cand in_scope acc
+     | Core.Mk_Coercion co, fv_cand, in_scope, acc => FV.emptyFV fv_cand in_scope acc
+     | Core.Mk_Var var, fv_cand, in_scope, acc => FV.unitFV var fv_cand in_scope acc
+     | Core.Lit _, fv_cand, in_scope, acc => FV.emptyFV fv_cand in_scope acc
+     | Core.App fun_ arg, fv_cand, in_scope, acc =>
+         (FV.unionFV (expr_fvs fun_) (expr_fvs arg)) fv_cand in_scope acc
+     | Core.Lam bndr body, fv_cand, in_scope, acc =>
+         addBndr bndr (expr_fvs body) fv_cand in_scope acc
+     | Core.Cast expr co, fv_cand, in_scope, acc =>
+         (FV.unionFV (expr_fvs expr) FV.emptyFV) fv_cand in_scope acc
+     | Core.Case scrut bndr ty alts, fv_cand, in_scope, acc =>
+         let alt_fvs :=
+           fun '(pair (pair _ bndrs) rhs) => addBndrs bndrs (expr_fvs rhs) in
+         (FV.unionFV (FV.unionFV (expr_fvs scrut) FV.emptyFV) (addBndr bndr (FV.unionsFV
+                                                                             (Lists.List.map alt_fvs alts)))) fv_cand
+         in_scope acc
+     | Core.Let (Core.NonRec bndr rhs) body, fv_cand, in_scope, acc =>
+         (FV.unionFV (let 'pair bndr rhs := pair bndr rhs in
+                      FV.unionFV (expr_fvs rhs) (bndrRuleAndUnfoldingFVs bndr)) (addBndr bndr
+                      (expr_fvs body))) fv_cand in_scope acc
+     | Core.Let (Core.Rec pairs) body, fv_cand, in_scope, acc =>
+         addBndrs (GHC.Base.map Data.Tuple.fst pairs) (FV.unionFV (FV.unionsFV
+                                                                   (Lists.List.map (fun '(pair bndr rhs) =>
+                                                                                      FV.unionFV (expr_fvs rhs)
+                                                                                                 (bndrRuleAndUnfoldingFVs
+                                                                                                  bndr)) pairs))
+                                                                  (expr_fvs body)) fv_cand in_scope acc
+     end.
 
 Definition exprFVs : Core.CoreExpr -> FV.FV :=
   FV.filterFV Core.isLocalVar GHC.Base.∘ expr_fvs.
@@ -354,121 +353,121 @@ Definition idUnfoldingVars : Core.Id -> Core.VarSet :=
 Definition freeVarsBind
    : Core.CoreBind -> Core.DVarSet -> (CoreBindWithFVs * Core.DVarSet)%type :=
   fix freeVars (arg_0__ : Core.CoreExpr) : CoreExprWithFVs
-        := match arg_0__ with
-           | Core.Mk_Var v =>
-               let ty_fvs := dVarTypeTyCoVars v in
-               if Core.isLocalVar v : bool
-               then pair (unionFVs (aFreeVar v) ty_fvs) (Core.AnnVar v) else
-               pair Core.emptyDVarSet (Core.AnnVar v)
-           | Core.Lit lit => pair Core.emptyDVarSet (Core.AnnLit lit)
-           | Core.Lam b body =>
-               let b_ty := Id.idType b in
-               let b_fvs := Core.emptyDVarSet in
-               let '(pair body_fvs _ as body') := freeVars body in
-               pair (unionFVs b_fvs (delBinderFV b body_fvs)) (Core.AnnLam b body')
-           | Core.App fun_ arg =>
-               let arg' := freeVars arg in
-               let fun' := freeVars fun_ in
-               pair (unionFVs (freeVarsOf fun') (freeVarsOf arg')) (Core.AnnApp fun' arg')
-           | Core.Case scrut bndr ty alts =>
-               let fv_alt :=
-                 fun '(pair (pair con args) rhs) =>
-                   let rhs2 := freeVars rhs in
-                   pair (delBindersFV args (freeVarsOf rhs2)) (pair (pair con args) rhs2) in
-               let 'pair alts_fvs_s alts2 := NestedRecursionHelpers.mapAndUnzipFix fv_alt
-                                               alts in
-               let alts_fvs := unionFVss alts_fvs_s in
-               let scrut2 := freeVars scrut in
-               pair (unionFVs (unionFVs (delBinderFV bndr alts_fvs) (freeVarsOf scrut2))
-                              Core.emptyDVarSet) (Core.AnnCase scrut2 bndr ty alts2)
-           | Core.Let bind body =>
-               let body2 := freeVars body in
-               let 'pair bind2 bind_fvs := freeVarsBind bind (freeVarsOf body2) in
-               pair bind_fvs (Core.AnnLet bind2 body2)
-           | Core.Cast expr co =>
-               let cfvs := Core.emptyDVarSet in
-               let expr2 := freeVars expr in
-               pair (unionFVs (freeVarsOf expr2) cfvs) (Core.AnnCast expr2 (pair cfvs co))
-           | Core.Mk_Type ty => pair Core.emptyDVarSet (Core.AnnType ty)
-           | Core.Mk_Coercion co => pair Core.emptyDVarSet (Core.AnnCoercion co)
-           end with freeVarsBind (arg_0__ : Core.CoreBind) (arg_1__ : Core.DVarSet)
-                      : (CoreBindWithFVs * Core.DVarSet)%type
-                      := match arg_0__, arg_1__ with
-                         | Core.NonRec binder rhs, body_fvs =>
-                             let body_fvs2 := delBinderFV binder body_fvs in
-                             let rhs2 := freeVars rhs in
-                             pair (Core.AnnNonRec binder rhs2) (unionFVs (unionFVs (freeVarsOf rhs2)
-                                                                                   body_fvs2)
-                                                                         (bndrRuleAndUnfoldingVarsDSet binder))
-                         | Core.Rec binds, body_fvs =>
-                             let 'pair binders rhss := GHC.List.unzip binds in
-                             let rhss2 := GHC.Base.map (freeVars GHC.Base.∘ snd) binds in
-                             let rhs_body_fvs :=
-                               Data.Foldable.foldr (unionFVs GHC.Base.∘ freeVarsOf) body_fvs rhss2 in
-                             let binders_fvs :=
-                               FV.fvDVarSet (FV.mapUnionFV bndrRuleAndUnfoldingFVs binders) in
-                             let all_fvs := unionFVs rhs_body_fvs binders_fvs in
-                             pair (Core.AnnRec (GHC.List.zip binders rhss2)) (delBindersFV binders all_fvs)
-                         end for freeVarsBind.
+    := match arg_0__ with
+       | Core.Mk_Var v =>
+           let ty_fvs := dVarTypeTyCoVars v in
+           if Core.isLocalVar v : bool
+           then pair (unionFVs (aFreeVar v) ty_fvs) (Core.AnnVar v) else
+           pair Core.emptyDVarSet (Core.AnnVar v)
+       | Core.Lit lit => pair Core.emptyDVarSet (Core.AnnLit lit)
+       | Core.Lam b body =>
+           let b_ty := Id.idType b in
+           let b_fvs := Core.emptyDVarSet in
+           let '(pair body_fvs _ as body') := freeVars body in
+           pair (unionFVs b_fvs (delBinderFV b body_fvs)) (Core.AnnLam b body')
+       | Core.App fun_ arg =>
+           let arg' := freeVars arg in
+           let fun' := freeVars fun_ in
+           pair (unionFVs (freeVarsOf fun') (freeVarsOf arg')) (Core.AnnApp fun' arg')
+       | Core.Case scrut bndr ty alts =>
+           let fv_alt :=
+             fun '(pair (pair con args) rhs) =>
+               let rhs2 := freeVars rhs in
+               pair (delBindersFV args (freeVarsOf rhs2)) (pair (pair con args) rhs2) in
+           let 'pair alts_fvs_s alts2 := NestedRecursionHelpers.mapAndUnzipFix fv_alt
+                                           alts in
+           let alts_fvs := unionFVss alts_fvs_s in
+           let scrut2 := freeVars scrut in
+           pair (unionFVs (unionFVs (delBinderFV bndr alts_fvs) (freeVarsOf scrut2))
+                          Core.emptyDVarSet) (Core.AnnCase scrut2 bndr ty alts2)
+       | Core.Let bind body =>
+           let body2 := freeVars body in
+           let 'pair bind2 bind_fvs := freeVarsBind bind (freeVarsOf body2) in
+           pair bind_fvs (Core.AnnLet bind2 body2)
+       | Core.Cast expr co =>
+           let cfvs := Core.emptyDVarSet in
+           let expr2 := freeVars expr in
+           pair (unionFVs (freeVarsOf expr2) cfvs) (Core.AnnCast expr2 (pair cfvs co))
+       | Core.Mk_Type ty => pair Core.emptyDVarSet (Core.AnnType ty)
+       | Core.Mk_Coercion co => pair Core.emptyDVarSet (Core.AnnCoercion co)
+       end
+  with freeVarsBind (arg_0__ : Core.CoreBind) (arg_1__ : Core.DVarSet)
+    : (CoreBindWithFVs * Core.DVarSet)%type
+    := match arg_0__, arg_1__ with
+       | Core.NonRec binder rhs, body_fvs =>
+           let body_fvs2 := delBinderFV binder body_fvs in
+           let rhs2 := freeVars rhs in
+           pair (Core.AnnNonRec binder rhs2) (unionFVs (unionFVs (freeVarsOf rhs2)
+                                                                 body_fvs2) (bndrRuleAndUnfoldingVarsDSet binder))
+       | Core.Rec binds, body_fvs =>
+           let 'pair binders rhss := GHC.List.unzip binds in
+           let rhss2 := GHC.Base.map (freeVars GHC.Base.∘ snd) binds in
+           let rhs_body_fvs :=
+             Data.Foldable.foldr (unionFVs GHC.Base.∘ freeVarsOf) body_fvs rhss2 in
+           let binders_fvs :=
+             FV.fvDVarSet (FV.mapUnionFV bndrRuleAndUnfoldingFVs binders) in
+           let all_fvs := unionFVs rhs_body_fvs binders_fvs in
+           pair (Core.AnnRec (GHC.List.zip binders rhss2)) (delBindersFV binders all_fvs)
+       end for freeVarsBind.
 
 Definition freeVars : Core.CoreExpr -> CoreExprWithFVs :=
   fix freeVars (arg_0__ : Core.CoreExpr) : CoreExprWithFVs
-        := match arg_0__ with
-           | Core.Mk_Var v =>
-               let ty_fvs := dVarTypeTyCoVars v in
-               if Core.isLocalVar v : bool
-               then pair (unionFVs (aFreeVar v) ty_fvs) (Core.AnnVar v) else
-               pair Core.emptyDVarSet (Core.AnnVar v)
-           | Core.Lit lit => pair Core.emptyDVarSet (Core.AnnLit lit)
-           | Core.Lam b body =>
-               let b_ty := Id.idType b in
-               let b_fvs := Core.emptyDVarSet in
-               let '(pair body_fvs _ as body') := freeVars body in
-               pair (unionFVs b_fvs (delBinderFV b body_fvs)) (Core.AnnLam b body')
-           | Core.App fun_ arg =>
-               let arg' := freeVars arg in
-               let fun' := freeVars fun_ in
-               pair (unionFVs (freeVarsOf fun') (freeVarsOf arg')) (Core.AnnApp fun' arg')
-           | Core.Case scrut bndr ty alts =>
-               let fv_alt :=
-                 fun '(pair (pair con args) rhs) =>
-                   let rhs2 := freeVars rhs in
-                   pair (delBindersFV args (freeVarsOf rhs2)) (pair (pair con args) rhs2) in
-               let 'pair alts_fvs_s alts2 := NestedRecursionHelpers.mapAndUnzipFix fv_alt
-                                               alts in
-               let alts_fvs := unionFVss alts_fvs_s in
-               let scrut2 := freeVars scrut in
-               pair (unionFVs (unionFVs (delBinderFV bndr alts_fvs) (freeVarsOf scrut2))
-                              Core.emptyDVarSet) (Core.AnnCase scrut2 bndr ty alts2)
-           | Core.Let bind body =>
-               let body2 := freeVars body in
-               let 'pair bind2 bind_fvs := freeVarsBind bind (freeVarsOf body2) in
-               pair bind_fvs (Core.AnnLet bind2 body2)
-           | Core.Cast expr co =>
-               let cfvs := Core.emptyDVarSet in
-               let expr2 := freeVars expr in
-               pair (unionFVs (freeVarsOf expr2) cfvs) (Core.AnnCast expr2 (pair cfvs co))
-           | Core.Mk_Type ty => pair Core.emptyDVarSet (Core.AnnType ty)
-           | Core.Mk_Coercion co => pair Core.emptyDVarSet (Core.AnnCoercion co)
-           end with freeVarsBind (arg_0__ : Core.CoreBind) (arg_1__ : Core.DVarSet)
-                      : (CoreBindWithFVs * Core.DVarSet)%type
-                      := match arg_0__, arg_1__ with
-                         | Core.NonRec binder rhs, body_fvs =>
-                             let body_fvs2 := delBinderFV binder body_fvs in
-                             let rhs2 := freeVars rhs in
-                             pair (Core.AnnNonRec binder rhs2) (unionFVs (unionFVs (freeVarsOf rhs2)
-                                                                                   body_fvs2)
-                                                                         (bndrRuleAndUnfoldingVarsDSet binder))
-                         | Core.Rec binds, body_fvs =>
-                             let 'pair binders rhss := GHC.List.unzip binds in
-                             let rhss2 := GHC.Base.map (freeVars GHC.Base.∘ snd) binds in
-                             let rhs_body_fvs :=
-                               Data.Foldable.foldr (unionFVs GHC.Base.∘ freeVarsOf) body_fvs rhss2 in
-                             let binders_fvs :=
-                               FV.fvDVarSet (FV.mapUnionFV bndrRuleAndUnfoldingFVs binders) in
-                             let all_fvs := unionFVs rhs_body_fvs binders_fvs in
-                             pair (Core.AnnRec (GHC.List.zip binders rhss2)) (delBindersFV binders all_fvs)
-                         end for freeVars.
+    := match arg_0__ with
+       | Core.Mk_Var v =>
+           let ty_fvs := dVarTypeTyCoVars v in
+           if Core.isLocalVar v : bool
+           then pair (unionFVs (aFreeVar v) ty_fvs) (Core.AnnVar v) else
+           pair Core.emptyDVarSet (Core.AnnVar v)
+       | Core.Lit lit => pair Core.emptyDVarSet (Core.AnnLit lit)
+       | Core.Lam b body =>
+           let b_ty := Id.idType b in
+           let b_fvs := Core.emptyDVarSet in
+           let '(pair body_fvs _ as body') := freeVars body in
+           pair (unionFVs b_fvs (delBinderFV b body_fvs)) (Core.AnnLam b body')
+       | Core.App fun_ arg =>
+           let arg' := freeVars arg in
+           let fun' := freeVars fun_ in
+           pair (unionFVs (freeVarsOf fun') (freeVarsOf arg')) (Core.AnnApp fun' arg')
+       | Core.Case scrut bndr ty alts =>
+           let fv_alt :=
+             fun '(pair (pair con args) rhs) =>
+               let rhs2 := freeVars rhs in
+               pair (delBindersFV args (freeVarsOf rhs2)) (pair (pair con args) rhs2) in
+           let 'pair alts_fvs_s alts2 := NestedRecursionHelpers.mapAndUnzipFix fv_alt
+                                           alts in
+           let alts_fvs := unionFVss alts_fvs_s in
+           let scrut2 := freeVars scrut in
+           pair (unionFVs (unionFVs (delBinderFV bndr alts_fvs) (freeVarsOf scrut2))
+                          Core.emptyDVarSet) (Core.AnnCase scrut2 bndr ty alts2)
+       | Core.Let bind body =>
+           let body2 := freeVars body in
+           let 'pair bind2 bind_fvs := freeVarsBind bind (freeVarsOf body2) in
+           pair bind_fvs (Core.AnnLet bind2 body2)
+       | Core.Cast expr co =>
+           let cfvs := Core.emptyDVarSet in
+           let expr2 := freeVars expr in
+           pair (unionFVs (freeVarsOf expr2) cfvs) (Core.AnnCast expr2 (pair cfvs co))
+       | Core.Mk_Type ty => pair Core.emptyDVarSet (Core.AnnType ty)
+       | Core.Mk_Coercion co => pair Core.emptyDVarSet (Core.AnnCoercion co)
+       end
+  with freeVarsBind (arg_0__ : Core.CoreBind) (arg_1__ : Core.DVarSet)
+    : (CoreBindWithFVs * Core.DVarSet)%type
+    := match arg_0__, arg_1__ with
+       | Core.NonRec binder rhs, body_fvs =>
+           let body_fvs2 := delBinderFV binder body_fvs in
+           let rhs2 := freeVars rhs in
+           pair (Core.AnnNonRec binder rhs2) (unionFVs (unionFVs (freeVarsOf rhs2)
+                                                                 body_fvs2) (bndrRuleAndUnfoldingVarsDSet binder))
+       | Core.Rec binds, body_fvs =>
+           let 'pair binders rhss := GHC.List.unzip binds in
+           let rhss2 := GHC.Base.map (freeVars GHC.Base.∘ snd) binds in
+           let rhs_body_fvs :=
+             Data.Foldable.foldr (unionFVs GHC.Base.∘ freeVarsOf) body_fvs rhss2 in
+           let binders_fvs :=
+             FV.fvDVarSet (FV.mapUnionFV bndrRuleAndUnfoldingFVs binders) in
+           let all_fvs := unionFVs rhs_body_fvs binders_fvs in
+           pair (Core.AnnRec (GHC.List.zip binders rhss2)) (delBindersFV binders all_fvs)
+       end for freeVars.
 
 (* External variables:
      None andb bool cons list negb op_zt__ option pair snd BasicTypes.Activation

--- a/examples/ghc/lib/CoreMonad.v
+++ b/examples/ghc/lib/CoreMonad.v
@@ -30,85 +30,84 @@ Require UniqSupply.
 
 (* Converted type declarations: *)
 
-Inductive Tick : Type
-  := | PreInlineUnconditionally : Core.Id -> Tick
-  |  PostInlineUnconditionally : Core.Id -> Tick
-  |  UnfoldingDone : Core.Id -> Tick
-  |  RuleFired : FastString.FastString -> Tick
-  |  LetFloatFromLet : Tick
-  |  EtaExpansion : Core.Id -> Tick
-  |  EtaReduction : Core.Id -> Tick
-  |  BetaReduction : Core.Id -> Tick
-  |  CaseOfCase : Core.Id -> Tick
-  |  KnownBranch : Core.Id -> Tick
-  |  CaseMerge : Core.Id -> Tick
-  |  AltMerge : Core.Id -> Tick
-  |  CaseElim : Core.Id -> Tick
-  |  CaseIdentity : Core.Id -> Tick
-  |  FillInCaseDefault : Core.Id -> Tick
-  |  BottomFound : Tick
-  |  SimplifierDone : Tick.
+Inductive Tick : Type :=
+  | PreInlineUnconditionally : Core.Id -> Tick
+  | PostInlineUnconditionally : Core.Id -> Tick
+  | UnfoldingDone : Core.Id -> Tick
+  | RuleFired : FastString.FastString -> Tick
+  | LetFloatFromLet : Tick
+  | EtaExpansion : Core.Id -> Tick
+  | EtaReduction : Core.Id -> Tick
+  | BetaReduction : Core.Id -> Tick
+  | CaseOfCase : Core.Id -> Tick
+  | KnownBranch : Core.Id -> Tick
+  | CaseMerge : Core.Id -> Tick
+  | AltMerge : Core.Id -> Tick
+  | CaseElim : Core.Id -> Tick
+  | CaseIdentity : Core.Id -> Tick
+  | FillInCaseDefault : Core.Id -> Tick
+  | BottomFound : Tick
+  | SimplifierDone : Tick.
 
 Definition TickCounts :=
   (Data.Map.Internal.Map Tick nat)%type.
 
-Inductive SimplMode : Type
-  := | Mk_SimplMode (sm_names : list GHC.Base.String) (sm_phase
+Inductive SimplMode : Type :=
+  | Mk_SimplMode (sm_names : list GHC.Base.String) (sm_phase
     : BasicTypes.CompilerPhase) (sm_dflags : DynFlags.DynFlags) (sm_rules : bool)
   (sm_inline : bool) (sm_case_case : bool) (sm_eta_expand : bool)
    : SimplMode.
 
-Inductive SimplCount : Type
-  := | VerySimplCount : nat -> SimplCount
-  |  Mk_SimplCount (ticks : nat) (details : TickCounts) (n_log : nat) (log1
+Inductive SimplCount : Type :=
+  | VerySimplCount : nat -> SimplCount
+  | Mk_SimplCount (ticks : nat) (details : TickCounts) (n_log : nat) (log1
     : list Tick) (log2 : list Tick)
    : SimplCount.
 
 Axiom PluginPass : Type.
 
-Inductive FloatOutSwitches : Type
-  := | Mk_FloatOutSwitches (floatOutLambdas : option nat) (floatOutConstants
-    : bool) (floatOutOverSatApps : bool) (floatToTopLevelOnly : bool)
+Inductive FloatOutSwitches : Type :=
+  | Mk_FloatOutSwitches (floatOutLambdas : option nat) (floatOutConstants : bool)
+  (floatOutOverSatApps : bool) (floatToTopLevelOnly : bool)
    : FloatOutSwitches.
 
-Inductive CoreWriter : Type
-  := | Mk_CoreWriter (cw_simpl_count : SimplCount) : CoreWriter.
+Inductive CoreWriter : Type :=
+  | Mk_CoreWriter (cw_simpl_count : SimplCount) : CoreWriter.
 
-Inductive CoreToDo : Type
-  := | CoreDoSimplify : nat -> SimplMode -> CoreToDo
-  |  CoreDoPluginPass : GHC.Base.String -> PluginPass -> CoreToDo
-  |  CoreDoFloatInwards : CoreToDo
-  |  CoreDoFloatOutwards : FloatOutSwitches -> CoreToDo
-  |  CoreLiberateCase : CoreToDo
-  |  CoreDoPrintCore : CoreToDo
-  |  CoreDoStaticArgs : CoreToDo
-  |  CoreDoCallArity : CoreToDo
-  |  CoreDoExitify : CoreToDo
-  |  CoreDoStrictness : CoreToDo
-  |  CoreDoWorkerWrapper : CoreToDo
-  |  CoreDoSpecialising : CoreToDo
-  |  CoreDoSpecConstr : CoreToDo
-  |  CoreCSE : CoreToDo
-  |  CoreDoRuleCheck : BasicTypes.CompilerPhase -> GHC.Base.String -> CoreToDo
-  |  CoreDoVectorisation : CoreToDo
-  |  CoreDoNothing : CoreToDo
-  |  CoreDoPasses : list CoreToDo -> CoreToDo
-  |  CoreDesugar : CoreToDo
-  |  CoreDesugarOpt : CoreToDo
-  |  CoreTidy : CoreToDo
-  |  CorePrep : CoreToDo
-  |  CoreOccurAnal : CoreToDo.
+Inductive CoreToDo : Type :=
+  | CoreDoSimplify : nat -> SimplMode -> CoreToDo
+  | CoreDoPluginPass : GHC.Base.String -> PluginPass -> CoreToDo
+  | CoreDoFloatInwards : CoreToDo
+  | CoreDoFloatOutwards : FloatOutSwitches -> CoreToDo
+  | CoreLiberateCase : CoreToDo
+  | CoreDoPrintCore : CoreToDo
+  | CoreDoStaticArgs : CoreToDo
+  | CoreDoCallArity : CoreToDo
+  | CoreDoExitify : CoreToDo
+  | CoreDoStrictness : CoreToDo
+  | CoreDoWorkerWrapper : CoreToDo
+  | CoreDoSpecialising : CoreToDo
+  | CoreDoSpecConstr : CoreToDo
+  | CoreCSE : CoreToDo
+  | CoreDoRuleCheck : BasicTypes.CompilerPhase -> GHC.Base.String -> CoreToDo
+  | CoreDoVectorisation : CoreToDo
+  | CoreDoNothing : CoreToDo
+  | CoreDoPasses : list CoreToDo -> CoreToDo
+  | CoreDesugar : CoreToDo
+  | CoreDesugarOpt : CoreToDo
+  | CoreTidy : CoreToDo
+  | CorePrep : CoreToDo
+  | CoreOccurAnal : CoreToDo.
 
-Inductive CoreState : Type
-  := | Mk_CoreState (cs_uniq_supply : UniqSupply.UniqSupply) : CoreState.
+Inductive CoreState : Type :=
+  | Mk_CoreState (cs_uniq_supply : UniqSupply.UniqSupply) : CoreState.
 
 Axiom CoreReader : Type.
 
 Axiom CoreIOEnv : Type -> Type.
 
-Inductive CoreM a : Type
-  := | Mk_CoreM (unCoreM
-    : CoreState -> CoreIOEnv (a * CoreState * CoreWriter)%type)
+Inductive CoreM a : Type :=
+  | Mk_CoreM (unCoreM : CoreState -> CoreIOEnv (a * CoreState * CoreWriter)%type)
    : CoreM a.
 
 Arguments Mk_CoreM {_} _.

--- a/examples/ghc/lib/CoreStats.v
+++ b/examples/ghc/lib/CoreStats.v
@@ -23,8 +23,8 @@ Require Id.
 
 (* Converted type declarations: *)
 
-Inductive CoreStats : Type
-  := | CS (cs_tm : nat) (cs_ty : nat) (cs_co : nat) (cs_vb : nat) (cs_jb : nat)
+Inductive CoreStats : Type :=
+  | CS (cs_tm : nat) (cs_ty : nat) (cs_co : nat) (cs_vb : nat) (cs_jb : nat)
    : CoreStats.
 
 Instance Default__CoreStats : GHC.Err.Default CoreStats :=
@@ -96,58 +96,60 @@ Definition letBndrStats : BasicTypes.TopLevelFlag -> Var -> CoreStats :=
 
 Definition bindStats : BasicTypes.TopLevelFlag -> CoreBind -> CoreStats :=
   fix exprStats (arg_0__ : CoreExpr) : CoreStats
-        := let altStats (arg_0__ : CoreAlt) : CoreStats :=
-             let 'pair (pair _ bs) r := arg_0__ in
-             plusCS (altBndrStats bs) (exprStats r) in
-           match arg_0__ with
-           | Mk_Var _ => oneTM
-           | Lit _ => oneTM
-           | Mk_Type t => tyStats t
-           | Mk_Coercion c => coStats c
-           | App f a => plusCS (exprStats f) (exprStats a)
-           | Lam b e => plusCS (bndrStats b) (exprStats e)
-           | Let b e => plusCS (bindStats BasicTypes.NotTopLevel b) (exprStats e)
-           | Case e b _ as_ =>
-               plusCS (plusCS (exprStats e) (bndrStats b)) (sumCS altStats as_)
-           | Cast e co => plusCS (coStats co) (exprStats e)
-           end with bindStats (arg_0__ : BasicTypes.TopLevelFlag) (arg_1__ : CoreBind)
-                      : CoreStats
-                      := let bindingStats (top_lvl : BasicTypes.TopLevelFlag) (v : Var) (r : CoreExpr)
-                          : CoreStats :=
-                           plusCS (letBndrStats top_lvl v) (exprStats r) in
-                         match arg_0__, arg_1__ with
-                         | top_lvl, NonRec v r => bindingStats top_lvl v r
-                         | top_lvl, Rec prs => sumCS (fun '(pair v r) => bindingStats top_lvl v r) prs
-                         end for bindStats.
+    := let altStats (arg_0__ : CoreAlt) : CoreStats :=
+         let 'pair (pair _ bs) r := arg_0__ in
+         plusCS (altBndrStats bs) (exprStats r) in
+       match arg_0__ with
+       | Mk_Var _ => oneTM
+       | Lit _ => oneTM
+       | Mk_Type t => tyStats t
+       | Mk_Coercion c => coStats c
+       | App f a => plusCS (exprStats f) (exprStats a)
+       | Lam b e => plusCS (bndrStats b) (exprStats e)
+       | Let b e => plusCS (bindStats BasicTypes.NotTopLevel b) (exprStats e)
+       | Case e b _ as_ =>
+           plusCS (plusCS (exprStats e) (bndrStats b)) (sumCS altStats as_)
+       | Cast e co => plusCS (coStats co) (exprStats e)
+       end
+  with bindStats (arg_0__ : BasicTypes.TopLevelFlag) (arg_1__ : CoreBind)
+    : CoreStats
+    := let bindingStats (top_lvl : BasicTypes.TopLevelFlag) (v : Var) (r : CoreExpr)
+        : CoreStats :=
+         plusCS (letBndrStats top_lvl v) (exprStats r) in
+       match arg_0__, arg_1__ with
+       | top_lvl, NonRec v r => bindingStats top_lvl v r
+       | top_lvl, Rec prs => sumCS (fun '(pair v r) => bindingStats top_lvl v r) prs
+       end for bindStats.
 
 Definition coreBindsStats : list CoreBind -> CoreStats :=
   sumCS (bindStats BasicTypes.TopLevel).
 
 Definition exprStats : CoreExpr -> CoreStats :=
   fix exprStats (arg_0__ : CoreExpr) : CoreStats
-        := let altStats (arg_0__ : CoreAlt) : CoreStats :=
-             let 'pair (pair _ bs) r := arg_0__ in
-             plusCS (altBndrStats bs) (exprStats r) in
-           match arg_0__ with
-           | Mk_Var _ => oneTM
-           | Lit _ => oneTM
-           | Mk_Type t => tyStats t
-           | Mk_Coercion c => coStats c
-           | App f a => plusCS (exprStats f) (exprStats a)
-           | Lam b e => plusCS (bndrStats b) (exprStats e)
-           | Let b e => plusCS (bindStats BasicTypes.NotTopLevel b) (exprStats e)
-           | Case e b _ as_ =>
-               plusCS (plusCS (exprStats e) (bndrStats b)) (sumCS altStats as_)
-           | Cast e co => plusCS (coStats co) (exprStats e)
-           end with bindStats (arg_0__ : BasicTypes.TopLevelFlag) (arg_1__ : CoreBind)
-                      : CoreStats
-                      := let bindingStats (top_lvl : BasicTypes.TopLevelFlag) (v : Var) (r : CoreExpr)
-                          : CoreStats :=
-                           plusCS (letBndrStats top_lvl v) (exprStats r) in
-                         match arg_0__, arg_1__ with
-                         | top_lvl, NonRec v r => bindingStats top_lvl v r
-                         | top_lvl, Rec prs => sumCS (fun '(pair v r) => bindingStats top_lvl v r) prs
-                         end for exprStats.
+    := let altStats (arg_0__ : CoreAlt) : CoreStats :=
+         let 'pair (pair _ bs) r := arg_0__ in
+         plusCS (altBndrStats bs) (exprStats r) in
+       match arg_0__ with
+       | Mk_Var _ => oneTM
+       | Lit _ => oneTM
+       | Mk_Type t => tyStats t
+       | Mk_Coercion c => coStats c
+       | App f a => plusCS (exprStats f) (exprStats a)
+       | Lam b e => plusCS (bndrStats b) (exprStats e)
+       | Let b e => plusCS (bindStats BasicTypes.NotTopLevel b) (exprStats e)
+       | Case e b _ as_ =>
+           plusCS (plusCS (exprStats e) (bndrStats b)) (sumCS altStats as_)
+       | Cast e co => plusCS (coStats co) (exprStats e)
+       end
+  with bindStats (arg_0__ : BasicTypes.TopLevelFlag) (arg_1__ : CoreBind)
+    : CoreStats
+    := let bindingStats (top_lvl : BasicTypes.TopLevelFlag) (v : Var) (r : CoreExpr)
+        : CoreStats :=
+         plusCS (letBndrStats top_lvl v) (exprStats r) in
+       match arg_0__, arg_1__ with
+       | top_lvl, NonRec v r => bindingStats top_lvl v r
+       | top_lvl, Rec prs => sumCS (fun '(pair v r) => bindingStats top_lvl v r) prs
+       end for exprStats.
 
 Definition bindingStats
    : BasicTypes.TopLevelFlag -> Var -> CoreExpr -> CoreStats :=
@@ -164,54 +166,56 @@ Definition bndrsSize : list Var -> nat :=
 
 Definition bindSize : CoreBind -> nat :=
   fix exprSize (arg_0__ : CoreExpr) : nat
-        := let altSize (arg_0__ : CoreAlt) : nat :=
-             let 'pair (pair _ bs) e := arg_0__ in
-             bndrsSize bs + exprSize e in
-           match arg_0__ with
-           | Mk_Var _ => 1
-           | Lit _ => 1
-           | App f a => exprSize f + exprSize a
-           | Lam b e => bndrSize b + exprSize e
-           | Let b e => bindSize b + exprSize e
-           | Case e b _ as_ => exprSize e + bndrSize b + 1 + sum (map altSize as_)
-           | Cast e _ => 1 + exprSize e
-           | Mk_Type _ => 1
-           | Mk_Coercion _ => 1
-           end with bindSize (arg_0__ : CoreBind) : nat
-                      := let pairSize (arg_0__ : (Var * CoreExpr)%type) : nat :=
-                           let 'pair b e := arg_0__ in
-                           bndrSize b + exprSize e in
-                         match arg_0__ with
-                         | NonRec b e => bndrSize b + exprSize e
-                         | Rec prs => sum (map pairSize prs)
-                         end for bindSize.
+    := let altSize (arg_0__ : CoreAlt) : nat :=
+         let 'pair (pair _ bs) e := arg_0__ in
+         bndrsSize bs + exprSize e in
+       match arg_0__ with
+       | Mk_Var _ => 1
+       | Lit _ => 1
+       | App f a => exprSize f + exprSize a
+       | Lam b e => bndrSize b + exprSize e
+       | Let b e => bindSize b + exprSize e
+       | Case e b _ as_ => exprSize e + bndrSize b + 1 + sum (map altSize as_)
+       | Cast e _ => 1 + exprSize e
+       | Mk_Type _ => 1
+       | Mk_Coercion _ => 1
+       end
+  with bindSize (arg_0__ : CoreBind) : nat
+    := let pairSize (arg_0__ : (Var * CoreExpr)%type) : nat :=
+         let 'pair b e := arg_0__ in
+         bndrSize b + exprSize e in
+       match arg_0__ with
+       | NonRec b e => bndrSize b + exprSize e
+       | Rec prs => sum (map pairSize prs)
+       end for bindSize.
 
 Definition coreBindsSize : list CoreBind -> nat :=
   fun bs => sum (map bindSize bs).
 
 Definition exprSize : CoreExpr -> nat :=
   fix exprSize (arg_0__ : CoreExpr) : nat
-        := let altSize (arg_0__ : CoreAlt) : nat :=
-             let 'pair (pair _ bs) e := arg_0__ in
-             bndrsSize bs + exprSize e in
-           match arg_0__ with
-           | Mk_Var _ => 1
-           | Lit _ => 1
-           | App f a => exprSize f + exprSize a
-           | Lam b e => bndrSize b + exprSize e
-           | Let b e => bindSize b + exprSize e
-           | Case e b _ as_ => exprSize e + bndrSize b + 1 + sum (map altSize as_)
-           | Cast e _ => 1 + exprSize e
-           | Mk_Type _ => 1
-           | Mk_Coercion _ => 1
-           end with bindSize (arg_0__ : CoreBind) : nat
-                      := let pairSize (arg_0__ : (Var * CoreExpr)%type) : nat :=
-                           let 'pair b e := arg_0__ in
-                           bndrSize b + exprSize e in
-                         match arg_0__ with
-                         | NonRec b e => bndrSize b + exprSize e
-                         | Rec prs => sum (map pairSize prs)
-                         end for exprSize.
+    := let altSize (arg_0__ : CoreAlt) : nat :=
+         let 'pair (pair _ bs) e := arg_0__ in
+         bndrsSize bs + exprSize e in
+       match arg_0__ with
+       | Mk_Var _ => 1
+       | Lit _ => 1
+       | App f a => exprSize f + exprSize a
+       | Lam b e => bndrSize b + exprSize e
+       | Let b e => bindSize b + exprSize e
+       | Case e b _ as_ => exprSize e + bndrSize b + 1 + sum (map altSize as_)
+       | Cast e _ => 1 + exprSize e
+       | Mk_Type _ => 1
+       | Mk_Coercion _ => 1
+       end
+  with bindSize (arg_0__ : CoreBind) : nat
+    := let pairSize (arg_0__ : (Var * CoreExpr)%type) : nat :=
+         let 'pair b e := arg_0__ in
+         bndrSize b + exprSize e in
+       match arg_0__ with
+       | NonRec b e => bndrSize b + exprSize e
+       | Rec prs => sum (map pairSize prs)
+       end for exprSize.
 
 Definition tickSize : Tickish Id -> nat :=
   fun arg_0__ => match arg_0__ with | ProfNote _ _ _ => 1 | _ => 1 end.

--- a/examples/ghc/lib/CoreSubst.v
+++ b/examples/ghc/lib/CoreSubst.v
@@ -39,8 +39,8 @@ Import GHC.Num.Notations.
 Definition IdSubstEnv :=
   (IdEnv CoreExpr)%type.
 
-Inductive Subst : Type
-  := | Mk_Subst : InScopeSet -> IdSubstEnv -> TvSubstEnv -> CvSubstEnv -> Subst.
+Inductive Subst : Type :=
+  | Mk_Subst : InScopeSet -> IdSubstEnv -> TvSubstEnv -> CvSubstEnv -> Subst.
 
 (* Midamble *)
 
@@ -153,12 +153,12 @@ Definition extendSubstWithVar : Subst -> Var -> Var -> Subst :=
     else extendIdSubst subst v1 (Mk_Var v2).
 
 Fixpoint extendSubstList (arg_0__ : Subst) (arg_1__ : list (Var * CoreArg)%type)
-           : Subst
-           := match arg_0__, arg_1__ with
-              | subst, nil => subst
-              | subst, cons (pair var rhs) prs =>
-                  extendSubstList (extendSubst subst var rhs) prs
-              end.
+  : Subst
+  := match arg_0__, arg_1__ with
+     | subst, nil => subst
+     | subst, cons (pair var rhs) prs =>
+         extendSubstList (extendSubst subst var rhs) prs
+     end.
 
 Definition lookupIdSubst : String -> Subst -> Id -> CoreExpr :=
   fun arg_0__ arg_1__ arg_2__ =>
@@ -324,47 +324,47 @@ Definition substRecBndrs : Subst -> list Id -> (Subst * list Id)%type :=
 
 Definition subst_expr : String -> Subst -> CoreExpr -> CoreExpr :=
   fix subst_expr (doc : String) (subst : Subst) (expr : CoreExpr) : CoreExpr
-        := let go_alt :=
-             fun arg_0__ arg_1__ =>
-               match arg_0__, arg_1__ with
-               | subst, pair (pair con bndrs) rhs =>
-                   let 'pair subst' bndrs' := substBndrs subst bndrs in
-                   pair (pair con bndrs') (subst_expr doc subst' rhs)
-               end in
-           let fix go arg_5__
-                     := match arg_5__ with
-                        | Mk_Var v => lookupIdSubst (doc) subst v
-                        | Mk_Type ty => Mk_Type (substTy subst ty)
-                        | Mk_Coercion co => Mk_Coercion (substCo subst co)
-                        | Lit lit => Lit lit
-                        | App fun_ arg => App (go fun_) (go arg)
-                        | Cast e co => Cast (go e) (substCo subst co)
-                        | Lam bndr body =>
-                            let 'pair subst' bndr' := substBndr subst bndr in
-                            Lam bndr' (subst_expr doc subst' body)
-                        | Let bind body =>
-                            let 'pair subst' bind' := substBind subst bind in
-                            Let bind' (subst_expr doc subst' body)
-                        | Case scrut bndr ty alts =>
-                            let 'pair subst' bndr' := substBndr subst bndr in
-                            Case (go scrut) bndr' (substTy subst ty) (map (go_alt subst') alts)
-                        end in
-           go expr with substBind (arg_0__ : Subst) (arg_1__ : CoreBind) : (Subst *
-                                                                            CoreBind)%type
-                          := match arg_0__, arg_1__ with
-                             | subst, NonRec bndr rhs =>
-                                 let 'pair subst' bndr' := substBndr subst bndr in
-                                 pair subst' (NonRec bndr' (subst_expr (Datatypes.id (GHC.Base.hs_string__
-                                                                                      "substBind")) subst rhs))
-                             | subst, Rec pairs =>
-                                 let 'pair bndrs rhss := unzip pairs in
-                                 let 'pair subst' bndrs' := substRecBndrs subst bndrs in
-                                 let rhss' :=
-                                   map (fun ps =>
-                                          subst_expr (Datatypes.id (GHC.Base.hs_string__ "substBind")) subst' (snd ps))
-                                       pairs in
-                                 pair subst' (Rec (zip bndrs' rhss'))
-                             end for subst_expr.
+    := let go_alt :=
+         fun arg_0__ arg_1__ =>
+           match arg_0__, arg_1__ with
+           | subst, pair (pair con bndrs) rhs =>
+               let 'pair subst' bndrs' := substBndrs subst bndrs in
+               pair (pair con bndrs') (subst_expr doc subst' rhs)
+           end in
+       let fix go arg_5__
+         := match arg_5__ with
+            | Mk_Var v => lookupIdSubst (doc) subst v
+            | Mk_Type ty => Mk_Type (substTy subst ty)
+            | Mk_Coercion co => Mk_Coercion (substCo subst co)
+            | Lit lit => Lit lit
+            | App fun_ arg => App (go fun_) (go arg)
+            | Cast e co => Cast (go e) (substCo subst co)
+            | Lam bndr body =>
+                let 'pair subst' bndr' := substBndr subst bndr in
+                Lam bndr' (subst_expr doc subst' body)
+            | Let bind body =>
+                let 'pair subst' bind' := substBind subst bind in
+                Let bind' (subst_expr doc subst' body)
+            | Case scrut bndr ty alts =>
+                let 'pair subst' bndr' := substBndr subst bndr in
+                Case (go scrut) bndr' (substTy subst ty) (map (go_alt subst') alts)
+            end in
+       go expr
+  with substBind (arg_0__ : Subst) (arg_1__ : CoreBind) : (Subst * CoreBind)%type
+    := match arg_0__, arg_1__ with
+       | subst, NonRec bndr rhs =>
+           let 'pair subst' bndr' := substBndr subst bndr in
+           pair subst' (NonRec bndr' (subst_expr (Datatypes.id (GHC.Base.hs_string__
+                                                                "substBind")) subst rhs))
+       | subst, Rec pairs =>
+           let 'pair bndrs rhss := unzip pairs in
+           let 'pair subst' bndrs' := substRecBndrs subst bndrs in
+           let rhss' :=
+             map (fun ps =>
+                    subst_expr (Datatypes.id (GHC.Base.hs_string__ "substBind")) subst' (snd ps))
+                 pairs in
+           pair subst' (Rec (zip bndrs' rhss'))
+       end for subst_expr.
 
 Definition substExprSC : String -> Subst -> CoreExpr -> CoreExpr :=
   fun doc subst orig_expr =>
@@ -376,47 +376,47 @@ Definition substExpr : String -> Subst -> CoreExpr -> CoreExpr :=
 
 Definition substBind : Subst -> CoreBind -> (Subst * CoreBind)%type :=
   fix subst_expr (doc : String) (subst : Subst) (expr : CoreExpr) : CoreExpr
-        := let go_alt :=
-             fun arg_0__ arg_1__ =>
-               match arg_0__, arg_1__ with
-               | subst, pair (pair con bndrs) rhs =>
-                   let 'pair subst' bndrs' := substBndrs subst bndrs in
-                   pair (pair con bndrs') (subst_expr doc subst' rhs)
-               end in
-           let fix go arg_5__
-                     := match arg_5__ with
-                        | Mk_Var v => lookupIdSubst (doc) subst v
-                        | Mk_Type ty => Mk_Type (substTy subst ty)
-                        | Mk_Coercion co => Mk_Coercion (substCo subst co)
-                        | Lit lit => Lit lit
-                        | App fun_ arg => App (go fun_) (go arg)
-                        | Cast e co => Cast (go e) (substCo subst co)
-                        | Lam bndr body =>
-                            let 'pair subst' bndr' := substBndr subst bndr in
-                            Lam bndr' (subst_expr doc subst' body)
-                        | Let bind body =>
-                            let 'pair subst' bind' := substBind subst bind in
-                            Let bind' (subst_expr doc subst' body)
-                        | Case scrut bndr ty alts =>
-                            let 'pair subst' bndr' := substBndr subst bndr in
-                            Case (go scrut) bndr' (substTy subst ty) (map (go_alt subst') alts)
-                        end in
-           go expr with substBind (arg_0__ : Subst) (arg_1__ : CoreBind) : (Subst *
-                                                                            CoreBind)%type
-                          := match arg_0__, arg_1__ with
-                             | subst, NonRec bndr rhs =>
-                                 let 'pair subst' bndr' := substBndr subst bndr in
-                                 pair subst' (NonRec bndr' (subst_expr (Datatypes.id (GHC.Base.hs_string__
-                                                                                      "substBind")) subst rhs))
-                             | subst, Rec pairs =>
-                                 let 'pair bndrs rhss := unzip pairs in
-                                 let 'pair subst' bndrs' := substRecBndrs subst bndrs in
-                                 let rhss' :=
-                                   map (fun ps =>
-                                          subst_expr (Datatypes.id (GHC.Base.hs_string__ "substBind")) subst' (snd ps))
-                                       pairs in
-                                 pair subst' (Rec (zip bndrs' rhss'))
-                             end for substBind.
+    := let go_alt :=
+         fun arg_0__ arg_1__ =>
+           match arg_0__, arg_1__ with
+           | subst, pair (pair con bndrs) rhs =>
+               let 'pair subst' bndrs' := substBndrs subst bndrs in
+               pair (pair con bndrs') (subst_expr doc subst' rhs)
+           end in
+       let fix go arg_5__
+         := match arg_5__ with
+            | Mk_Var v => lookupIdSubst (doc) subst v
+            | Mk_Type ty => Mk_Type (substTy subst ty)
+            | Mk_Coercion co => Mk_Coercion (substCo subst co)
+            | Lit lit => Lit lit
+            | App fun_ arg => App (go fun_) (go arg)
+            | Cast e co => Cast (go e) (substCo subst co)
+            | Lam bndr body =>
+                let 'pair subst' bndr' := substBndr subst bndr in
+                Lam bndr' (subst_expr doc subst' body)
+            | Let bind body =>
+                let 'pair subst' bind' := substBind subst bind in
+                Let bind' (subst_expr doc subst' body)
+            | Case scrut bndr ty alts =>
+                let 'pair subst' bndr' := substBndr subst bndr in
+                Case (go scrut) bndr' (substTy subst ty) (map (go_alt subst') alts)
+            end in
+       go expr
+  with substBind (arg_0__ : Subst) (arg_1__ : CoreBind) : (Subst * CoreBind)%type
+    := match arg_0__, arg_1__ with
+       | subst, NonRec bndr rhs =>
+           let 'pair subst' bndr' := substBndr subst bndr in
+           pair subst' (NonRec bndr' (subst_expr (Datatypes.id (GHC.Base.hs_string__
+                                                                "substBind")) subst rhs))
+       | subst, Rec pairs =>
+           let 'pair bndrs rhss := unzip pairs in
+           let 'pair subst' bndrs' := substRecBndrs subst bndrs in
+           let rhss' :=
+             map (fun ps =>
+                    subst_expr (Datatypes.id (GHC.Base.hs_string__ "substBind")) subst' (snd ps))
+                 pairs in
+           pair subst' (Rec (zip bndrs' rhss'))
+       end for substBind.
 
 Definition substBindSC : Subst -> CoreBind -> (Subst * CoreBind)%type :=
   fun subst bind =>

--- a/examples/ghc/lib/CoreTidy.v
+++ b/examples/ghc/lib/CoreTidy.v
@@ -114,79 +114,83 @@ Definition tidyVarOcc : Core.TidyEnv -> Core.Var -> Core.Var :=
 Definition tidyBind
    : Core.TidyEnv -> Core.CoreBind -> (Core.TidyEnv * Core.CoreBind)%type :=
   fix tidyExpr (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreExpr) : Core.CoreExpr
-        := let tidyAlt (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreAlt)
-            : Core.CoreAlt :=
-             match arg_0__, arg_1__ with
-             | env, pair (pair con vs) rhs =>
-                 tidyBndrs env vs =:
-                 (fun '(pair env' vs) => pair (pair con vs) (tidyExpr env' rhs))
-             end in
-           match arg_0__, arg_1__ with
-           | env, Core.Mk_Var v => Core.Mk_Var (tidyVarOcc env v)
-           | env, Core.Mk_Type ty => Core.Mk_Type (Core.tidyType env ty)
-           | env, Core.Mk_Coercion co => Core.Mk_Coercion (Core.tidyCo env co)
-           | _, Core.Lit lit => Core.Lit lit
-           | env, Core.App f a => Core.App (tidyExpr env f) (tidyExpr env a)
-           | env, Core.Cast e co => Core.Cast (tidyExpr env e) (Core.tidyCo env co)
-           | env, Core.Let b e =>
-               tidyBind env b =: (fun '(pair env' b') => Core.Let b' (tidyExpr env' e))
-           | env, Core.Case e b ty alts =>
-               tidyBndr env b =:
-               (fun '(pair env' b) =>
-                  Core.Case (tidyExpr env e) b (Core.tidyType env ty) (GHC.Base.map (tidyAlt env')
-                                                                       alts))
-           | env, Core.Lam b e =>
-               tidyBndr env b =: (fun '(pair env' b) => Core.Lam b (tidyExpr env' e))
-           end with tidyBind (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreBind)
-                      : (Core.TidyEnv * Core.CoreBind)%type
-                      := match arg_0__, arg_1__ with
-                         | env, Core.NonRec bndr rhs =>
-                             tidyLetBndr env env (pair bndr rhs) =:
-                             (fun '(pair env' bndr') => pair env' (Core.NonRec bndr' (tidyExpr env' rhs)))
-                         | env, Core.Rec prs =>
-                             let 'pair env' bndrs' := Data.Traversable.mapAccumL (tidyLetBndr
-                                                                                  GHC.Err.default) env prs in
-                             GHC.Base.map (fun x => tidyExpr env' (snd x)) prs =:
-                             (fun rhss' => pair env' (Core.Rec (GHC.List.zip bndrs' rhss')))
-                         end for tidyBind.
+    := let tidyAlt (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreAlt)
+        : Core.CoreAlt :=
+         match arg_0__, arg_1__ with
+         | env, pair (pair con vs) rhs =>
+             tidyBndrs env vs =:
+             (fun '(pair env' vs) => pair (pair con vs) (tidyExpr env' rhs))
+         end in
+       match arg_0__, arg_1__ with
+       | env, Core.Mk_Var v => Core.Mk_Var (tidyVarOcc env v)
+       | env, Core.Mk_Type ty => Core.Mk_Type (Core.tidyType env ty)
+       | env, Core.Mk_Coercion co => Core.Mk_Coercion (Core.tidyCo env co)
+       | _, Core.Lit lit => Core.Lit lit
+       | env, Core.App f a => Core.App (tidyExpr env f) (tidyExpr env a)
+       | env, Core.Cast e co => Core.Cast (tidyExpr env e) (Core.tidyCo env co)
+       | env, Core.Let b e =>
+           tidyBind env b =: (fun '(pair env' b') => Core.Let b' (tidyExpr env' e))
+       | env, Core.Case e b ty alts =>
+           tidyBndr env b =:
+           (fun '(pair env' b) =>
+              Core.Case (tidyExpr env e) b (Core.tidyType env ty) (GHC.Base.map (tidyAlt env')
+                                                                   alts))
+       | env, Core.Lam b e =>
+           tidyBndr env b =: (fun '(pair env' b) => Core.Lam b (tidyExpr env' e))
+       end
+  with tidyBind (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreBind) : (Core.TidyEnv
+                                                                      *
+                                                                      Core.CoreBind)%type
+    := match arg_0__, arg_1__ with
+       | env, Core.NonRec bndr rhs =>
+           tidyLetBndr env env (pair bndr rhs) =:
+           (fun '(pair env' bndr') => pair env' (Core.NonRec bndr' (tidyExpr env' rhs)))
+       | env, Core.Rec prs =>
+           let 'pair env' bndrs' := Data.Traversable.mapAccumL (tidyLetBndr
+                                                                GHC.Err.default) env prs in
+           GHC.Base.map (fun x => tidyExpr env' (snd x)) prs =:
+           (fun rhss' => pair env' (Core.Rec (GHC.List.zip bndrs' rhss')))
+       end for tidyBind.
 
 Definition tidyExpr : Core.TidyEnv -> Core.CoreExpr -> Core.CoreExpr :=
   fix tidyExpr (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreExpr) : Core.CoreExpr
-        := let tidyAlt (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreAlt)
-            : Core.CoreAlt :=
-             match arg_0__, arg_1__ with
-             | env, pair (pair con vs) rhs =>
-                 tidyBndrs env vs =:
-                 (fun '(pair env' vs) => pair (pair con vs) (tidyExpr env' rhs))
-             end in
-           match arg_0__, arg_1__ with
-           | env, Core.Mk_Var v => Core.Mk_Var (tidyVarOcc env v)
-           | env, Core.Mk_Type ty => Core.Mk_Type (Core.tidyType env ty)
-           | env, Core.Mk_Coercion co => Core.Mk_Coercion (Core.tidyCo env co)
-           | _, Core.Lit lit => Core.Lit lit
-           | env, Core.App f a => Core.App (tidyExpr env f) (tidyExpr env a)
-           | env, Core.Cast e co => Core.Cast (tidyExpr env e) (Core.tidyCo env co)
-           | env, Core.Let b e =>
-               tidyBind env b =: (fun '(pair env' b') => Core.Let b' (tidyExpr env' e))
-           | env, Core.Case e b ty alts =>
-               tidyBndr env b =:
-               (fun '(pair env' b) =>
-                  Core.Case (tidyExpr env e) b (Core.tidyType env ty) (GHC.Base.map (tidyAlt env')
-                                                                       alts))
-           | env, Core.Lam b e =>
-               tidyBndr env b =: (fun '(pair env' b) => Core.Lam b (tidyExpr env' e))
-           end with tidyBind (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreBind)
-                      : (Core.TidyEnv * Core.CoreBind)%type
-                      := match arg_0__, arg_1__ with
-                         | env, Core.NonRec bndr rhs =>
-                             tidyLetBndr env env (pair bndr rhs) =:
-                             (fun '(pair env' bndr') => pair env' (Core.NonRec bndr' (tidyExpr env' rhs)))
-                         | env, Core.Rec prs =>
-                             let 'pair env' bndrs' := Data.Traversable.mapAccumL (tidyLetBndr
-                                                                                  GHC.Err.default) env prs in
-                             GHC.Base.map (fun x => tidyExpr env' (snd x)) prs =:
-                             (fun rhss' => pair env' (Core.Rec (GHC.List.zip bndrs' rhss')))
-                         end for tidyExpr.
+    := let tidyAlt (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreAlt)
+        : Core.CoreAlt :=
+         match arg_0__, arg_1__ with
+         | env, pair (pair con vs) rhs =>
+             tidyBndrs env vs =:
+             (fun '(pair env' vs) => pair (pair con vs) (tidyExpr env' rhs))
+         end in
+       match arg_0__, arg_1__ with
+       | env, Core.Mk_Var v => Core.Mk_Var (tidyVarOcc env v)
+       | env, Core.Mk_Type ty => Core.Mk_Type (Core.tidyType env ty)
+       | env, Core.Mk_Coercion co => Core.Mk_Coercion (Core.tidyCo env co)
+       | _, Core.Lit lit => Core.Lit lit
+       | env, Core.App f a => Core.App (tidyExpr env f) (tidyExpr env a)
+       | env, Core.Cast e co => Core.Cast (tidyExpr env e) (Core.tidyCo env co)
+       | env, Core.Let b e =>
+           tidyBind env b =: (fun '(pair env' b') => Core.Let b' (tidyExpr env' e))
+       | env, Core.Case e b ty alts =>
+           tidyBndr env b =:
+           (fun '(pair env' b) =>
+              Core.Case (tidyExpr env e) b (Core.tidyType env ty) (GHC.Base.map (tidyAlt env')
+                                                                   alts))
+       | env, Core.Lam b e =>
+           tidyBndr env b =: (fun '(pair env' b) => Core.Lam b (tidyExpr env' e))
+       end
+  with tidyBind (arg_0__ : Core.TidyEnv) (arg_1__ : Core.CoreBind) : (Core.TidyEnv
+                                                                      *
+                                                                      Core.CoreBind)%type
+    := match arg_0__, arg_1__ with
+       | env, Core.NonRec bndr rhs =>
+           tidyLetBndr env env (pair bndr rhs) =:
+           (fun '(pair env' bndr') => pair env' (Core.NonRec bndr' (tidyExpr env' rhs)))
+       | env, Core.Rec prs =>
+           let 'pair env' bndrs' := Data.Traversable.mapAccumL (tidyLetBndr
+                                                                GHC.Err.default) env prs in
+           GHC.Base.map (fun x => tidyExpr env' (snd x)) prs =:
+           (fun rhss' => pair env' (Core.Rec (GHC.List.zip bndrs' rhss')))
+       end for tidyExpr.
 
 Definition tidyAlt : Core.TidyEnv -> Core.CoreAlt -> Core.CoreAlt :=
   fun arg_0__ arg_1__ =>

--- a/examples/ghc/lib/CoreUtils.v
+++ b/examples/ghc/lib/CoreUtils.v
@@ -60,56 +60,52 @@ Axiom applyTypeToArgs : Core.CoreExpr ->
                         AxiomatizedTypes.Type_ -> list Core.CoreExpr -> AxiomatizedTypes.Type_.
 
 Fixpoint mkCast (arg_0__ : Core.CoreExpr) (arg_1__ : AxiomatizedTypes.Coercion)
-           : Core.CoreExpr
-           := match arg_0__, arg_1__ with
-              | e, co =>
-                  if (if andb Util.debugIsOn (negb (Core.coercionRole co GHC.Base.==
-                                                    AxiomatizedTypes.Representational)) : bool
-                      then (GHC.Err.error (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
-                                                                               (GHC.Base.mappend (GHC.Base.mappend
-                                                                                                  (Datatypes.id
-                                                                                                   (GHC.Base.hs_string__
-                                                                                                    "coercion"))
-                                                                                                  Panic.someSDoc)
-                                                                                                 Panic.someSDoc)
-                                                                               Panic.someSDoc) (Datatypes.id
-                                                                               (GHC.Base.hs_string__ "has wrong role")))
-                                                            Panic.someSDoc))
-                      else Core.isReflCo co) : bool
-                  then e else
-                  let j_7__ :=
-                    match arg_0__, arg_1__ with
-                    | Core.Cast expr co2, co =>
-                        Panic.warnPprTrace (let 'Pair.Mk_Pair _from_ty2 to_ty2 := Core.coercionKind
-                                                                                    co2 in
-                                            let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
-                                            negb (Core.eqType from_ty to_ty2)) (GHC.Base.hs_string__
-                                            "ghc/compiler/coreSyn/CoreUtils.hs") #279 (Panic.someSDoc) (mkCast expr
-                                                                                                               (Core.mkTransCo
-                                                                                                                co2 co))
-                    | expr, co =>
-                        let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
-                        Panic.warnPprTrace (negb (Core.eqType from_ty (exprType expr)))
-                                           (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreUtils.hs") #290
-                                           (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
-                                                                                                  (Datatypes.id
-                                                                                                   (GHC.Base.hs_string__
-                                                                                                    "Trying to coerce"))
-                                                                                                  (Datatypes.id
-                                                                                                   (GHC.Base.hs_string__
-                                                                                                    "(")))
-                                                                                                 Panic.someSDoc)
-                                                                               Panic.someSDoc) (Datatypes.id
-                                                              (GHC.Base.hs_string__ ")"))) (Core.Cast expr co)
-                    end in
-                  match arg_0__, arg_1__ with
-                  | Core.Mk_Coercion e_co, co =>
-                      if Core.isCoercionType (Pair.pSnd (Core.coercionKind co)) : bool
-                      then Core.Mk_Coercion (Core.mkCoCast e_co co) else
-                      j_7__
-                  | _, _ => j_7__
-                  end
-              end.
+  : Core.CoreExpr
+  := match arg_0__, arg_1__ with
+     | e, co =>
+         if (if andb Util.debugIsOn (negb (Core.coercionRole co GHC.Base.==
+                                           AxiomatizedTypes.Representational)) : bool
+             then (GHC.Err.error (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
+                                                                      (GHC.Base.mappend (GHC.Base.mappend (Datatypes.id
+                                                                                                           (GHC.Base.hs_string__
+                                                                                                            "coercion"))
+                                                                                                          Panic.someSDoc)
+                                                                                        Panic.someSDoc) Panic.someSDoc)
+                                                                     (Datatypes.id (GHC.Base.hs_string__
+                                                                                    "has wrong role"))) Panic.someSDoc))
+             else Core.isReflCo co) : bool
+         then e else
+         let j_7__ :=
+           match arg_0__, arg_1__ with
+           | Core.Cast expr co2, co =>
+               Panic.warnPprTrace (let 'Pair.Mk_Pair _from_ty2 to_ty2 := Core.coercionKind
+                                                                           co2 in
+                                   let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
+                                   negb (Core.eqType from_ty to_ty2)) (GHC.Base.hs_string__
+                                   "ghc/compiler/coreSyn/CoreUtils.hs") #279 (Panic.someSDoc) (mkCast expr
+                                                                                                      (Core.mkTransCo
+                                                                                                       co2 co))
+           | expr, co =>
+               let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
+               Panic.warnPprTrace (negb (Core.eqType from_ty (exprType expr)))
+                                  (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreUtils.hs") #290
+                                  (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
+                                                                                         (Datatypes.id
+                                                                                          (GHC.Base.hs_string__
+                                                                                           "Trying to coerce"))
+                                                                                         (Datatypes.id
+                                                                                          (GHC.Base.hs_string__ "(")))
+                                                                                        Panic.someSDoc) Panic.someSDoc)
+                                                    (Datatypes.id (GHC.Base.hs_string__ ")"))) (Core.Cast expr co)
+           end in
+         match arg_0__, arg_1__ with
+         | Core.Mk_Coercion e_co, co =>
+             if Core.isCoercionType (Pair.pSnd (Core.coercionKind co)) : bool
+             then Core.Mk_Coercion (Core.mkCoCast e_co co) else
+             j_7__
+         | _, _ => j_7__
+         end
+     end.
 
 (* Skipping definition `CoreUtils.mkTick' *)
 
@@ -118,13 +114,13 @@ Fixpoint mkCast (arg_0__ : Core.CoreExpr) (arg_1__ : AxiomatizedTypes.Coercion)
 Definition isSaturatedConApp : Core.CoreExpr -> bool :=
   fun e =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | Core.App f a, as_ => go f (cons a as_)
-                 | Core.Mk_Var fun_, args =>
-                     andb (Id.isConLikeId fun_) (Id.idArity fun_ GHC.Base.== Core.valArgCount args)
-                 | Core.Cast f _, as_ => go f as_
-                 | _, _ => false
-                 end in
+      := match arg_0__, arg_1__ with
+         | Core.App f a, as_ => go f (cons a as_)
+         | Core.Mk_Var fun_, args =>
+             andb (Id.isConLikeId fun_) (Id.idArity fun_ GHC.Base.== Core.valArgCount args)
+         | Core.Cast f _, as_ => go f as_
+         | _, _ => false
+         end in
     go e nil.
 
 (* Skipping definition `CoreUtils.mkTickNoHNF' *)
@@ -144,44 +140,46 @@ Definition stripTicksE {b}
   fun p expr =>
     let go :=
       fix go arg_0__
-            := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
-                 let 'pair (pair c bs) e := arg_14__ in
-                 pair (pair c bs) (go e) in
-               match arg_0__ with
-               | Core.App e a => Core.App (go e) (go a)
-               | Core.Lam b e => Core.Lam b (go e)
-               | Core.Let b e => Core.Let (go_bs b) (go e)
-               | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
-               | Core.Cast e c => Core.Cast (go e) c
-               | other => other
-               end with go_bs arg_7__
-                          := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
-                               let 'pair b e := arg_11__ in
-                               pair b (go e) in
-                             match arg_7__ with
-                             | Core.NonRec b e => Core.NonRec b (go e)
-                             | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
-                             end for go in
+        := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
+             let 'pair (pair c bs) e := arg_14__ in
+             pair (pair c bs) (go e) in
+           match arg_0__ with
+           | Core.App e a => Core.App (go e) (go a)
+           | Core.Lam b e => Core.Lam b (go e)
+           | Core.Let b e => Core.Let (go_bs b) (go e)
+           | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
+           | Core.Cast e c => Core.Cast (go e) c
+           | other => other
+           end
+      with go_bs arg_7__
+        := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
+             let 'pair b e := arg_11__ in
+             pair b (go e) in
+           match arg_7__ with
+           | Core.NonRec b e => Core.NonRec b (go e)
+           | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
+           end for go in
     let go_bs :=
       fix go arg_0__
-            := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
-                 let 'pair (pair c bs) e := arg_14__ in
-                 pair (pair c bs) (go e) in
-               match arg_0__ with
-               | Core.App e a => Core.App (go e) (go a)
-               | Core.Lam b e => Core.Lam b (go e)
-               | Core.Let b e => Core.Let (go_bs b) (go e)
-               | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
-               | Core.Cast e c => Core.Cast (go e) c
-               | other => other
-               end with go_bs arg_7__
-                          := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
-                               let 'pair b e := arg_11__ in
-                               pair b (go e) in
-                             match arg_7__ with
-                             | Core.NonRec b e => Core.NonRec b (go e)
-                             | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
-                             end for go_bs in
+        := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
+             let 'pair (pair c bs) e := arg_14__ in
+             pair (pair c bs) (go e) in
+           match arg_0__ with
+           | Core.App e a => Core.App (go e) (go a)
+           | Core.Lam b e => Core.Lam b (go e)
+           | Core.Let b e => Core.Let (go_bs b) (go e)
+           | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
+           | Core.Cast e c => Core.Cast (go e) c
+           | other => other
+           end
+      with go_bs arg_7__
+        := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
+             let 'pair b e := arg_11__ in
+             pair b (go e) in
+           match arg_7__ with
+           | Core.NonRec b e => Core.NonRec b (go e)
+           | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
+           end for go_bs in
     let go_b : b * Core.Expr b -> b * Core.Expr b :=
       fun '(pair b e) => pair b (go e) in
     let go_a : Core.Alt b -> Core.Alt b :=
@@ -194,48 +192,50 @@ Definition stripTicksT {b}
   fun p expr =>
     let go :=
       fix go arg_0__
-            := let go_a (arg_14__ : Core.Alt b) : OrdList.OrdList (Core.Tickish Core.Id) :=
-                 let 'pair (pair _ _) e := arg_14__ in
-                 go e in
-               match arg_0__ with
-               | Core.App e a => OrdList.appOL (go e) (go a)
-               | Core.Lam _ e => go e
-               | Core.Let b e => OrdList.appOL (go_bs b) (go e)
-               | Core.Case e _ _ as_ =>
-                   OrdList.appOL (go e) (OrdList.concatOL (GHC.Base.map go_a as_))
-               | Core.Cast e _ => go e
-               | _ => OrdList.nilOL
-               end with go_bs arg_7__
-                          := let go_b (arg_11__ : b * Core.Expr b)
-                              : OrdList.OrdList (Core.Tickish Core.Id) :=
-                               let 'pair _ e := arg_11__ in
-                               go e in
-                             match arg_7__ with
-                             | Core.NonRec _ e => go e
-                             | Core.Rec bs => OrdList.concatOL (GHC.Base.map go_b bs)
-                             end for go in
+        := let go_a (arg_14__ : Core.Alt b) : OrdList.OrdList (Core.Tickish Core.Id) :=
+             let 'pair (pair _ _) e := arg_14__ in
+             go e in
+           match arg_0__ with
+           | Core.App e a => OrdList.appOL (go e) (go a)
+           | Core.Lam _ e => go e
+           | Core.Let b e => OrdList.appOL (go_bs b) (go e)
+           | Core.Case e _ _ as_ =>
+               OrdList.appOL (go e) (OrdList.concatOL (GHC.Base.map go_a as_))
+           | Core.Cast e _ => go e
+           | _ => OrdList.nilOL
+           end
+      with go_bs arg_7__
+        := let go_b (arg_11__ : b * Core.Expr b)
+            : OrdList.OrdList (Core.Tickish Core.Id) :=
+             let 'pair _ e := arg_11__ in
+             go e in
+           match arg_7__ with
+           | Core.NonRec _ e => go e
+           | Core.Rec bs => OrdList.concatOL (GHC.Base.map go_b bs)
+           end for go in
     let go_bs :=
       fix go arg_0__
-            := let go_a (arg_14__ : Core.Alt b) : OrdList.OrdList (Core.Tickish Core.Id) :=
-                 let 'pair (pair _ _) e := arg_14__ in
-                 go e in
-               match arg_0__ with
-               | Core.App e a => OrdList.appOL (go e) (go a)
-               | Core.Lam _ e => go e
-               | Core.Let b e => OrdList.appOL (go_bs b) (go e)
-               | Core.Case e _ _ as_ =>
-                   OrdList.appOL (go e) (OrdList.concatOL (GHC.Base.map go_a as_))
-               | Core.Cast e _ => go e
-               | _ => OrdList.nilOL
-               end with go_bs arg_7__
-                          := let go_b (arg_11__ : b * Core.Expr b)
-                              : OrdList.OrdList (Core.Tickish Core.Id) :=
-                               let 'pair _ e := arg_11__ in
-                               go e in
-                             match arg_7__ with
-                             | Core.NonRec _ e => go e
-                             | Core.Rec bs => OrdList.concatOL (GHC.Base.map go_b bs)
-                             end for go_bs in
+        := let go_a (arg_14__ : Core.Alt b) : OrdList.OrdList (Core.Tickish Core.Id) :=
+             let 'pair (pair _ _) e := arg_14__ in
+             go e in
+           match arg_0__ with
+           | Core.App e a => OrdList.appOL (go e) (go a)
+           | Core.Lam _ e => go e
+           | Core.Let b e => OrdList.appOL (go_bs b) (go e)
+           | Core.Case e _ _ as_ =>
+               OrdList.appOL (go e) (OrdList.concatOL (GHC.Base.map go_a as_))
+           | Core.Cast e _ => go e
+           | _ => OrdList.nilOL
+           end
+      with go_bs arg_7__
+        := let go_b (arg_11__ : b * Core.Expr b)
+            : OrdList.OrdList (Core.Tickish Core.Id) :=
+             let 'pair _ e := arg_11__ in
+             go e in
+           match arg_7__ with
+           | Core.NonRec _ e => go e
+           | Core.Rec bs => OrdList.concatOL (GHC.Base.map go_b bs)
+           end for go_bs in
     let go_b : b * Core.Expr b -> OrdList.OrdList (Core.Tickish Core.Id) :=
       fun '(pair _ e) => go e in
     let go_a : Core.Alt b -> OrdList.OrdList (Core.Tickish Core.Id) :=
@@ -296,19 +296,19 @@ Definition findAlt {a} {b}
      list (Core.AltCon * a * b)%type -> option (Core.AltCon * a * b)%type :=
   fun con alts =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, deflt => deflt
-                 | cons (pair (pair con1 _) _ as alt) alts, deflt =>
-                     match Core.cmpAltCon con con1 with
-                     | Lt => deflt
-                     | Eq => Some alt
-                     | Gt =>
-                         if andb Util.debugIsOn (negb (negb (con1 GHC.Base.== Core.DEFAULT))) : bool
-                         then (Panic.assertPanic (GHC.Base.hs_string__
-                                                  "ghc/compiler/coreSyn/CoreUtils.hs") #545)
-                         else go alts deflt
-                     end
-                 end in
+      := match arg_0__, arg_1__ with
+         | nil, deflt => deflt
+         | cons (pair (pair con1 _) _ as alt) alts, deflt =>
+             match Core.cmpAltCon con con1 with
+             | Lt => deflt
+             | Eq => Some alt
+             | Gt =>
+                 if andb Util.debugIsOn (negb (negb (con1 GHC.Base.== Core.DEFAULT))) : bool
+                 then (Panic.assertPanic (GHC.Base.hs_string__
+                                          "ghc/compiler/coreSyn/CoreUtils.hs") #545)
+                 else go alts deflt
+             end
+         end in
     match alts with
     | cons (pair (pair Core.DEFAULT _) _ as deflt) alts => go alts (Some deflt)
     | _ => go alts None
@@ -384,28 +384,28 @@ Axiom combineIdenticalAlts : list Core.AltCon ->
                              list Core.CoreAlt -> (bool * list Core.AltCon * list Core.CoreAlt)%type.
 
 Fixpoint exprIsTrivial (arg_0__ : Core.CoreExpr) : bool
-           := match arg_0__ with
-              | Core.Mk_Var _ => true
-              | Core.Mk_Type _ => true
-              | Core.Mk_Coercion _ => true
-              | Core.Lit lit => Literal.litIsTrivial lit
-              | Core.App e arg => andb (negb (Core.isRuntimeArg arg)) (exprIsTrivial e)
-              | Core.Lam b e => andb (negb (Core.isRuntimeVar b)) (exprIsTrivial e)
-              | Core.Cast e _ => exprIsTrivial e
-              | Core.Case e _ _ nil => exprIsTrivial e
-              | _ => false
-              end.
+  := match arg_0__ with
+     | Core.Mk_Var _ => true
+     | Core.Mk_Type _ => true
+     | Core.Mk_Coercion _ => true
+     | Core.Lit lit => Literal.litIsTrivial lit
+     | Core.App e arg => andb (negb (Core.isRuntimeArg arg)) (exprIsTrivial e)
+     | Core.Lam b e => andb (negb (Core.isRuntimeVar b)) (exprIsTrivial e)
+     | Core.Cast e _ => exprIsTrivial e
+     | Core.Case e _ _ nil => exprIsTrivial e
+     | _ => false
+     end.
 
 Definition getIdFromTrivialExpr_maybe : Core.CoreExpr -> option Core.Id :=
   fun e =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Core.Mk_Var v => Some v
-                 | Core.App f t => if negb (Core.isRuntimeArg t) : bool then go f else None
-                 | Core.Cast e _ => go e
-                 | Core.Lam b e => if negb (Core.isRuntimeVar b) : bool then go e else None
-                 | _ => None
-                 end in
+      := match arg_0__ with
+         | Core.Mk_Var v => Some v
+         | Core.App f t => if negb (Core.isRuntimeArg t) : bool then go f else None
+         | Core.Cast e _ => go e
+         | Core.Lam b e => if negb (Core.isRuntimeVar b) : bool then go e else None
+         | _ => None
+         end in
     go e.
 
 Definition getIdFromTrivialExpr : Core.CoreExpr -> Core.Id :=
@@ -430,21 +430,21 @@ Definition isEmptyTy : AxiomatizedTypes.Type_ -> bool :=
 Definition exprIsBottom : Core.CoreExpr -> bool :=
   fun e =>
     let fix go arg_0__ arg_1__
-              := let j_3__ :=
-                   match arg_0__, arg_1__ with
-                   | _, Core.Case _ _ _ alts => Data.Foldable.null alts
-                   | _, _ => false
-                   end in
-                 match arg_0__, arg_1__ with
-                 | n, Core.Mk_Var v => andb (Id.isBottomingId v) (n GHC.Base.>= Id.idArity v)
-                 | n, Core.App e a =>
-                     if Core.isTypeArg a : bool then go n e else
-                     go (n GHC.Num.+ #1) e
-                 | n, Core.Cast e _ => go n e
-                 | n, Core.Let _ e => go n e
-                 | n, Core.Lam v e => if Core.isTyVar v : bool then go n e else j_3__
-                 | _, _ => j_3__
-                 end in
+      := let j_3__ :=
+           match arg_0__, arg_1__ with
+           | _, Core.Case _ _ _ alts => Data.Foldable.null alts
+           | _, _ => false
+           end in
+         match arg_0__, arg_1__ with
+         | n, Core.Mk_Var v => andb (Id.isBottomingId v) (n GHC.Base.>= Id.idArity v)
+         | n, Core.App e a =>
+             if Core.isTypeArg a : bool then go n e else
+             go (n GHC.Num.+ #1) e
+         | n, Core.Cast e _ => go n e
+         | n, Core.Let _ e => go n e
+         | n, Core.Lam v e => if Core.isTyVar v : bool then go n e else j_3__
+         | _, _ => j_3__
+         end in
     if isEmptyTy (exprType e) : bool then true else
     go #0 e.
 
@@ -461,45 +461,45 @@ Definition exprIsDupable : DynFlags.DynFlags -> Core.CoreExpr -> bool :=
         Some (n GHC.Num.- #1) in
     let go : nat -> Core.CoreExpr -> option nat :=
       fix go (arg_6__ : nat) (arg_7__ : Core.CoreExpr) : option nat
-            := match arg_6__, arg_7__ with
-               | n, Core.Mk_Type _ => Some n
-               | n, Core.Mk_Coercion _ => Some n
-               | n, Core.Mk_Var _ => decrement n
-               | n, Core.Cast e _ => go n e
-               | n, Core.App f a => match go n a with | Some n' => go n' f | _ => None end
-               | n, Core.Lit lit =>
-                   if Literal.litIsDupable dflags lit : bool then decrement n else
-                   None
-               | _, _ => None
-               end in
+        := match arg_6__, arg_7__ with
+           | n, Core.Mk_Type _ => Some n
+           | n, Core.Mk_Coercion _ => Some n
+           | n, Core.Mk_Var _ => decrement n
+           | n, Core.Cast e _ => go n e
+           | n, Core.App f a => match go n a with | Some n' => go n' f | _ => None end
+           | n, Core.Lit lit =>
+               if Literal.litIsDupable dflags lit : bool then decrement n else
+               None
+           | _, _ => None
+           end in
     Data.Maybe.isJust (go dupAppSize e).
 
 Definition exprIsCheapX : CheapAppFun -> Core.CoreExpr -> bool :=
   fun ok_app e =>
     let fix go arg_1__ arg_2__
-              := let ok e := go #0 e in
-                 match arg_1__, arg_2__ with
-                 | n, Core.Mk_Var v => ok_app v n
-                 | _, Core.Lit _ => true
-                 | _, Core.Mk_Type _ => true
-                 | _, Core.Mk_Coercion _ => true
-                 | n, Core.Cast e _ => go n e
-                 | n, Core.Case scrut _ _ alts =>
-                     andb (ok scrut) (Data.Foldable.and (let cont_5__ arg_6__ :=
-                                                           let 'pair (pair _ _) rhs := arg_6__ in
-                                                           cons (go n rhs) nil in
-                                                         Coq.Lists.List.flat_map cont_5__ alts))
-                 | n, Core.Lam x e =>
-                     if Core.isRuntimeVar x : bool
-                     then orb (n GHC.Base.== #0) (go (n GHC.Num.- #1) e) else
-                     go n e
-                 | n, Core.App f e =>
-                     if Core.isRuntimeArg e : bool then andb (go (n GHC.Num.+ #1) f) (ok e) else
-                     go n f
-                 | n, Core.Let (Core.NonRec _ r) e => andb (go n e) (ok r)
-                 | n, Core.Let (Core.Rec prs) e =>
-                     andb (go n e) (Data.Foldable.all (ok GHC.Base.∘ Data.Tuple.snd) prs)
-                 end in
+      := let ok e := go #0 e in
+         match arg_1__, arg_2__ with
+         | n, Core.Mk_Var v => ok_app v n
+         | _, Core.Lit _ => true
+         | _, Core.Mk_Type _ => true
+         | _, Core.Mk_Coercion _ => true
+         | n, Core.Cast e _ => go n e
+         | n, Core.Case scrut _ _ alts =>
+             andb (ok scrut) (Data.Foldable.and (let cont_5__ arg_6__ :=
+                                                   let 'pair (pair _ _) rhs := arg_6__ in
+                                                   cons (go n rhs) nil in
+                                                 Coq.Lists.List.flat_map cont_5__ alts))
+         | n, Core.Lam x e =>
+             if Core.isRuntimeVar x : bool
+             then orb (n GHC.Base.== #0) (go (n GHC.Num.- #1) e) else
+             go n e
+         | n, Core.App f e =>
+             if Core.isRuntimeArg e : bool then andb (go (n GHC.Num.+ #1) f) (ok e) else
+             go n f
+         | n, Core.Let (Core.NonRec _ r) e => andb (go n e) (ok r)
+         | n, Core.Let (Core.Rec prs) e =>
+             andb (go n e) (Data.Foldable.all (ok GHC.Base.∘ Data.Tuple.snd) prs)
+         end in
     let ok := fun e => go #0 e in ok e.
 
 Axiom isCheapApp : CheapAppFun.
@@ -555,27 +555,27 @@ Definition exprIsHNFlike
                                                                                   PrelNames.absentErrorIdKey)) in
     let app_is_value : Core.CoreExpr -> nat -> bool :=
       fix app_is_value (arg_1__ : Core.CoreExpr) (arg_2__ : nat) : bool
-            := match arg_1__, arg_2__ with
-               | Core.Mk_Var f, nva => id_app_is_value f nva
-               | Core.Cast f _, nva => app_is_value f nva
-               | Core.App f a, nva =>
-                   if Core.isValArg a : bool then app_is_value f (nva GHC.Num.+ #1) else
-                   app_is_value f nva
-               | _, _ => false
-               end in
+        := match arg_1__, arg_2__ with
+           | Core.Mk_Var f, nva => id_app_is_value f nva
+           | Core.Cast f _, nva => app_is_value f nva
+           | Core.App f a, nva =>
+               if Core.isValArg a : bool then app_is_value f (nva GHC.Num.+ #1) else
+               app_is_value f nva
+           | _, _ => false
+           end in
     let fix is_hnf_like arg_8__
-              := match arg_8__ with
-                 | Core.Mk_Var v => orb (id_app_is_value v #0) (is_con_unf (Id.idUnfolding v))
-                 | Core.Lit _ => true
-                 | Core.Mk_Type _ => true
-                 | Core.Mk_Coercion _ => true
-                 | Core.Lam b e => orb (Core.isRuntimeVar b) (is_hnf_like e)
-                 | Core.Cast e _ => is_hnf_like e
-                 | Core.App e a =>
-                     if Core.isValArg a : bool then app_is_value e #1 else
-                     is_hnf_like e
-                 | _ => match arg_8__ with | Core.Let _ e => is_hnf_like e | _ => false end
-                 end in
+      := match arg_8__ with
+         | Core.Mk_Var v => orb (id_app_is_value v #0) (is_con_unf (Id.idUnfolding v))
+         | Core.Lit _ => true
+         | Core.Mk_Type _ => true
+         | Core.Mk_Coercion _ => true
+         | Core.Lam b e => orb (Core.isRuntimeVar b) (is_hnf_like e)
+         | Core.Cast e _ => is_hnf_like e
+         | Core.App e a =>
+             if Core.isValArg a : bool then app_is_value e #1 else
+             is_hnf_like e
+         | _ => match arg_8__ with | Core.Let _ e => is_hnf_like e | _ => false end
+         end in
     is_hnf_like.
 
 Definition exprIsHNF : Core.CoreExpr -> bool :=
@@ -619,57 +619,56 @@ Definition cheapEqExpr {b} : Core.Expr b -> Core.Expr b -> bool :=
   cheapEqExpr' (GHC.Base.const false).
 
 Fixpoint exprIsBig {b} (arg_0__ : Core.Expr b) : bool
-           := match arg_0__ with
-              | Core.Lit _ => false
-              | Core.Mk_Var _ => false
-              | Core.Mk_Type _ => false
-              | Core.Mk_Coercion _ => false
-              | Core.Lam _ e => exprIsBig e
-              | Core.App f a => orb (exprIsBig f) (exprIsBig a)
-              | Core.Cast e _ => exprIsBig e
-              | _ => true
-              end.
+  := match arg_0__ with
+     | Core.Lit _ => false
+     | Core.Mk_Var _ => false
+     | Core.Mk_Type _ => false
+     | Core.Mk_Coercion _ => false
+     | Core.Lam _ e => exprIsBig e
+     | Core.App f a => orb (exprIsBig f) (exprIsBig a)
+     | Core.Cast e _ => exprIsBig e
+     | _ => true
+     end.
 
 Definition eqExpr : Core.InScopeSet -> Core.CoreExpr -> Core.CoreExpr -> bool :=
   fun in_scope e1 e2 =>
     let fix go arg_0__ arg_1__ arg_2__
-              := let go_alt (arg_18__ : Core.RnEnv2) (arg_19__ arg_20__ : Core.CoreAlt)
-                  : bool :=
-                   match arg_18__, arg_19__, arg_20__ with
-                   | env, pair (pair c1 bs1) e1, pair (pair c2 bs2) e2 =>
-                       andb (c1 GHC.Base.== c2) (go (Core.rnBndrs2 env bs1 bs2) e1 e2)
-                   end in
-                 match arg_0__, arg_1__, arg_2__ with
-                 | env, Core.Mk_Var v1, Core.Mk_Var v2 =>
-                     if Core.rnOccL env v1 GHC.Base.== Core.rnOccR env v2 : bool then true else
-                     false
-                 | _, Core.Lit lit1, Core.Lit lit2 => lit1 GHC.Base.== lit2
-                 | env, Core.Mk_Type t1, Core.Mk_Type t2 => Core.eqTypeX env t1 t2
-                 | env, Core.Mk_Coercion co1, Core.Mk_Coercion co2 =>
-                     Core.eqCoercionX env co1 co2
-                 | env, Core.Cast e1 co1, Core.Cast e2 co2 =>
-                     andb (Core.eqCoercionX env co1 co2) (go env e1 e2)
-                 | env, Core.App f1 a1, Core.App f2 a2 => andb (go env f1 f2) (go env a1 a2)
-                 | env, Core.Lam b1 e1, Core.Lam b2 e2 =>
-                     andb (Core.eqTypeX env (Core.varType b1) (Core.varType b2)) (go (Core.rnBndr2
-                                                                                      env b1 b2) e1 e2)
-                 | env, Core.Let (Core.NonRec v1 r1) e1, Core.Let (Core.NonRec v2 r2) e2 =>
-                     andb (go env r1 r2) (go (Core.rnBndr2 env v1 v2) e1 e2)
-                 | env, Core.Let (Core.Rec ps1) e1, Core.Let (Core.Rec ps2) e2 =>
-                     let 'pair bs2 rs2 := GHC.List.unzip ps2 in
-                     let 'pair bs1 rs1 := GHC.List.unzip ps1 in
-                     let env' := Core.rnBndrs2 env bs1 bs2 in
-                     andb (Util.equalLength ps1 ps2) (andb (NestedRecursionHelpers.all2Map (go env')
-                                                                                           snd snd ps1 ps2) (go env' e1
-                                                            e2))
-                 | env, Core.Case e1 b1 t1 a1, Core.Case e2 b2 t2 a2 =>
-                     if Data.Foldable.null a1 : bool
-                     then andb (Data.Foldable.null a2) (andb (go env e1 e2) (Core.eqTypeX env t1
-                                                              t2)) else
-                     andb (go env e1 e2) (NestedRecursionHelpers.all2Map (go_alt (Core.rnBndr2 env b1
-                                                                                  b2)) id id a1 a2)
-                 | _, _, _ => false
-                 end in
+      := let go_alt (arg_18__ : Core.RnEnv2) (arg_19__ arg_20__ : Core.CoreAlt)
+          : bool :=
+           match arg_18__, arg_19__, arg_20__ with
+           | env, pair (pair c1 bs1) e1, pair (pair c2 bs2) e2 =>
+               andb (c1 GHC.Base.== c2) (go (Core.rnBndrs2 env bs1 bs2) e1 e2)
+           end in
+         match arg_0__, arg_1__, arg_2__ with
+         | env, Core.Mk_Var v1, Core.Mk_Var v2 =>
+             if Core.rnOccL env v1 GHC.Base.== Core.rnOccR env v2 : bool then true else
+             false
+         | _, Core.Lit lit1, Core.Lit lit2 => lit1 GHC.Base.== lit2
+         | env, Core.Mk_Type t1, Core.Mk_Type t2 => Core.eqTypeX env t1 t2
+         | env, Core.Mk_Coercion co1, Core.Mk_Coercion co2 =>
+             Core.eqCoercionX env co1 co2
+         | env, Core.Cast e1 co1, Core.Cast e2 co2 =>
+             andb (Core.eqCoercionX env co1 co2) (go env e1 e2)
+         | env, Core.App f1 a1, Core.App f2 a2 => andb (go env f1 f2) (go env a1 a2)
+         | env, Core.Lam b1 e1, Core.Lam b2 e2 =>
+             andb (Core.eqTypeX env (Core.varType b1) (Core.varType b2)) (go (Core.rnBndr2
+                                                                              env b1 b2) e1 e2)
+         | env, Core.Let (Core.NonRec v1 r1) e1, Core.Let (Core.NonRec v2 r2) e2 =>
+             andb (go env r1 r2) (go (Core.rnBndr2 env v1 v2) e1 e2)
+         | env, Core.Let (Core.Rec ps1) e1, Core.Let (Core.Rec ps2) e2 =>
+             let 'pair bs2 rs2 := GHC.List.unzip ps2 in
+             let 'pair bs1 rs1 := GHC.List.unzip ps1 in
+             let env' := Core.rnBndrs2 env bs1 bs2 in
+             andb (Util.equalLength ps1 ps2) (andb (NestedRecursionHelpers.all2Map (go env')
+                                                                                   snd snd ps1 ps2) (go env' e1 e2))
+         | env, Core.Case e1 b1 t1 a1, Core.Case e2 b2 t2 a2 =>
+             if Data.Foldable.null a1 : bool
+             then andb (Data.Foldable.null a2) (andb (go env e1 e2) (Core.eqTypeX env t1
+                                                      t2)) else
+             andb (go env e1 e2) (NestedRecursionHelpers.all2Map (go_alt (Core.rnBndr2 env b1
+                                                                          b2)) id id a1 a2)
+         | _, _, _ => false
+         end in
     let go_alt : Core.RnEnv2 -> Core.CoreAlt -> Core.CoreAlt -> bool :=
       fun arg_18__ arg_19__ arg_20__ =>
         match arg_18__, arg_19__, arg_20__ with

--- a/examples/ghc/lib/Digraph.v
+++ b/examples/ghc/lib/Digraph.v
@@ -21,8 +21,8 @@ Axiom Set_ : Type -> Type.
 
 Axiom ReduceFn : Type -> Type -> Type.
 
-Inductive Node key payload : Type
-  := | DigraphNode (node_payload : payload) (node_key : key) (node_dependencies
+Inductive Node key payload : Type :=
+  | DigraphNode (node_payload : payload) (node_key : key) (node_dependencies
     : list key)
    : Node key payload.
 

--- a/examples/ghc/lib/DynFlags.v
+++ b/examples/ghc/lib/DynFlags.v
@@ -25,351 +25,351 @@ Require SrcLoc.
 
 (* Converted type declarations: *)
 
-Inductive Way : Type
-  := | WayCustom : GHC.Base.String -> Way
-  |  WayThreaded : Way
-  |  WayDebug : Way
-  |  WayProf : Way
-  |  WayEventLog : Way
-  |  WayDyn : Way.
+Inductive Way : Type :=
+  | WayCustom : GHC.Base.String -> Way
+  | WayThreaded : Way
+  | WayDebug : Way
+  | WayProf : Way
+  | WayEventLog : Way
+  | WayDyn : Way.
 
-Inductive WarningFlag : Type
-  := | Opt_WarnDuplicateExports : WarningFlag
-  |  Opt_WarnDuplicateConstraints : WarningFlag
-  |  Opt_WarnRedundantConstraints : WarningFlag
-  |  Opt_WarnHiShadows : WarningFlag
-  |  Opt_WarnImplicitPrelude : WarningFlag
-  |  Opt_WarnIncompletePatterns : WarningFlag
-  |  Opt_WarnIncompleteUniPatterns : WarningFlag
-  |  Opt_WarnIncompletePatternsRecUpd : WarningFlag
-  |  Opt_WarnOverflowedLiterals : WarningFlag
-  |  Opt_WarnEmptyEnumerations : WarningFlag
-  |  Opt_WarnMissingFields : WarningFlag
-  |  Opt_WarnMissingImportList : WarningFlag
-  |  Opt_WarnMissingMethods : WarningFlag
-  |  Opt_WarnMissingSignatures : WarningFlag
-  |  Opt_WarnMissingLocalSignatures : WarningFlag
-  |  Opt_WarnNameShadowing : WarningFlag
-  |  Opt_WarnOverlappingPatterns : WarningFlag
-  |  Opt_WarnTypeDefaults : WarningFlag
-  |  Opt_WarnMonomorphism : WarningFlag
-  |  Opt_WarnUnusedTopBinds : WarningFlag
-  |  Opt_WarnUnusedLocalBinds : WarningFlag
-  |  Opt_WarnUnusedPatternBinds : WarningFlag
-  |  Opt_WarnUnusedImports : WarningFlag
-  |  Opt_WarnUnusedMatches : WarningFlag
-  |  Opt_WarnUnusedTypePatterns : WarningFlag
-  |  Opt_WarnUnusedForalls : WarningFlag
-  |  Opt_WarnWarningsDeprecations : WarningFlag
-  |  Opt_WarnDeprecatedFlags : WarningFlag
-  |  Opt_WarnAMP : WarningFlag
-  |  Opt_WarnMissingMonadFailInstances : WarningFlag
-  |  Opt_WarnSemigroup : WarningFlag
-  |  Opt_WarnDodgyExports : WarningFlag
-  |  Opt_WarnDodgyImports : WarningFlag
-  |  Opt_WarnOrphans : WarningFlag
-  |  Opt_WarnAutoOrphans : WarningFlag
-  |  Opt_WarnIdentities : WarningFlag
-  |  Opt_WarnTabs : WarningFlag
-  |  Opt_WarnUnrecognisedPragmas : WarningFlag
-  |  Opt_WarnDodgyForeignImports : WarningFlag
-  |  Opt_WarnUnusedDoBind : WarningFlag
-  |  Opt_WarnWrongDoBind : WarningFlag
-  |  Opt_WarnAlternativeLayoutRuleTransitional : WarningFlag
-  |  Opt_WarnUnsafe : WarningFlag
-  |  Opt_WarnSafe : WarningFlag
-  |  Opt_WarnTrustworthySafe : WarningFlag
-  |  Opt_WarnMissedSpecs : WarningFlag
-  |  Opt_WarnAllMissedSpecs : WarningFlag
-  |  Opt_WarnUnsupportedCallingConventions : WarningFlag
-  |  Opt_WarnUnsupportedLlvmVersion : WarningFlag
-  |  Opt_WarnInlineRuleShadowing : WarningFlag
-  |  Opt_WarnTypedHoles : WarningFlag
-  |  Opt_WarnPartialTypeSignatures : WarningFlag
-  |  Opt_WarnMissingExportedSignatures : WarningFlag
-  |  Opt_WarnUntickedPromotedConstructors : WarningFlag
-  |  Opt_WarnDerivingTypeable : WarningFlag
-  |  Opt_WarnDeferredTypeErrors : WarningFlag
-  |  Opt_WarnDeferredOutOfScopeVariables : WarningFlag
-  |  Opt_WarnNonCanonicalMonadInstances : WarningFlag
-  |  Opt_WarnNonCanonicalMonadFailInstances : WarningFlag
-  |  Opt_WarnNonCanonicalMonoidInstances : WarningFlag
-  |  Opt_WarnMissingPatternSynonymSignatures : WarningFlag
-  |  Opt_WarnUnrecognisedWarningFlags : WarningFlag
-  |  Opt_WarnSimplifiableClassConstraints : WarningFlag
-  |  Opt_WarnCPPUndef : WarningFlag
-  |  Opt_WarnUnbangedStrictPatterns : WarningFlag
-  |  Opt_WarnMissingHomeModules : WarningFlag
-  |  Opt_WarnPartialFields : WarningFlag
-  |  Opt_WarnMissingExportList : WarningFlag.
+Inductive WarningFlag : Type :=
+  | Opt_WarnDuplicateExports : WarningFlag
+  | Opt_WarnDuplicateConstraints : WarningFlag
+  | Opt_WarnRedundantConstraints : WarningFlag
+  | Opt_WarnHiShadows : WarningFlag
+  | Opt_WarnImplicitPrelude : WarningFlag
+  | Opt_WarnIncompletePatterns : WarningFlag
+  | Opt_WarnIncompleteUniPatterns : WarningFlag
+  | Opt_WarnIncompletePatternsRecUpd : WarningFlag
+  | Opt_WarnOverflowedLiterals : WarningFlag
+  | Opt_WarnEmptyEnumerations : WarningFlag
+  | Opt_WarnMissingFields : WarningFlag
+  | Opt_WarnMissingImportList : WarningFlag
+  | Opt_WarnMissingMethods : WarningFlag
+  | Opt_WarnMissingSignatures : WarningFlag
+  | Opt_WarnMissingLocalSignatures : WarningFlag
+  | Opt_WarnNameShadowing : WarningFlag
+  | Opt_WarnOverlappingPatterns : WarningFlag
+  | Opt_WarnTypeDefaults : WarningFlag
+  | Opt_WarnMonomorphism : WarningFlag
+  | Opt_WarnUnusedTopBinds : WarningFlag
+  | Opt_WarnUnusedLocalBinds : WarningFlag
+  | Opt_WarnUnusedPatternBinds : WarningFlag
+  | Opt_WarnUnusedImports : WarningFlag
+  | Opt_WarnUnusedMatches : WarningFlag
+  | Opt_WarnUnusedTypePatterns : WarningFlag
+  | Opt_WarnUnusedForalls : WarningFlag
+  | Opt_WarnWarningsDeprecations : WarningFlag
+  | Opt_WarnDeprecatedFlags : WarningFlag
+  | Opt_WarnAMP : WarningFlag
+  | Opt_WarnMissingMonadFailInstances : WarningFlag
+  | Opt_WarnSemigroup : WarningFlag
+  | Opt_WarnDodgyExports : WarningFlag
+  | Opt_WarnDodgyImports : WarningFlag
+  | Opt_WarnOrphans : WarningFlag
+  | Opt_WarnAutoOrphans : WarningFlag
+  | Opt_WarnIdentities : WarningFlag
+  | Opt_WarnTabs : WarningFlag
+  | Opt_WarnUnrecognisedPragmas : WarningFlag
+  | Opt_WarnDodgyForeignImports : WarningFlag
+  | Opt_WarnUnusedDoBind : WarningFlag
+  | Opt_WarnWrongDoBind : WarningFlag
+  | Opt_WarnAlternativeLayoutRuleTransitional : WarningFlag
+  | Opt_WarnUnsafe : WarningFlag
+  | Opt_WarnSafe : WarningFlag
+  | Opt_WarnTrustworthySafe : WarningFlag
+  | Opt_WarnMissedSpecs : WarningFlag
+  | Opt_WarnAllMissedSpecs : WarningFlag
+  | Opt_WarnUnsupportedCallingConventions : WarningFlag
+  | Opt_WarnUnsupportedLlvmVersion : WarningFlag
+  | Opt_WarnInlineRuleShadowing : WarningFlag
+  | Opt_WarnTypedHoles : WarningFlag
+  | Opt_WarnPartialTypeSignatures : WarningFlag
+  | Opt_WarnMissingExportedSignatures : WarningFlag
+  | Opt_WarnUntickedPromotedConstructors : WarningFlag
+  | Opt_WarnDerivingTypeable : WarningFlag
+  | Opt_WarnDeferredTypeErrors : WarningFlag
+  | Opt_WarnDeferredOutOfScopeVariables : WarningFlag
+  | Opt_WarnNonCanonicalMonadInstances : WarningFlag
+  | Opt_WarnNonCanonicalMonadFailInstances : WarningFlag
+  | Opt_WarnNonCanonicalMonoidInstances : WarningFlag
+  | Opt_WarnMissingPatternSynonymSignatures : WarningFlag
+  | Opt_WarnUnrecognisedWarningFlags : WarningFlag
+  | Opt_WarnSimplifiableClassConstraints : WarningFlag
+  | Opt_WarnCPPUndef : WarningFlag
+  | Opt_WarnUnbangedStrictPatterns : WarningFlag
+  | Opt_WarnMissingHomeModules : WarningFlag
+  | Opt_WarnPartialFields : WarningFlag
+  | Opt_WarnMissingExportList : WarningFlag.
 
-Inductive WarnReason : Type
-  := | NoReason : WarnReason
-  |  Reason : WarningFlag -> WarnReason
-  |  ErrReason : (option WarningFlag) -> WarnReason.
+Inductive WarnReason : Type :=
+  | NoReason : WarnReason
+  | Reason : WarningFlag -> WarnReason
+  | ErrReason : (option WarningFlag) -> WarnReason.
 
 Definition TurnOnFlag :=
   bool%type.
 
-Inductive TrustFlag : Type
-  := | TrustPackage : GHC.Base.String -> TrustFlag
-  |  DistrustPackage : GHC.Base.String -> TrustFlag.
+Inductive TrustFlag : Type :=
+  | TrustPackage : GHC.Base.String -> TrustFlag
+  | DistrustPackage : GHC.Base.String -> TrustFlag.
 
-Inductive SseVersion : Type
-  := | SSE1 : SseVersion
-  |  SSE2 : SseVersion
-  |  SSE3 : SseVersion
-  |  SSE4 : SseVersion
-  |  SSE42 : SseVersion.
+Inductive SseVersion : Type :=
+  | SSE1 : SseVersion
+  | SSE2 : SseVersion
+  | SSE3 : SseVersion
+  | SSE4 : SseVersion
+  | SSE42 : SseVersion.
 
 Axiom Settings : Type.
 
-Inductive SafeHaskellMode : Type
-  := | Sf_None : SafeHaskellMode
-  |  Sf_Unsafe : SafeHaskellMode
-  |  Sf_Trustworthy : SafeHaskellMode
-  |  Sf_Safe : SafeHaskellMode.
+Inductive SafeHaskellMode : Type :=
+  | Sf_None : SafeHaskellMode
+  | Sf_Unsafe : SafeHaskellMode
+  | Sf_Trustworthy : SafeHaskellMode
+  | Sf_Safe : SafeHaskellMode.
 
-Inductive RtsOptsEnabled : Type
-  := | RtsOptsNone : RtsOptsEnabled
-  |  RtsOptsIgnore : RtsOptsEnabled
-  |  RtsOptsIgnoreAll : RtsOptsEnabled
-  |  RtsOptsSafeOnly : RtsOptsEnabled
-  |  RtsOptsAll : RtsOptsEnabled.
+Inductive RtsOptsEnabled : Type :=
+  | RtsOptsNone : RtsOptsEnabled
+  | RtsOptsIgnore : RtsOptsEnabled
+  | RtsOptsIgnoreAll : RtsOptsEnabled
+  | RtsOptsSafeOnly : RtsOptsEnabled
+  | RtsOptsAll : RtsOptsEnabled.
 
-Inductive ProfAuto : Type
-  := | NoProfAuto : ProfAuto
-  |  ProfAutoAll : ProfAuto
-  |  ProfAutoTop : ProfAuto
-  |  ProfAutoExports : ProfAuto
-  |  ProfAutoCalls : ProfAuto.
+Inductive ProfAuto : Type :=
+  | NoProfAuto : ProfAuto
+  | ProfAutoAll : ProfAuto
+  | ProfAutoTop : ProfAuto
+  | ProfAutoExports : ProfAuto
+  | ProfAutoCalls : ProfAuto.
 
-Inductive PkgConfRef : Type
-  := | GlobalPkgConf : PkgConfRef
-  |  UserPkgConf : PkgConfRef
-  |  PkgConfFile : GHC.Base.String -> PkgConfRef.
+Inductive PkgConfRef : Type :=
+  | GlobalPkgConf : PkgConfRef
+  | UserPkgConf : PkgConfRef
+  | PkgConfFile : GHC.Base.String -> PkgConfRef.
 
-Inductive PackageDBFlag : Type
-  := | PackageDB : PkgConfRef -> PackageDBFlag
-  |  NoUserPackageDB : PackageDBFlag
-  |  NoGlobalPackageDB : PackageDBFlag
-  |  ClearPackageDBs : PackageDBFlag.
+Inductive PackageDBFlag : Type :=
+  | PackageDB : PkgConfRef -> PackageDBFlag
+  | NoUserPackageDB : PackageDBFlag
+  | NoGlobalPackageDB : PackageDBFlag
+  | ClearPackageDBs : PackageDBFlag.
 
-Inductive PackageArg : Type
-  := | Mk_PackageArg : GHC.Base.String -> PackageArg
-  |  UnitIdArg : Module.UnitId -> PackageArg.
+Inductive PackageArg : Type :=
+  | Mk_PackageArg : GHC.Base.String -> PackageArg
+  | UnitIdArg : Module.UnitId -> PackageArg.
 
-Inductive Option : Type
-  := | FileOption : GHC.Base.String -> GHC.Base.String -> Option
-  |  Mk_Option : GHC.Base.String -> Option.
+Inductive Option : Type :=
+  | FileOption : GHC.Base.String -> GHC.Base.String -> Option
+  | Mk_Option : GHC.Base.String -> Option.
 
-Inductive OnOff a : Type := | On : a -> OnOff a |  Off : a -> OnOff a.
+Inductive OnOff a : Type := | On : a -> OnOff a | Off : a -> OnOff a.
 
-Inductive ModRenaming : Type
-  := | Mk_ModRenaming (modRenamingWithImplicit : bool) (modRenamings
+Inductive ModRenaming : Type :=
+  | Mk_ModRenaming (modRenamingWithImplicit : bool) (modRenamings
     : list (Module.ModuleName * Module.ModuleName)%type)
    : ModRenaming.
 
-Inductive PackageFlag : Type
-  := | ExposePackage : GHC.Base.String -> PackageArg -> ModRenaming -> PackageFlag
-  |  HidePackage : GHC.Base.String -> PackageFlag.
+Inductive PackageFlag : Type :=
+  | ExposePackage : GHC.Base.String -> PackageArg -> ModRenaming -> PackageFlag
+  | HidePackage : GHC.Base.String -> PackageFlag.
 
-Inductive LlvmTarget : Type
-  := | Mk_LlvmTarget (lDataLayout : GHC.Base.String) (lCPU : GHC.Base.String)
+Inductive LlvmTarget : Type :=
+  | Mk_LlvmTarget (lDataLayout : GHC.Base.String) (lCPU : GHC.Base.String)
   (lAttributes : list GHC.Base.String)
    : LlvmTarget.
 
 Definition LlvmTargets :=
   (list (GHC.Base.String * LlvmTarget)%type)%type.
 
-Inductive LinkerInfo : Type
-  := | GnuLD : list Option -> LinkerInfo
-  |  GnuGold : list Option -> LinkerInfo
-  |  LlvmLLD : list Option -> LinkerInfo
-  |  DarwinLD : list Option -> LinkerInfo
-  |  SolarisLD : list Option -> LinkerInfo
-  |  AixLD : list Option -> LinkerInfo
-  |  UnknownLD : LinkerInfo.
+Inductive LinkerInfo : Type :=
+  | GnuLD : list Option -> LinkerInfo
+  | GnuGold : list Option -> LinkerInfo
+  | LlvmLLD : list Option -> LinkerInfo
+  | DarwinLD : list Option -> LinkerInfo
+  | SolarisLD : list Option -> LinkerInfo
+  | AixLD : list Option -> LinkerInfo
+  | UnknownLD : LinkerInfo.
 
-Inductive Language : Type := | Haskell98 : Language |  Haskell2010 : Language.
+Inductive Language : Type := | Haskell98 : Language | Haskell2010 : Language.
 
-Inductive IgnorePackageFlag : Type
-  := | IgnorePackage : GHC.Base.String -> IgnorePackageFlag.
+Inductive IgnorePackageFlag : Type :=
+  | IgnorePackage : GHC.Base.String -> IgnorePackageFlag.
 
-Inductive HscTarget : Type
-  := | HscC : HscTarget
-  |  HscAsm : HscTarget
-  |  HscLlvm : HscTarget
-  |  HscInterpreted : HscTarget
-  |  HscNothing : HscTarget.
+Inductive HscTarget : Type :=
+  | HscC : HscTarget
+  | HscAsm : HscTarget
+  | HscLlvm : HscTarget
+  | HscInterpreted : HscTarget
+  | HscNothing : HscTarget.
 
-Inductive GhcMode : Type
-  := | CompManager : GhcMode
-  |  OneShot : GhcMode
-  |  MkDepend : GhcMode.
+Inductive GhcMode : Type :=
+  | CompManager : GhcMode
+  | OneShot : GhcMode
+  | MkDepend : GhcMode.
 
-Inductive GhcLink : Type
-  := | NoLink : GhcLink
-  |  LinkBinary : GhcLink
-  |  LinkInMemory : GhcLink
-  |  LinkDynLib : GhcLink
-  |  LinkStaticLib : GhcLink.
+Inductive GhcLink : Type :=
+  | NoLink : GhcLink
+  | LinkBinary : GhcLink
+  | LinkInMemory : GhcLink
+  | LinkDynLib : GhcLink
+  | LinkStaticLib : GhcLink.
 
-Inductive GeneralFlag : Type
-  := | Opt_DumpToFile : GeneralFlag
-  |  Opt_D_faststring_stats : GeneralFlag
-  |  Opt_D_dump_minimal_imports : GeneralFlag
-  |  Opt_DoCoreLinting : GeneralFlag
-  |  Opt_DoStgLinting : GeneralFlag
-  |  Opt_DoCmmLinting : GeneralFlag
-  |  Opt_DoAsmLinting : GeneralFlag
-  |  Opt_DoAnnotationLinting : GeneralFlag
-  |  Opt_NoLlvmMangler : GeneralFlag
-  |  Opt_FastLlvm : GeneralFlag
-  |  Opt_WarnIsError : GeneralFlag
-  |  Opt_ShowWarnGroups : GeneralFlag
-  |  Opt_HideSourcePaths : GeneralFlag
-  |  Opt_PrintExplicitForalls : GeneralFlag
-  |  Opt_PrintExplicitKinds : GeneralFlag
-  |  Opt_PrintExplicitCoercions : GeneralFlag
-  |  Opt_PrintExplicitRuntimeReps : GeneralFlag
-  |  Opt_PrintEqualityRelations : GeneralFlag
-  |  Opt_PrintUnicodeSyntax : GeneralFlag
-  |  Opt_PrintExpandedSynonyms : GeneralFlag
-  |  Opt_PrintPotentialInstances : GeneralFlag
-  |  Opt_PrintTypecheckerElaboration : GeneralFlag
-  |  Opt_CallArity : GeneralFlag
-  |  Opt_Exitification : GeneralFlag
-  |  Opt_Strictness : GeneralFlag
-  |  Opt_LateDmdAnal : GeneralFlag
-  |  Opt_KillAbsence : GeneralFlag
-  |  Opt_KillOneShot : GeneralFlag
-  |  Opt_FullLaziness : GeneralFlag
-  |  Opt_FloatIn : GeneralFlag
-  |  Opt_Specialise : GeneralFlag
-  |  Opt_SpecialiseAggressively : GeneralFlag
-  |  Opt_CrossModuleSpecialise : GeneralFlag
-  |  Opt_StaticArgumentTransformation : GeneralFlag
-  |  Opt_CSE : GeneralFlag
-  |  Opt_StgCSE : GeneralFlag
-  |  Opt_LiberateCase : GeneralFlag
-  |  Opt_SpecConstr : GeneralFlag
-  |  Opt_SpecConstrKeen : GeneralFlag
-  |  Opt_DoLambdaEtaExpansion : GeneralFlag
-  |  Opt_IgnoreAsserts : GeneralFlag
-  |  Opt_DoEtaReduction : GeneralFlag
-  |  Opt_CaseMerge : GeneralFlag
-  |  Opt_CaseFolding : GeneralFlag
-  |  Opt_UnboxStrictFields : GeneralFlag
-  |  Opt_UnboxSmallStrictFields : GeneralFlag
-  |  Opt_DictsCheap : GeneralFlag
-  |  Opt_EnableRewriteRules : GeneralFlag
-  |  Opt_Vectorise : GeneralFlag
-  |  Opt_VectorisationAvoidance : GeneralFlag
-  |  Opt_RegsGraph : GeneralFlag
-  |  Opt_RegsIterative : GeneralFlag
-  |  Opt_PedanticBottoms : GeneralFlag
-  |  Opt_LlvmTBAA : GeneralFlag
-  |  Opt_LlvmPassVectorsInRegisters : GeneralFlag
-  |  Opt_LlvmFillUndefWithGarbage : GeneralFlag
-  |  Opt_IrrefutableTuples : GeneralFlag
-  |  Opt_CmmSink : GeneralFlag
-  |  Opt_CmmElimCommonBlocks : GeneralFlag
-  |  Opt_OmitYields : GeneralFlag
-  |  Opt_FunToThunk : GeneralFlag
-  |  Opt_DictsStrict : GeneralFlag
-  |  Opt_DmdTxDictSel : GeneralFlag
-  |  Opt_Loopification : GeneralFlag
-  |  Opt_CprAnal : GeneralFlag
-  |  Opt_WorkerWrapper : GeneralFlag
-  |  Opt_SolveConstantDicts : GeneralFlag
-  |  Opt_AlignmentSanitisation : GeneralFlag
-  |  Opt_CatchBottoms : GeneralFlag
-  |  Opt_SimplPreInlining : GeneralFlag
-  |  Opt_IgnoreInterfacePragmas : GeneralFlag
-  |  Opt_OmitInterfacePragmas : GeneralFlag
-  |  Opt_ExposeAllUnfoldings : GeneralFlag
-  |  Opt_WriteInterface : GeneralFlag
-  |  Opt_AutoSccsOnIndividualCafs : GeneralFlag
-  |  Opt_ProfCountEntries : GeneralFlag
-  |  Opt_Pp : GeneralFlag
-  |  Opt_ForceRecomp : GeneralFlag
-  |  Opt_IgnoreOptimChanges : GeneralFlag
-  |  Opt_IgnoreHpcChanges : GeneralFlag
-  |  Opt_ExcessPrecision : GeneralFlag
-  |  Opt_EagerBlackHoling : GeneralFlag
-  |  Opt_NoHsMain : GeneralFlag
-  |  Opt_SplitObjs : GeneralFlag
-  |  Opt_SplitSections : GeneralFlag
-  |  Opt_StgStats : GeneralFlag
-  |  Opt_HideAllPackages : GeneralFlag
-  |  Opt_HideAllPluginPackages : GeneralFlag
-  |  Opt_PrintBindResult : GeneralFlag
-  |  Opt_Haddock : GeneralFlag
-  |  Opt_HaddockOptions : GeneralFlag
-  |  Opt_BreakOnException : GeneralFlag
-  |  Opt_BreakOnError : GeneralFlag
-  |  Opt_PrintEvldWithShow : GeneralFlag
-  |  Opt_PrintBindContents : GeneralFlag
-  |  Opt_GenManifest : GeneralFlag
-  |  Opt_EmbedManifest : GeneralFlag
-  |  Opt_SharedImplib : GeneralFlag
-  |  Opt_BuildingCabalPackage : GeneralFlag
-  |  Opt_IgnoreDotGhci : GeneralFlag
-  |  Opt_GhciSandbox : GeneralFlag
-  |  Opt_GhciHistory : GeneralFlag
-  |  Opt_LocalGhciHistory : GeneralFlag
-  |  Opt_HelpfulErrors : GeneralFlag
-  |  Opt_DeferTypeErrors : GeneralFlag
-  |  Opt_DeferTypedHoles : GeneralFlag
-  |  Opt_DeferOutOfScopeVariables : GeneralFlag
-  |  Opt_PIC : GeneralFlag
-  |  Opt_PIE : GeneralFlag
-  |  Opt_PICExecutable : GeneralFlag
-  |  Opt_SccProfilingOn : GeneralFlag
-  |  Opt_Ticky : GeneralFlag
-  |  Opt_Ticky_Allocd : GeneralFlag
-  |  Opt_Ticky_LNE : GeneralFlag
-  |  Opt_Ticky_Dyn_Thunk : GeneralFlag
-  |  Opt_RPath : GeneralFlag
-  |  Opt_RelativeDynlibPaths : GeneralFlag
-  |  Opt_Hpc : GeneralFlag
-  |  Opt_FlatCache : GeneralFlag
-  |  Opt_ExternalInterpreter : GeneralFlag
-  |  Opt_OptimalApplicativeDo : GeneralFlag
-  |  Opt_VersionMacros : GeneralFlag
-  |  Opt_WholeArchiveHsLibs : GeneralFlag
-  |  Opt_ErrorSpans : GeneralFlag
-  |  Opt_DiagnosticsShowCaret : GeneralFlag
-  |  Opt_PprCaseAsLet : GeneralFlag
-  |  Opt_PprShowTicks : GeneralFlag
-  |  Opt_ShowHoleConstraints : GeneralFlag
-  |  Opt_ShowLoadedModules : GeneralFlag
-  |  Opt_SuppressCoercions : GeneralFlag
-  |  Opt_SuppressVarKinds : GeneralFlag
-  |  Opt_SuppressModulePrefixes : GeneralFlag
-  |  Opt_SuppressTypeApplications : GeneralFlag
-  |  Opt_SuppressIdInfo : GeneralFlag
-  |  Opt_SuppressUnfoldings : GeneralFlag
-  |  Opt_SuppressTypeSignatures : GeneralFlag
-  |  Opt_SuppressUniques : GeneralFlag
-  |  Opt_SuppressStgFreeVars : GeneralFlag
-  |  Opt_SuppressTicks : GeneralFlag
-  |  Opt_AutoLinkPackages : GeneralFlag
-  |  Opt_ImplicitImportQualified : GeneralFlag
-  |  Opt_KeepHiDiffs : GeneralFlag
-  |  Opt_KeepHcFiles : GeneralFlag
-  |  Opt_KeepSFiles : GeneralFlag
-  |  Opt_KeepTmpFiles : GeneralFlag
-  |  Opt_KeepRawTokenStream : GeneralFlag
-  |  Opt_KeepLlvmFiles : GeneralFlag
-  |  Opt_KeepHiFiles : GeneralFlag
-  |  Opt_KeepOFiles : GeneralFlag
-  |  Opt_BuildDynamicToo : GeneralFlag
-  |  Opt_DistrustAllPackages : GeneralFlag
-  |  Opt_PackageTrust : GeneralFlag
-  |  Opt_G_NoStateHack : GeneralFlag
-  |  Opt_G_NoOptCoercion : GeneralFlag.
+Inductive GeneralFlag : Type :=
+  | Opt_DumpToFile : GeneralFlag
+  | Opt_D_faststring_stats : GeneralFlag
+  | Opt_D_dump_minimal_imports : GeneralFlag
+  | Opt_DoCoreLinting : GeneralFlag
+  | Opt_DoStgLinting : GeneralFlag
+  | Opt_DoCmmLinting : GeneralFlag
+  | Opt_DoAsmLinting : GeneralFlag
+  | Opt_DoAnnotationLinting : GeneralFlag
+  | Opt_NoLlvmMangler : GeneralFlag
+  | Opt_FastLlvm : GeneralFlag
+  | Opt_WarnIsError : GeneralFlag
+  | Opt_ShowWarnGroups : GeneralFlag
+  | Opt_HideSourcePaths : GeneralFlag
+  | Opt_PrintExplicitForalls : GeneralFlag
+  | Opt_PrintExplicitKinds : GeneralFlag
+  | Opt_PrintExplicitCoercions : GeneralFlag
+  | Opt_PrintExplicitRuntimeReps : GeneralFlag
+  | Opt_PrintEqualityRelations : GeneralFlag
+  | Opt_PrintUnicodeSyntax : GeneralFlag
+  | Opt_PrintExpandedSynonyms : GeneralFlag
+  | Opt_PrintPotentialInstances : GeneralFlag
+  | Opt_PrintTypecheckerElaboration : GeneralFlag
+  | Opt_CallArity : GeneralFlag
+  | Opt_Exitification : GeneralFlag
+  | Opt_Strictness : GeneralFlag
+  | Opt_LateDmdAnal : GeneralFlag
+  | Opt_KillAbsence : GeneralFlag
+  | Opt_KillOneShot : GeneralFlag
+  | Opt_FullLaziness : GeneralFlag
+  | Opt_FloatIn : GeneralFlag
+  | Opt_Specialise : GeneralFlag
+  | Opt_SpecialiseAggressively : GeneralFlag
+  | Opt_CrossModuleSpecialise : GeneralFlag
+  | Opt_StaticArgumentTransformation : GeneralFlag
+  | Opt_CSE : GeneralFlag
+  | Opt_StgCSE : GeneralFlag
+  | Opt_LiberateCase : GeneralFlag
+  | Opt_SpecConstr : GeneralFlag
+  | Opt_SpecConstrKeen : GeneralFlag
+  | Opt_DoLambdaEtaExpansion : GeneralFlag
+  | Opt_IgnoreAsserts : GeneralFlag
+  | Opt_DoEtaReduction : GeneralFlag
+  | Opt_CaseMerge : GeneralFlag
+  | Opt_CaseFolding : GeneralFlag
+  | Opt_UnboxStrictFields : GeneralFlag
+  | Opt_UnboxSmallStrictFields : GeneralFlag
+  | Opt_DictsCheap : GeneralFlag
+  | Opt_EnableRewriteRules : GeneralFlag
+  | Opt_Vectorise : GeneralFlag
+  | Opt_VectorisationAvoidance : GeneralFlag
+  | Opt_RegsGraph : GeneralFlag
+  | Opt_RegsIterative : GeneralFlag
+  | Opt_PedanticBottoms : GeneralFlag
+  | Opt_LlvmTBAA : GeneralFlag
+  | Opt_LlvmPassVectorsInRegisters : GeneralFlag
+  | Opt_LlvmFillUndefWithGarbage : GeneralFlag
+  | Opt_IrrefutableTuples : GeneralFlag
+  | Opt_CmmSink : GeneralFlag
+  | Opt_CmmElimCommonBlocks : GeneralFlag
+  | Opt_OmitYields : GeneralFlag
+  | Opt_FunToThunk : GeneralFlag
+  | Opt_DictsStrict : GeneralFlag
+  | Opt_DmdTxDictSel : GeneralFlag
+  | Opt_Loopification : GeneralFlag
+  | Opt_CprAnal : GeneralFlag
+  | Opt_WorkerWrapper : GeneralFlag
+  | Opt_SolveConstantDicts : GeneralFlag
+  | Opt_AlignmentSanitisation : GeneralFlag
+  | Opt_CatchBottoms : GeneralFlag
+  | Opt_SimplPreInlining : GeneralFlag
+  | Opt_IgnoreInterfacePragmas : GeneralFlag
+  | Opt_OmitInterfacePragmas : GeneralFlag
+  | Opt_ExposeAllUnfoldings : GeneralFlag
+  | Opt_WriteInterface : GeneralFlag
+  | Opt_AutoSccsOnIndividualCafs : GeneralFlag
+  | Opt_ProfCountEntries : GeneralFlag
+  | Opt_Pp : GeneralFlag
+  | Opt_ForceRecomp : GeneralFlag
+  | Opt_IgnoreOptimChanges : GeneralFlag
+  | Opt_IgnoreHpcChanges : GeneralFlag
+  | Opt_ExcessPrecision : GeneralFlag
+  | Opt_EagerBlackHoling : GeneralFlag
+  | Opt_NoHsMain : GeneralFlag
+  | Opt_SplitObjs : GeneralFlag
+  | Opt_SplitSections : GeneralFlag
+  | Opt_StgStats : GeneralFlag
+  | Opt_HideAllPackages : GeneralFlag
+  | Opt_HideAllPluginPackages : GeneralFlag
+  | Opt_PrintBindResult : GeneralFlag
+  | Opt_Haddock : GeneralFlag
+  | Opt_HaddockOptions : GeneralFlag
+  | Opt_BreakOnException : GeneralFlag
+  | Opt_BreakOnError : GeneralFlag
+  | Opt_PrintEvldWithShow : GeneralFlag
+  | Opt_PrintBindContents : GeneralFlag
+  | Opt_GenManifest : GeneralFlag
+  | Opt_EmbedManifest : GeneralFlag
+  | Opt_SharedImplib : GeneralFlag
+  | Opt_BuildingCabalPackage : GeneralFlag
+  | Opt_IgnoreDotGhci : GeneralFlag
+  | Opt_GhciSandbox : GeneralFlag
+  | Opt_GhciHistory : GeneralFlag
+  | Opt_LocalGhciHistory : GeneralFlag
+  | Opt_HelpfulErrors : GeneralFlag
+  | Opt_DeferTypeErrors : GeneralFlag
+  | Opt_DeferTypedHoles : GeneralFlag
+  | Opt_DeferOutOfScopeVariables : GeneralFlag
+  | Opt_PIC : GeneralFlag
+  | Opt_PIE : GeneralFlag
+  | Opt_PICExecutable : GeneralFlag
+  | Opt_SccProfilingOn : GeneralFlag
+  | Opt_Ticky : GeneralFlag
+  | Opt_Ticky_Allocd : GeneralFlag
+  | Opt_Ticky_LNE : GeneralFlag
+  | Opt_Ticky_Dyn_Thunk : GeneralFlag
+  | Opt_RPath : GeneralFlag
+  | Opt_RelativeDynlibPaths : GeneralFlag
+  | Opt_Hpc : GeneralFlag
+  | Opt_FlatCache : GeneralFlag
+  | Opt_ExternalInterpreter : GeneralFlag
+  | Opt_OptimalApplicativeDo : GeneralFlag
+  | Opt_VersionMacros : GeneralFlag
+  | Opt_WholeArchiveHsLibs : GeneralFlag
+  | Opt_ErrorSpans : GeneralFlag
+  | Opt_DiagnosticsShowCaret : GeneralFlag
+  | Opt_PprCaseAsLet : GeneralFlag
+  | Opt_PprShowTicks : GeneralFlag
+  | Opt_ShowHoleConstraints : GeneralFlag
+  | Opt_ShowLoadedModules : GeneralFlag
+  | Opt_SuppressCoercions : GeneralFlag
+  | Opt_SuppressVarKinds : GeneralFlag
+  | Opt_SuppressModulePrefixes : GeneralFlag
+  | Opt_SuppressTypeApplications : GeneralFlag
+  | Opt_SuppressIdInfo : GeneralFlag
+  | Opt_SuppressUnfoldings : GeneralFlag
+  | Opt_SuppressTypeSignatures : GeneralFlag
+  | Opt_SuppressUniques : GeneralFlag
+  | Opt_SuppressStgFreeVars : GeneralFlag
+  | Opt_SuppressTicks : GeneralFlag
+  | Opt_AutoLinkPackages : GeneralFlag
+  | Opt_ImplicitImportQualified : GeneralFlag
+  | Opt_KeepHiDiffs : GeneralFlag
+  | Opt_KeepHcFiles : GeneralFlag
+  | Opt_KeepSFiles : GeneralFlag
+  | Opt_KeepTmpFiles : GeneralFlag
+  | Opt_KeepRawTokenStream : GeneralFlag
+  | Opt_KeepLlvmFiles : GeneralFlag
+  | Opt_KeepHiFiles : GeneralFlag
+  | Opt_KeepOFiles : GeneralFlag
+  | Opt_BuildDynamicToo : GeneralFlag
+  | Opt_DistrustAllPackages : GeneralFlag
+  | Opt_PackageTrust : GeneralFlag
+  | Opt_G_NoStateHack : GeneralFlag
+  | Opt_G_NoOptCoercion : GeneralFlag.
 
 Axiom FlushOut : Type.
 
@@ -377,14 +377,14 @@ Axiom FlushErr : Type.
 
 Axiom FlagSpec : Type -> Type.
 
-Inductive FilesToClean : Type
-  := | Mk_FilesToClean (ftcGhcSession : (Data.Set.Internal.Set_ GHC.Base.String))
+Inductive FilesToClean : Type :=
+  | Mk_FilesToClean (ftcGhcSession : (Data.Set.Internal.Set_ GHC.Base.String))
   (ftcCurrentModule : (Data.Set.Internal.Set_ GHC.Base.String))
    : FilesToClean.
 
-Inductive DynLibLoader : Type
-  := | Deployable : DynLibLoader
-  |  SystemDependent : DynLibLoader.
+Inductive DynLibLoader : Type :=
+  | Deployable : DynLibLoader
+  | SystemDependent : DynLibLoader.
 
 Axiom DynFlags : Type.
 
@@ -398,92 +398,92 @@ Existing Class HasDynFlags.
 Definition getDynFlags `{g__0__ : HasDynFlags m} : m DynFlags :=
   g__0__ _ (getDynFlags__ m).
 
-Inductive DumpFlag : Type
-  := | Opt_D_dump_cmm : DumpFlag
-  |  Opt_D_dump_cmm_from_stg : DumpFlag
-  |  Opt_D_dump_cmm_raw : DumpFlag
-  |  Opt_D_dump_cmm_verbose : DumpFlag
-  |  Opt_D_dump_cmm_cfg : DumpFlag
-  |  Opt_D_dump_cmm_cbe : DumpFlag
-  |  Opt_D_dump_cmm_switch : DumpFlag
-  |  Opt_D_dump_cmm_proc : DumpFlag
-  |  Opt_D_dump_cmm_sp : DumpFlag
-  |  Opt_D_dump_cmm_sink : DumpFlag
-  |  Opt_D_dump_cmm_caf : DumpFlag
-  |  Opt_D_dump_cmm_procmap : DumpFlag
-  |  Opt_D_dump_cmm_split : DumpFlag
-  |  Opt_D_dump_cmm_info : DumpFlag
-  |  Opt_D_dump_cmm_cps : DumpFlag
-  |  Opt_D_dump_asm : DumpFlag
-  |  Opt_D_dump_asm_native : DumpFlag
-  |  Opt_D_dump_asm_liveness : DumpFlag
-  |  Opt_D_dump_asm_regalloc : DumpFlag
-  |  Opt_D_dump_asm_regalloc_stages : DumpFlag
-  |  Opt_D_dump_asm_conflicts : DumpFlag
-  |  Opt_D_dump_asm_stats : DumpFlag
-  |  Opt_D_dump_asm_expanded : DumpFlag
-  |  Opt_D_dump_llvm : DumpFlag
-  |  Opt_D_dump_core_stats : DumpFlag
-  |  Opt_D_dump_deriv : DumpFlag
-  |  Opt_D_dump_ds : DumpFlag
-  |  Opt_D_dump_foreign : DumpFlag
-  |  Opt_D_dump_inlinings : DumpFlag
-  |  Opt_D_dump_rule_firings : DumpFlag
-  |  Opt_D_dump_rule_rewrites : DumpFlag
-  |  Opt_D_dump_simpl_trace : DumpFlag
-  |  Opt_D_dump_occur_anal : DumpFlag
-  |  Opt_D_dump_parsed : DumpFlag
-  |  Opt_D_dump_parsed_ast : DumpFlag
-  |  Opt_D_dump_rn : DumpFlag
-  |  Opt_D_dump_rn_ast : DumpFlag
-  |  Opt_D_dump_shape : DumpFlag
-  |  Opt_D_dump_simpl : DumpFlag
-  |  Opt_D_dump_simpl_iterations : DumpFlag
-  |  Opt_D_dump_spec : DumpFlag
-  |  Opt_D_dump_prep : DumpFlag
-  |  Opt_D_dump_stg : DumpFlag
-  |  Opt_D_dump_call_arity : DumpFlag
-  |  Opt_D_dump_exitify : DumpFlag
-  |  Opt_D_dump_stranal : DumpFlag
-  |  Opt_D_dump_str_signatures : DumpFlag
-  |  Opt_D_dump_tc : DumpFlag
-  |  Opt_D_dump_tc_ast : DumpFlag
-  |  Opt_D_dump_types : DumpFlag
-  |  Opt_D_dump_rules : DumpFlag
-  |  Opt_D_dump_cse : DumpFlag
-  |  Opt_D_dump_worker_wrapper : DumpFlag
-  |  Opt_D_dump_rn_trace : DumpFlag
-  |  Opt_D_dump_rn_stats : DumpFlag
-  |  Opt_D_dump_opt_cmm : DumpFlag
-  |  Opt_D_dump_simpl_stats : DumpFlag
-  |  Opt_D_dump_cs_trace : DumpFlag
-  |  Opt_D_dump_tc_trace : DumpFlag
-  |  Opt_D_dump_ec_trace : DumpFlag
-  |  Opt_D_dump_if_trace : DumpFlag
-  |  Opt_D_dump_vt_trace : DumpFlag
-  |  Opt_D_dump_splices : DumpFlag
-  |  Opt_D_th_dec_file : DumpFlag
-  |  Opt_D_dump_BCOs : DumpFlag
-  |  Opt_D_dump_vect : DumpFlag
-  |  Opt_D_dump_ticked : DumpFlag
-  |  Opt_D_dump_rtti : DumpFlag
-  |  Opt_D_source_stats : DumpFlag
-  |  Opt_D_verbose_stg2stg : DumpFlag
-  |  Opt_D_dump_hi : DumpFlag
-  |  Opt_D_dump_hi_diffs : DumpFlag
-  |  Opt_D_dump_mod_cycles : DumpFlag
-  |  Opt_D_dump_mod_map : DumpFlag
-  |  Opt_D_dump_timings : DumpFlag
-  |  Opt_D_dump_view_pattern_commoning : DumpFlag
-  |  Opt_D_verbose_core2core : DumpFlag
-  |  Opt_D_dump_debug : DumpFlag
-  |  Opt_D_dump_json : DumpFlag
-  |  Opt_D_ppr_debug : DumpFlag
-  |  Opt_D_no_debug_output : DumpFlag.
+Inductive DumpFlag : Type :=
+  | Opt_D_dump_cmm : DumpFlag
+  | Opt_D_dump_cmm_from_stg : DumpFlag
+  | Opt_D_dump_cmm_raw : DumpFlag
+  | Opt_D_dump_cmm_verbose : DumpFlag
+  | Opt_D_dump_cmm_cfg : DumpFlag
+  | Opt_D_dump_cmm_cbe : DumpFlag
+  | Opt_D_dump_cmm_switch : DumpFlag
+  | Opt_D_dump_cmm_proc : DumpFlag
+  | Opt_D_dump_cmm_sp : DumpFlag
+  | Opt_D_dump_cmm_sink : DumpFlag
+  | Opt_D_dump_cmm_caf : DumpFlag
+  | Opt_D_dump_cmm_procmap : DumpFlag
+  | Opt_D_dump_cmm_split : DumpFlag
+  | Opt_D_dump_cmm_info : DumpFlag
+  | Opt_D_dump_cmm_cps : DumpFlag
+  | Opt_D_dump_asm : DumpFlag
+  | Opt_D_dump_asm_native : DumpFlag
+  | Opt_D_dump_asm_liveness : DumpFlag
+  | Opt_D_dump_asm_regalloc : DumpFlag
+  | Opt_D_dump_asm_regalloc_stages : DumpFlag
+  | Opt_D_dump_asm_conflicts : DumpFlag
+  | Opt_D_dump_asm_stats : DumpFlag
+  | Opt_D_dump_asm_expanded : DumpFlag
+  | Opt_D_dump_llvm : DumpFlag
+  | Opt_D_dump_core_stats : DumpFlag
+  | Opt_D_dump_deriv : DumpFlag
+  | Opt_D_dump_ds : DumpFlag
+  | Opt_D_dump_foreign : DumpFlag
+  | Opt_D_dump_inlinings : DumpFlag
+  | Opt_D_dump_rule_firings : DumpFlag
+  | Opt_D_dump_rule_rewrites : DumpFlag
+  | Opt_D_dump_simpl_trace : DumpFlag
+  | Opt_D_dump_occur_anal : DumpFlag
+  | Opt_D_dump_parsed : DumpFlag
+  | Opt_D_dump_parsed_ast : DumpFlag
+  | Opt_D_dump_rn : DumpFlag
+  | Opt_D_dump_rn_ast : DumpFlag
+  | Opt_D_dump_shape : DumpFlag
+  | Opt_D_dump_simpl : DumpFlag
+  | Opt_D_dump_simpl_iterations : DumpFlag
+  | Opt_D_dump_spec : DumpFlag
+  | Opt_D_dump_prep : DumpFlag
+  | Opt_D_dump_stg : DumpFlag
+  | Opt_D_dump_call_arity : DumpFlag
+  | Opt_D_dump_exitify : DumpFlag
+  | Opt_D_dump_stranal : DumpFlag
+  | Opt_D_dump_str_signatures : DumpFlag
+  | Opt_D_dump_tc : DumpFlag
+  | Opt_D_dump_tc_ast : DumpFlag
+  | Opt_D_dump_types : DumpFlag
+  | Opt_D_dump_rules : DumpFlag
+  | Opt_D_dump_cse : DumpFlag
+  | Opt_D_dump_worker_wrapper : DumpFlag
+  | Opt_D_dump_rn_trace : DumpFlag
+  | Opt_D_dump_rn_stats : DumpFlag
+  | Opt_D_dump_opt_cmm : DumpFlag
+  | Opt_D_dump_simpl_stats : DumpFlag
+  | Opt_D_dump_cs_trace : DumpFlag
+  | Opt_D_dump_tc_trace : DumpFlag
+  | Opt_D_dump_ec_trace : DumpFlag
+  | Opt_D_dump_if_trace : DumpFlag
+  | Opt_D_dump_vt_trace : DumpFlag
+  | Opt_D_dump_splices : DumpFlag
+  | Opt_D_th_dec_file : DumpFlag
+  | Opt_D_dump_BCOs : DumpFlag
+  | Opt_D_dump_vect : DumpFlag
+  | Opt_D_dump_ticked : DumpFlag
+  | Opt_D_dump_rtti : DumpFlag
+  | Opt_D_source_stats : DumpFlag
+  | Opt_D_verbose_stg2stg : DumpFlag
+  | Opt_D_dump_hi : DumpFlag
+  | Opt_D_dump_hi_diffs : DumpFlag
+  | Opt_D_dump_mod_cycles : DumpFlag
+  | Opt_D_dump_mod_map : DumpFlag
+  | Opt_D_dump_timings : DumpFlag
+  | Opt_D_dump_view_pattern_commoning : DumpFlag
+  | Opt_D_verbose_core2core : DumpFlag
+  | Opt_D_dump_debug : DumpFlag
+  | Opt_D_dump_json : DumpFlag
+  | Opt_D_ppr_debug : DumpFlag
+  | Opt_D_no_debug_output : DumpFlag.
 
-Inductive Deprecation : Type
-  := | NotDeprecated : Deprecation
-  |  Deprecated : Deprecation.
+Inductive Deprecation : Type :=
+  | NotDeprecated : Deprecation
+  | Deprecated : Deprecation.
 
 Record ContainsDynFlags__Dict t := ContainsDynFlags__Dict_Build {
   extractDynFlags__ : t -> DynFlags }.
@@ -495,14 +495,14 @@ Existing Class ContainsDynFlags.
 Definition extractDynFlags `{g__0__ : ContainsDynFlags t} : t -> DynFlags :=
   g__0__ _ (extractDynFlags__ t).
 
-Inductive CompilerInfo : Type
-  := | GCC : CompilerInfo
-  |  Clang : CompilerInfo
-  |  AppleClang : CompilerInfo
-  |  AppleClang51 : CompilerInfo
-  |  UnknownCC : CompilerInfo.
+Inductive CompilerInfo : Type :=
+  | GCC : CompilerInfo
+  | Clang : CompilerInfo
+  | AppleClang : CompilerInfo
+  | AppleClang51 : CompilerInfo
+  | UnknownCC : CompilerInfo.
 
-Inductive BmiVersion : Type := | BMI1 : BmiVersion |  BMI2 : BmiVersion.
+Inductive BmiVersion : Type := | BMI1 : BmiVersion | BMI2 : BmiVersion.
 
 Arguments On {_} _.
 

--- a/examples/ghc/lib/EnumSet.v
+++ b/examples/ghc/lib/EnumSet.v
@@ -18,8 +18,8 @@ Require GHC.Enum.
 
 (* Converted type declarations: *)
 
-Inductive EnumSet (a : Type) : Type
-  := | Mk_EnumSet : Data.IntSet.Internal.IntSet -> EnumSet a.
+Inductive EnumSet (a : Type) : Type :=
+  | Mk_EnumSet : Data.IntSet.Internal.IntSet -> EnumSet a.
 
 Arguments Mk_EnumSet {_} _.
 

--- a/examples/ghc/lib/Exitify.v
+++ b/examples/ghc/lib/Exitify.v
@@ -218,36 +218,36 @@ Definition exitifyProgram : Core.CoreProgram -> Core.CoreProgram :=
   fun binds =>
     let go : Core.InScopeSet -> Core.CoreExpr -> Core.CoreExpr :=
       fix go (arg_0__ : Core.InScopeSet) (arg_1__ : Core.CoreExpr) : Core.CoreExpr
-            := match arg_0__, arg_1__ with
-               | _, (Core.Mk_Var _ as e) => e
-               | _, (Core.Lit _ as e) => e
-               | _, (Core.Mk_Type _ as e) => e
-               | _, (Core.Mk_Coercion _ as e) => e
-               | in_scope, Core.Cast e' c => Core.Cast (go in_scope e') c
-               | in_scope, Core.App e1 e2 => Core.App (go in_scope e1) (go in_scope e2)
-               | in_scope, Core.Lam v e' =>
-                   let in_scope' := Core.extendInScopeSet in_scope v in
-                   Core.Lam v (go in_scope' e')
-               | in_scope, Core.Case scrut bndr ty alts =>
-                   let in_scope1 := Core.extendInScopeSet in_scope bndr in
-                   let go_alt :=
-                     fun '(pair (pair dc pats) rhs) =>
-                       let in_scope' := Core.extendInScopeSetList in_scope1 pats in
-                       pair (pair dc pats) (go in_scope' rhs) in
-                   Core.Case (go in_scope scrut) bndr ty (GHC.Base.map go_alt alts)
-               | in_scope, Core.Let (Core.NonRec bndr rhs) body =>
-                   let in_scope' := Core.extendInScopeSet in_scope bndr in
-                   Core.Let (Core.NonRec bndr (go in_scope rhs)) (go in_scope' body)
-               | in_scope, Core.Let (Core.Rec pairs) body =>
-                   let in_scope' :=
-                     Core.extendInScopeSetList in_scope (Core.bindersOf (Core.Rec pairs)) in
-                   let pairs' := Util.mapSnd (go in_scope') pairs in
-                   let body' := go in_scope' body in
-                   let is_join_rec :=
-                     Data.Foldable.any (Id.isJoinId GHC.Base.∘ Data.Tuple.fst) pairs in
-                   if is_join_rec : bool then Core.mkLets (exitifyRec in_scope' pairs') body' else
-                   Core.Let (Core.Rec pairs') body'
-               end in
+        := match arg_0__, arg_1__ with
+           | _, (Core.Mk_Var _ as e) => e
+           | _, (Core.Lit _ as e) => e
+           | _, (Core.Mk_Type _ as e) => e
+           | _, (Core.Mk_Coercion _ as e) => e
+           | in_scope, Core.Cast e' c => Core.Cast (go in_scope e') c
+           | in_scope, Core.App e1 e2 => Core.App (go in_scope e1) (go in_scope e2)
+           | in_scope, Core.Lam v e' =>
+               let in_scope' := Core.extendInScopeSet in_scope v in
+               Core.Lam v (go in_scope' e')
+           | in_scope, Core.Case scrut bndr ty alts =>
+               let in_scope1 := Core.extendInScopeSet in_scope bndr in
+               let go_alt :=
+                 fun '(pair (pair dc pats) rhs) =>
+                   let in_scope' := Core.extendInScopeSetList in_scope1 pats in
+                   pair (pair dc pats) (go in_scope' rhs) in
+               Core.Case (go in_scope scrut) bndr ty (GHC.Base.map go_alt alts)
+           | in_scope, Core.Let (Core.NonRec bndr rhs) body =>
+               let in_scope' := Core.extendInScopeSet in_scope bndr in
+               Core.Let (Core.NonRec bndr (go in_scope rhs)) (go in_scope' body)
+           | in_scope, Core.Let (Core.Rec pairs) body =>
+               let in_scope' :=
+                 Core.extendInScopeSetList in_scope (Core.bindersOf (Core.Rec pairs)) in
+               let pairs' := Util.mapSnd (go in_scope') pairs in
+               let body' := go in_scope' body in
+               let is_join_rec :=
+                 Data.Foldable.any (Id.isJoinId GHC.Base.∘ Data.Tuple.fst) pairs in
+               if is_join_rec : bool then Core.mkLets (exitifyRec in_scope' pairs') body' else
+               Core.Let (Core.Rec pairs') body'
+           end in
     let in_scope_toplvl :=
       Core.extendInScopeSetList Core.emptyInScopeSet (Core.bindersOfBinds binds) in
     let goTopLvl :=

--- a/examples/ghc/lib/FV.v
+++ b/examples/ghc/lib/FV.v
@@ -76,11 +76,11 @@ Definition filterFV : InterestingVarFun -> FV -> FV :=
 
 Fixpoint mapUnionFV {a} `(arg_0__ : (a -> FV)) `(arg_1__ : list a) arg_2__
                     arg_3__ arg_4__
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-              | _f, nil, _fv_cand, _in_scope, acc => acc
-              | f, cons a as_, fv_cand, in_scope, acc =>
-                  mapUnionFV f as_ fv_cand in_scope (f a fv_cand in_scope acc)
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+     | _f, nil, _fv_cand, _in_scope, acc => acc
+     | f, cons a as_, fv_cand, in_scope, acc =>
+         mapUnionFV f as_ fv_cand in_scope (f a fv_cand in_scope acc)
+     end.
 
 Definition unionsFV : list FV -> FV :=
   fun fvs fv_cand in_scope acc => mapUnionFV GHC.Base.id fvs fv_cand in_scope acc.

--- a/examples/ghc/lib/FieldLabel.v
+++ b/examples/ghc/lib/FieldLabel.v
@@ -25,9 +25,9 @@ Require OccName.
 Definition FieldLabelString :=
   FastString.FastString%type.
 
-Inductive FieldLbl a : Type
-  := | Mk_FieldLabel (flLabel : FieldLabelString) (flIsOverloaded : bool)
-  (flSelector : a)
+Inductive FieldLbl a : Type :=
+  | Mk_FieldLabel (flLabel : FieldLabelString) (flIsOverloaded : bool) (flSelector
+    : a)
    : FieldLbl a.
 
 Definition FieldLabel :=

--- a/examples/ghc/lib/FloatIn.v
+++ b/examples/ghc/lib/FloatIn.v
@@ -41,8 +41,8 @@ Definition FreeVarSet :=
 Definition BoundVarSet :=
   Core.DIdSet%type.
 
-Inductive FloatInBind : Type
-  := | FB : BoundVarSet -> FreeVarSet -> MkCore.FloatBind -> FloatInBind.
+Inductive FloatInBind : Type :=
+  | FB : BoundVarSet -> FreeVarSet -> MkCore.FloatBind -> FloatInBind.
 
 Definition FloatInBinds :=
   (list FloatInBind)%type.
@@ -129,43 +129,43 @@ Definition sepBindsByDropPoint
     let n_alts := Coq.Lists.List.length drop_pts in
     let go : FloatInBinds -> list DropBox -> list FloatInBinds :=
       fix go (arg_1__ : FloatInBinds) (arg_2__ : list DropBox) : list FloatInBinds
-            := match arg_1__, arg_2__ with
-               | nil, drop_boxes =>
-                   GHC.Base.map (GHC.List.reverse GHC.Base.∘ Data.Tuple.snd) drop_boxes
-               | cons (FB bndrs bind_fvs bind as bind_w_fvs) binds
-               , (cons here_box fork_boxes as drop_boxes) =>
-                   let insert : DropBox -> DropBox :=
-                     fun '(pair fvs drops) =>
-                       pair (Core.unionDVarSet fvs bind_fvs) (cons bind_w_fvs drops) in
-                   let insert_maybe :=
-                     fun arg_7__ arg_8__ =>
-                       match arg_7__, arg_8__ with
-                       | box, true => insert box
-                       | box, false => box
-                       end in
-                   match (let cont_11__ arg_12__ :=
-                              let 'pair fvs _ := arg_12__ in
-                              cons (Core.intersectsDVarSet fvs bndrs) nil in
-                            Coq.Lists.List.flat_map cont_11__ drop_boxes) with
-                   | cons used_here used_in_flags =>
-                       let n_used_alts := Util.count GHC.Base.id used_in_flags in
-                       let cant_push :=
-                         if is_case : bool
-                         then orb (n_used_alts GHC.Base.== n_alts) (andb (n_used_alts GHC.Base.> #1)
-                                                                         (negb (floatIsDupable dflags bind))) else
-                         orb (floatIsCase bind) (n_used_alts GHC.Base.> #1) in
-                       let drop_here := orb used_here cant_push in
-                       let new_fork_boxes :=
-                         Util.zipWithEqual (GHC.Base.hs_string__ "FloatIn.sepBinds") insert_maybe
-                         fork_boxes used_in_flags in
-                       let new_boxes :=
-                         if drop_here : bool then (cons (insert here_box) fork_boxes) else
-                         (cons here_box new_fork_boxes) in
-                       go binds new_boxes
-                   | _ => GHC.Err.patternFailure
-                   end
-               | _, _ => Panic.panic (GHC.Base.hs_string__ "sepBindsByDropPoint/go")
-               end in
+        := match arg_1__, arg_2__ with
+           | nil, drop_boxes =>
+               GHC.Base.map (GHC.List.reverse GHC.Base.∘ Data.Tuple.snd) drop_boxes
+           | cons (FB bndrs bind_fvs bind as bind_w_fvs) binds
+           , (cons here_box fork_boxes as drop_boxes) =>
+               let insert : DropBox -> DropBox :=
+                 fun '(pair fvs drops) =>
+                   pair (Core.unionDVarSet fvs bind_fvs) (cons bind_w_fvs drops) in
+               let insert_maybe :=
+                 fun arg_7__ arg_8__ =>
+                   match arg_7__, arg_8__ with
+                   | box, true => insert box
+                   | box, false => box
+                   end in
+               match (let cont_11__ arg_12__ :=
+                          let 'pair fvs _ := arg_12__ in
+                          cons (Core.intersectsDVarSet fvs bndrs) nil in
+                        Coq.Lists.List.flat_map cont_11__ drop_boxes) with
+               | cons used_here used_in_flags =>
+                   let n_used_alts := Util.count GHC.Base.id used_in_flags in
+                   let cant_push :=
+                     if is_case : bool
+                     then orb (n_used_alts GHC.Base.== n_alts) (andb (n_used_alts GHC.Base.> #1)
+                                                                     (negb (floatIsDupable dflags bind))) else
+                     orb (floatIsCase bind) (n_used_alts GHC.Base.> #1) in
+                   let drop_here := orb used_here cant_push in
+                   let new_fork_boxes :=
+                     Util.zipWithEqual (GHC.Base.hs_string__ "FloatIn.sepBinds") insert_maybe
+                     fork_boxes used_in_flags in
+                   let new_boxes :=
+                     if drop_here : bool then (cons (insert here_box) fork_boxes) else
+                     (cons here_box new_fork_boxes) in
+                   go binds new_boxes
+               | _ => GHC.Err.patternFailure
+               end
+           | _, _ => Panic.panic (GHC.Base.hs_string__ "sepBindsByDropPoint/go")
+           end in
     if Data.Foldable.null floaters : bool
     then cons nil (Coq.Lists.List.flat_map (fun _ => cons nil nil) drop_pts) else
     if andb Util.debugIsOn (negb (Util.lengthAtLeast drop_pts #2)) : bool
@@ -239,11 +239,11 @@ Definition fiBind
     end.
 
 Fixpoint wrapFloats (arg_0__ : FloatInBinds) (arg_1__ : Core.CoreExpr)
-           : Core.CoreExpr
-           := match arg_0__, arg_1__ with
-              | nil, e => e
-              | cons (FB _ _ fl) bs, e => wrapFloats bs (MkCore.wrapFloat fl e)
-              end.
+  : Core.CoreExpr
+  := match arg_0__, arg_1__ with
+     | nil, e => e
+     | cons (FB _ _ fl) bs, e => wrapFloats bs (MkCore.wrapFloat fl e)
+     end.
 
 (* External variables:
      Some andb bool cons false list negb nil op_zt__ orb pair true

--- a/examples/ghc/lib/FloatOut.v
+++ b/examples/ghc/lib/FloatOut.v
@@ -47,8 +47,8 @@ Inductive FloatStats : Type := | FlS : nat -> nat -> nat -> FloatStats.
 Definition FloatLet :=
   Core.CoreBind%type.
 
-Inductive FloatBinds : Type
-  := | FB
+Inductive FloatBinds : Type :=
+  | FB
    : (Bag.Bag FloatLet) -> (Bag.Bag MkCore.FloatBind) -> MajorEnv -> FloatBinds.
 
 (* Midamble *)
@@ -118,13 +118,13 @@ Definition zeroStats : FloatStats :=
 
 Fixpoint floatList {a} {b} (arg_0__ : (a -> (FloatStats * FloatBinds * b)%type))
                    (arg_1__ : list a) : (FloatStats * FloatBinds * list b)%type
-           := match arg_0__, arg_1__ with
-              | _, nil => pair (pair zeroStats emptyFloats) nil
-              | f, cons a as_ =>
-                  let 'pair (pair fs_a binds_a) b := f a in
-                  let 'pair (pair fs_as binds_as) bs := floatList f as_ in
-                  pair (pair (add_stats fs_a fs_as) (plusFloats binds_a binds_as)) (cons b bs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => pair (pair zeroStats emptyFloats) nil
+     | f, cons a as_ =>
+         let 'pair (pair fs_a binds_a) b := f a in
+         let 'pair (pair fs_as binds_as) bs := floatList f as_ in
+         pair (pair (add_stats fs_a fs_as) (plusFloats binds_a binds_as)) (cons b bs)
+     end.
 
 Definition install
    : Bag.Bag MkCore.FloatBind -> Core.CoreExpr -> Core.CoreExpr :=
@@ -160,15 +160,15 @@ Definition floatRhs
      SetLevels.LevelledExpr -> (FloatStats * FloatBinds * Core.CoreExpr)%type :=
   fun bndr rhs =>
     let fix try_collect arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | num_3__, expr, acc =>
-                     if num_3__ GHC.Base.== #0 : bool
-                     then Some (pair (GHC.List.reverse acc) expr) else
-                     match arg_0__, arg_1__, arg_2__ with
-                     | n, Core.Lam b e, acc => try_collect (n GHC.Num.- #1) e (cons b acc)
-                     | _, _, _ => None
-                     end
-                 end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | num_3__, expr, acc =>
+             if num_3__ GHC.Base.== #0 : bool
+             then Some (pair (GHC.List.reverse acc) expr) else
+             match arg_0__, arg_1__, arg_2__ with
+             | n, Core.Lam b e, acc => try_collect (n GHC.Num.- #1) e (cons b acc)
+             | _, _, _ => None
+             end
+         end in
     let j_17__ := atJoinCeiling (floatExpr rhs) in
     match Id.isJoinId_maybe bndr with
     | Some join_arity =>
@@ -193,10 +193,10 @@ Definition installUnderLambdas
    : Bag.Bag MkCore.FloatBind -> Core.CoreExpr -> Core.CoreExpr :=
   fun floats e =>
     let fix go arg_0__
-              := match arg_0__ with
-                 | Core.Lam b e => Core.Lam b (go e)
-                 | e => install floats e
-                 end in
+      := match arg_0__ with
+         | Core.Lam b e => Core.Lam b (go e)
+         | e => install floats e
+         end in
     if Bag.isEmptyBag floats : bool then e else
     go e.
 
@@ -206,19 +206,19 @@ Definition splitRecFloats
       Bag.Bag MkCore.FloatBind)%type :=
   fun fs =>
     let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | ul_prs, prs, cons (MkCore.FloatLet (Core.NonRec b r)) fs =>
-                     if andb (Core.isUnliftedType (Id.idType b)) (negb (Id.isJoinId b)) : bool
-                     then go (cons (pair b r) ul_prs) prs fs else
-                     go ul_prs (cons (pair b r) prs) fs
-                 | _, _, _ =>
-                     match arg_0__, arg_1__, arg_2__ with
-                     | ul_prs, prs, cons (MkCore.FloatLet (Core.Rec prs')) fs =>
-                         go ul_prs (Coq.Init.Datatypes.app prs' prs) fs
-                     | ul_prs, prs, fs =>
-                         pair (pair (GHC.List.reverse ul_prs) prs) (Bag.listToBag fs)
-                     end
-                 end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | ul_prs, prs, cons (MkCore.FloatLet (Core.NonRec b r)) fs =>
+             if andb (Core.isUnliftedType (Id.idType b)) (negb (Id.isJoinId b)) : bool
+             then go (cons (pair b r) ul_prs) prs fs else
+             go ul_prs (cons (pair b r) prs) fs
+         | _, _, _ =>
+             match arg_0__, arg_1__, arg_2__ with
+             | ul_prs, prs, cons (MkCore.FloatLet (Core.Rec prs')) fs =>
+                 go ul_prs (Coq.Init.Datatypes.app prs' prs) fs
+             | ul_prs, prs, fs =>
+                 pair (pair (GHC.List.reverse ul_prs) prs) (Bag.listToBag fs)
+             end
+         end in
     go nil nil (Bag.bagToList fs).
 
 Definition floatBind

--- a/examples/ghc/lib/ListSetOps.v
+++ b/examples/ghc/lib/ListSetOps.v
@@ -64,12 +64,12 @@ Definition minusList {a} `{GHC.Base.Ord a} : list a -> list a -> list a :=
 
 Fixpoint assocDefaultUsing {a} {b} (arg_0__ : (a -> a -> bool)) (arg_1__ : b)
                            (arg_2__ : Assoc a b) (arg_3__ : a) : b
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, deflt, nil, _ => deflt
-              | eq, deflt, cons (pair k v) rest, key =>
-                  if eq k key : bool then v else
-                  assocDefaultUsing eq deflt rest key
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | _, deflt, nil, _ => deflt
+     | eq, deflt, cons (pair k v) rest, key =>
+         if eq k key : bool then v else
+         assocDefaultUsing eq deflt rest key
+     end.
 
 Definition assoc {a} {b} `{GHC.Base.Eq_ a} `{GHC.Err.Default b}
    : GHC.Base.String -> Assoc a b -> a -> b :=
@@ -91,26 +91,26 @@ Definition assocMaybe {a} {b} `{(GHC.Base.Eq_ a)}
    : Assoc a b -> a -> option b :=
   fun alist key =>
     let fix lookup arg_0__
-              := match arg_0__ with
-                 | nil => None
-                 | cons (pair tv ty) rest =>
-                     if key GHC.Base.== tv : bool
-                     then Some ty
-                     else lookup rest
-                 end in
+      := match arg_0__ with
+         | nil => None
+         | cons (pair tv ty) rest =>
+             if key GHC.Base.== tv : bool
+             then Some ty
+             else lookup rest
+         end in
     lookup alist.
 
 Definition hasNoDups {a} `{(GHC.Base.Eq_ a)} : list a -> bool :=
   fun xs =>
     let is_elem := Util.isIn (GHC.Base.hs_string__ "hasNoDups") in
     let fix f arg_1__ arg_2__
-              := match arg_1__, arg_2__ with
-                 | _, nil => true
-                 | seen_so_far, cons x xs =>
-                     if is_elem x seen_so_far : bool
-                     then false
-                     else f (cons x seen_so_far) xs
-                 end in
+      := match arg_1__, arg_2__ with
+         | _, nil => true
+         | seen_so_far, cons x xs =>
+             if is_elem x seen_so_far : bool
+             then false
+             else f (cons x seen_so_far) xs
+         end in
     f nil xs.
 
 Axiom equivClasses : forall {a},

--- a/examples/ghc/lib/Literal.v
+++ b/examples/ghc/lib/Literal.v
@@ -29,19 +29,19 @@ Require UniqFM.
 
 (* Converted type declarations: *)
 
-Inductive Literal : Type
-  := | MachChar : GHC.Char.Char -> Literal
-  |  MachStr : GHC.Base.String -> Literal
-  |  MachNullAddr : Literal
-  |  MachInt : GHC.Num.Integer -> Literal
-  |  MachInt64 : GHC.Num.Integer -> Literal
-  |  MachWord : GHC.Num.Integer -> Literal
-  |  MachWord64 : GHC.Num.Integer -> Literal
-  |  MachFloat : GHC.Real.Rational -> Literal
-  |  MachDouble : GHC.Real.Rational -> Literal
-  |  MachLabel
+Inductive Literal : Type :=
+  | MachChar : GHC.Char.Char -> Literal
+  | MachStr : GHC.Base.String -> Literal
+  | MachNullAddr : Literal
+  | MachInt : GHC.Num.Integer -> Literal
+  | MachInt64 : GHC.Num.Integer -> Literal
+  | MachWord : GHC.Num.Integer -> Literal
+  | MachWord64 : GHC.Num.Integer -> Literal
+  | MachFloat : GHC.Real.Rational -> Literal
+  | MachDouble : GHC.Real.Rational -> Literal
+  | MachLabel
    : FastString.FastString -> (option nat) -> BasicTypes.FunctionOrData -> Literal
-  |  LitInteger : GHC.Num.Integer -> AxiomatizedTypes.Type_ -> Literal.
+  | LitInteger : GHC.Num.Integer -> AxiomatizedTypes.Type_ -> Literal.
 
 Instance Default__Literal : GHC.Err.Default Literal :=
   GHC.Err.Build_Default _ MachNullAddr.

--- a/examples/ghc/lib/Maybes.v
+++ b/examples/ghc/lib/Maybes.v
@@ -21,9 +21,9 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive MaybeErr err val : Type
-  := | Succeeded : val -> MaybeErr err val
-  |  Failed : err -> MaybeErr err val.
+Inductive MaybeErr err val : Type :=
+  | Succeeded : val -> MaybeErr err val
+  | Failed : err -> MaybeErr err val.
 
 Arguments Succeeded {_} {_} _.
 

--- a/examples/ghc/lib/MkCore.v
+++ b/examples/ghc/lib/MkCore.v
@@ -41,9 +41,9 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive FloatBind : Type
-  := | FloatLet : Core.CoreBind -> FloatBind
-  |  FloatCase
+Inductive FloatBind : Type :=
+  | FloatLet : Core.CoreBind -> FloatBind
+  | FloatCase
    : Core.CoreExpr -> Core.Id -> Core.AltCon -> list Core.Var -> FloatBind.
 
 (* Converted value declarations: *)

--- a/examples/ghc/lib/Module.v
+++ b/examples/ghc/lib/Module.v
@@ -36,50 +36,50 @@ Import GHC.Base.Notations.
 Definition ModuleNameEnv :=
   UniqFM.UniqFM%type.
 
-Inductive ModuleName : Type
-  := | Mk_ModuleName : FastString.FastString -> ModuleName.
+Inductive ModuleName : Type :=
+  | Mk_ModuleName : FastString.FastString -> ModuleName.
 
-Inductive ModLocation : Type
-  := | Mk_ModLocation (ml_hs_file : option GHC.Base.String) (ml_hi_file
+Inductive ModLocation : Type :=
+  | Mk_ModLocation (ml_hs_file : option GHC.Base.String) (ml_hi_file
     : GHC.Base.String) (ml_obj_file : GHC.Base.String)
    : ModLocation.
 
-Inductive InstalledUnitId : Type
-  := | Mk_InstalledUnitId (installedUnitIdFS : FastString.FastString)
+Inductive InstalledUnitId : Type :=
+  | Mk_InstalledUnitId (installedUnitIdFS : FastString.FastString)
    : InstalledUnitId.
 
-Inductive InstalledModule : Type
-  := | Mk_InstalledModule (installedModuleUnitId : InstalledUnitId)
+Inductive InstalledModule : Type :=
+  | Mk_InstalledModule (installedModuleUnitId : InstalledUnitId)
   (installedModuleName : ModuleName)
    : InstalledModule.
 
-Inductive InstalledModuleEnv elt : Type
-  := | Mk_InstalledModuleEnv
+Inductive InstalledModuleEnv elt : Type :=
+  | Mk_InstalledModuleEnv
    : (Data.Map.Internal.Map InstalledModule elt) -> InstalledModuleEnv elt.
 
-Inductive DefUnitId : Type
-  := | Mk_DefUnitId (unDefUnitId : InstalledUnitId) : DefUnitId.
+Inductive DefUnitId : Type :=
+  | Mk_DefUnitId (unDefUnitId : InstalledUnitId) : DefUnitId.
 
 Definition DModuleNameEnv :=
   UniqFM.UniqFM%type.
 
-Inductive ComponentId : Type
-  := | Mk_ComponentId : FastString.FastString -> ComponentId.
+Inductive ComponentId : Type :=
+  | Mk_ComponentId : FastString.FastString -> ComponentId.
 
-Inductive IndefUnitId : Type
-  := | Mk_IndefUnitId (indefUnitIdFS : FastString.FastString) (indefUnitIdKey
+Inductive IndefUnitId : Type :=
+  | Mk_IndefUnitId (indefUnitIdFS : FastString.FastString) (indefUnitIdKey
     : Unique.Unique) (indefUnitIdComponentId : ComponentId) (indefUnitIdInsts
     : list (ModuleName * Module)%type) (indefUnitIdFreeHoles
     : UniqSet.UniqSet ModuleName)
    : IndefUnitId
-with Module : Type
-  := | Mk_Module (moduleUnitId : UnitId) (moduleName : ModuleName) : Module
-with UnitId : Type
-  := | IndefiniteUnitId : IndefUnitId -> UnitId
-  |  DefiniteUnitId : DefUnitId -> UnitId.
+with Module : Type :=
+  | Mk_Module (moduleUnitId : UnitId) (moduleName : ModuleName) : Module
+with UnitId : Type :=
+  | IndefiniteUnitId : IndefUnitId -> UnitId
+  | DefiniteUnitId : DefUnitId -> UnitId.
 
-Inductive IndefModule : Type
-  := | Mk_IndefModule (indefModuleUnitId : IndefUnitId) (indefModuleName
+Inductive IndefModule : Type :=
+  | Mk_IndefModule (indefModuleUnitId : IndefUnitId) (indefModuleName
     : ModuleName)
    : IndefModule.
 
@@ -105,8 +105,8 @@ Definition getModule `{g__0__ : HasModule m} : m Module :=
 
 Inductive NDModule : Type := | Mk_NDModule (unNDModule : Module) : NDModule.
 
-Inductive ModuleEnv elt : Type
-  := | Mk_ModuleEnv : (Data.Map.Internal.Map NDModule elt) -> ModuleEnv elt.
+Inductive ModuleEnv elt : Type :=
+  | Mk_ModuleEnv : (Data.Map.Internal.Map NDModule elt) -> ModuleEnv elt.
 
 Definition ModuleSet :=
   (Data.Set.Internal.Set_ NDModule)%type.

--- a/examples/ghc/lib/Name.v
+++ b/examples/ghc/lib/Name.v
@@ -28,20 +28,20 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive BuiltInSyntax : Type
-  := | Mk_BuiltInSyntax : BuiltInSyntax
-  |  UserSyntax : BuiltInSyntax.
+Inductive BuiltInSyntax : Type :=
+  | Mk_BuiltInSyntax : BuiltInSyntax
+  | UserSyntax : BuiltInSyntax.
 
-Inductive NameSort : Type
-  := | External : Module.Module -> NameSort
-  |  WiredIn
+Inductive NameSort : Type :=
+  | External : Module.Module -> NameSort
+  | WiredIn
    : Module.Module -> AxiomatizedTypes.TyThing -> BuiltInSyntax -> NameSort
-  |  Internal : NameSort
-  |  System : NameSort.
+  | Internal : NameSort
+  | System : NameSort.
 
-Inductive Name : Type
-  := | Mk_Name (n_sort : NameSort) (n_occ : OccName.OccName) (n_uniq
-    : Unique.Unique) (n_loc : SrcLoc.SrcSpan)
+Inductive Name : Type :=
+  | Mk_Name (n_sort : NameSort) (n_occ : OccName.OccName) (n_uniq : Unique.Unique)
+  (n_loc : SrcLoc.SrcSpan)
    : Name.
 
 Record NamedThing__Dict a := NamedThing__Dict_Build {

--- a/examples/ghc/lib/OccName.v
+++ b/examples/ghc/lib/OccName.v
@@ -32,14 +32,14 @@ Definition TidyOccEnv :=
 
 Inductive OccEnv a : Type := | A : (UniqFM.UniqFM a) -> OccEnv a.
 
-Inductive NameSpace : Type
-  := | VarName : NameSpace
-  |  DataName : NameSpace
-  |  TvName : NameSpace
-  |  TcClsName : NameSpace.
+Inductive NameSpace : Type :=
+  | VarName : NameSpace
+  | DataName : NameSpace
+  | TvName : NameSpace
+  | TcClsName : NameSpace.
 
-Inductive OccName : Type
-  := | Mk_OccName (occNameSpace : NameSpace) (occNameFS : FastString.FastString)
+Inductive OccName : Type :=
+  | Mk_OccName (occNameSpace : NameSpace) (occNameFS : FastString.FastString)
    : OccName.
 
 Definition OccSet :=
@@ -738,14 +738,14 @@ Definition emptyTidyOccEnv : TidyOccEnv :=
 Definition avoidClashesOccEnv : TidyOccEnv -> list OccName -> TidyOccEnv :=
   fun env occs =>
     let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | env, _, nil => env
-                 | env, seenOnce, cons (Mk_OccName _ fs) occs =>
-                     if UniqFM.elemUFM fs env : bool then go env seenOnce occs else
-                     if UniqFM.elemUFM fs seenOnce : bool
-                     then go (UniqFM.addToUFM env fs #1) seenOnce occs else
-                     go env (UniqFM.addToUFM seenOnce fs tt) occs
-                 end in
+      := match arg_0__, arg_1__, arg_2__ with
+         | env, _, nil => env
+         | env, seenOnce, cons (Mk_OccName _ fs) occs =>
+             if UniqFM.elemUFM fs env : bool then go env seenOnce occs else
+             if UniqFM.elemUFM fs seenOnce : bool
+             then go (UniqFM.addToUFM env fs #1) seenOnce occs else
+             go env (UniqFM.addToUFM seenOnce fs tt) occs
+         end in
     go env UniqFM.emptyUFM occs.
 
 Axiom tidyOccName : TidyOccEnv -> OccName -> (TidyOccEnv * OccName)%type.

--- a/examples/ghc/lib/OccurAnal.v
+++ b/examples/ghc/lib/OccurAnal.v
@@ -51,12 +51,12 @@ Definition OccInfoEnv :=
 Definition ZappedSet :=
   OccInfoEnv%type.
 
-Inductive UsageDetails : Type
-  := | UD (ud_env : OccInfoEnv) (ud_z_many : ZappedSet) (ud_z_in_lam : ZappedSet)
+Inductive UsageDetails : Type :=
+  | UD (ud_env : OccInfoEnv) (ud_z_many : ZappedSet) (ud_z_in_lam : ZappedSet)
   (ud_z_no_tail : ZappedSet)
    : UsageDetails.
 
-Inductive OccEncl : Type := | OccRhs : OccEncl |  OccVanilla : OccEncl.
+Inductive OccEncl : Type := | OccRhs : OccEncl | OccVanilla : OccEncl.
 
 Definition NodeScore :=
   (nat * nat * bool)%type%type.
@@ -70,14 +70,14 @@ Definition IdWithOccInfo :=
 Definition GlobalScruts :=
   Core.IdSet%type.
 
-Inductive OccEnv : Type
-  := | Mk_OccEnv (occ_encl : OccEncl) (occ_one_shots : OneShots) (occ_gbl_scrut
+Inductive OccEnv : Type :=
+  | Mk_OccEnv (occ_encl : OccEncl) (occ_one_shots : OneShots) (occ_gbl_scrut
     : GlobalScruts) (occ_rule_act : BasicTypes.Activation -> bool) (occ_binder_swap
     : bool)
    : OccEnv.
 
-Inductive Details : Type
-  := | ND (nd_bndr : Core.Id) (nd_rhs : Core.CoreExpr) (nd_rhs_bndrs
+Inductive Details : Type :=
+  | ND (nd_bndr : Core.Id) (nd_rhs : Core.CoreExpr) (nd_rhs_bndrs
     : list Core.CoreBndr) (nd_uds : UsageDetails) (nd_inl : Core.IdSet) (nd_weak
     : Core.IdSet) (nd_active_rule_fvs : Core.IdSet) (nd_score : NodeScore)
    : Details.
@@ -378,19 +378,19 @@ Definition markJoinOneShots
    : option BasicTypes.JoinArity -> list Core.Var -> list Core.Var :=
   fun mb_join_arity bndrs =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | num_2__, bndrs =>
-                     if num_2__ GHC.Base.== #0 : bool then bndrs else
-                     match arg_0__, arg_1__ with
-                     | _, nil =>
-                         Panic.warnPprTrace (true) (GHC.Base.hs_string__
-                                             "ghc/compiler/simplCore/OccurAnal.hs") #2194 (GHC.Base.mappend
-                                             Panic.someSDoc Panic.someSDoc) nil
-                     | n, cons b bs =>
-                         let b' := if Core.isId b : bool then Id.setOneShotLambda b else b in
-                         cons b' (go (n GHC.Num.- #1) bs)
-                     end
-                 end in
+      := match arg_0__, arg_1__ with
+         | num_2__, bndrs =>
+             if num_2__ GHC.Base.== #0 : bool then bndrs else
+             match arg_0__, arg_1__ with
+             | _, nil =>
+                 Panic.warnPprTrace (true) (GHC.Base.hs_string__
+                                     "ghc/compiler/simplCore/OccurAnal.hs") #2194 (GHC.Base.mappend Panic.someSDoc
+                                                                                                    Panic.someSDoc) nil
+             | n, cons b bs =>
+                 let b' := if Core.isId b : bool then Id.setOneShotLambda b else b in
+                 cons b' (go (n GHC.Num.- #1) bs)
+             end
+         end in
     match mb_join_arity with
     | None => bndrs
     | Some n => go n bndrs
@@ -603,17 +603,17 @@ Definition rank : NodeScore -> nat :=
 Fixpoint chooseLoopBreaker (arg_0__ : bool) (arg_1__ : NodeScore) (arg_2__
                             arg_3__ arg_4__
                              : list LetrecNode) : (list LetrecNode * list LetrecNode)%type
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-              | _, _, loop_nodes, acc, nil => pair loop_nodes acc
-              | approx_lb, loop_sc, loop_nodes, acc, cons node nodes =>
-                  let sc := nd_score (Digraph.node_payload node) in
-                  if andb approx_lb (rank sc GHC.Base.== rank loop_sc) : bool
-                  then chooseLoopBreaker approx_lb loop_sc (cons node loop_nodes) acc nodes else
-                  if betterLB sc loop_sc : bool
-                  then chooseLoopBreaker approx_lb sc (cons node nil) (Coq.Init.Datatypes.app
-                                                                       loop_nodes acc) nodes else
-                  chooseLoopBreaker approx_lb loop_sc loop_nodes (cons node acc) nodes
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+     | _, _, loop_nodes, acc, nil => pair loop_nodes acc
+     | approx_lb, loop_sc, loop_nodes, acc, cons node nodes =>
+         let sc := nd_score (Digraph.node_payload node) in
+         if andb approx_lb (rank sc GHC.Base.== rank loop_sc) : bool
+         then chooseLoopBreaker approx_lb loop_sc (cons node loop_nodes) acc nodes else
+         if betterLB sc loop_sc : bool
+         then chooseLoopBreaker approx_lb sc (cons node nil) (Coq.Init.Datatypes.app
+                                                              loop_nodes acc) nodes else
+         chooseLoopBreaker approx_lb loop_sc loop_nodes (cons node acc) nodes
+     end.
 
 Definition noImpRuleEdges : ImpRuleEdges :=
   Core.emptyVarEnv.
@@ -697,12 +697,12 @@ Definition nodeScore
    : Core.Id -> Core.Id -> Core.CoreExpr -> Core.VarSet -> NodeScore :=
   fun old_bndr new_bndr bind_rhs lb_deps =>
     let fix is_con_app arg_0__
-              := match arg_0__ with
-                 | Core.Mk_Var v => Id.isConLikeId v
-                 | Core.App f _ => is_con_app f
-                 | Core.Lam _ e => is_con_app e
-                 | _ => false
-                 end in
+      := match arg_0__ with
+         | Core.Mk_Var v => Id.isConLikeId v
+         | Core.App f _ => is_con_app f
+         | Core.Lam _ e => is_con_app e
+         | _ => false
+         end in
     let id_unfolding := Id.realIdUnfolding old_bndr in
     let can_unfold := Core.canUnfold id_unfolding in
     let rhs := bind_rhs in
@@ -977,23 +977,23 @@ Definition oneShotGroup
     match arg_0__, arg_1__ with
     | (Mk_OccEnv _ ctxt _ _ _ as env), bndrs =>
         let fix go arg_2__ arg_3__ arg_4__
-                  := match arg_2__, arg_3__, arg_4__ with
-                     | ctxt, nil, rev_bndrs =>
-                         pair (let 'Mk_OccEnv occ_encl_5__ occ_one_shots_6__ occ_gbl_scrut_7__
-                                  occ_rule_act_8__ occ_binder_swap_9__ := env in
-                               Mk_OccEnv OccVanilla ctxt occ_gbl_scrut_7__ occ_rule_act_8__
-                                         occ_binder_swap_9__) (GHC.List.reverse rev_bndrs)
-                     | nil, bndrs, rev_bndrs =>
-                         pair (let 'Mk_OccEnv occ_encl_13__ occ_one_shots_14__ occ_gbl_scrut_15__
-                                  occ_rule_act_16__ occ_binder_swap_17__ := env in
-                               Mk_OccEnv OccVanilla nil occ_gbl_scrut_15__ occ_rule_act_16__
-                                         occ_binder_swap_17__) (Coq.Init.Datatypes.app (GHC.List.reverse rev_bndrs)
-                                                                                       bndrs)
-                     | (cons one_shot ctxt' as ctxt), cons bndr bndrs, rev_bndrs =>
-                         let bndr' := Id.updOneShotInfo bndr one_shot in
-                         if Core.isId bndr : bool then go ctxt' bndrs (cons bndr' rev_bndrs) else
-                         go ctxt bndrs (cons bndr rev_bndrs)
-                     end in
+          := match arg_2__, arg_3__, arg_4__ with
+             | ctxt, nil, rev_bndrs =>
+                 pair (let 'Mk_OccEnv occ_encl_5__ occ_one_shots_6__ occ_gbl_scrut_7__
+                          occ_rule_act_8__ occ_binder_swap_9__ := env in
+                       Mk_OccEnv OccVanilla ctxt occ_gbl_scrut_7__ occ_rule_act_8__
+                                 occ_binder_swap_9__) (GHC.List.reverse rev_bndrs)
+             | nil, bndrs, rev_bndrs =>
+                 pair (let 'Mk_OccEnv occ_encl_13__ occ_one_shots_14__ occ_gbl_scrut_15__
+                          occ_rule_act_16__ occ_binder_swap_17__ := env in
+                       Mk_OccEnv OccVanilla nil occ_gbl_scrut_15__ occ_rule_act_16__
+                                 occ_binder_swap_17__) (Coq.Init.Datatypes.app (GHC.List.reverse rev_bndrs)
+                                                                               bndrs)
+             | (cons one_shot ctxt' as ctxt), cons bndr bndrs, rev_bndrs =>
+                 let bndr' := Id.updOneShotInfo bndr one_shot in
+                 if Core.isId bndr : bool then go ctxt' bndrs (cons bndr' rev_bndrs) else
+                 go ctxt bndrs (cons bndr rev_bndrs)
+             end in
         go ctxt bndrs nil
     end.
 

--- a/examples/ghc/lib/OrdList.v
+++ b/examples/ghc/lib/OrdList.v
@@ -26,13 +26,13 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive OrdList a : Type
-  := | None : OrdList a
-  |  One : a -> OrdList a
-  |  Many : list a -> OrdList a
-  |  Cons : a -> (OrdList a) -> OrdList a
-  |  Snoc : (OrdList a) -> a -> OrdList a
-  |  Two : (OrdList a) -> (OrdList a) -> OrdList a.
+Inductive OrdList a : Type :=
+  | None : OrdList a
+  | One : a -> OrdList a
+  | Many : list a -> OrdList a
+  | Cons : a -> (OrdList a) -> OrdList a
+  | Snoc : (OrdList a) -> a -> OrdList a
+  | Two : (OrdList a) -> (OrdList a) -> OrdList a.
 
 Arguments None {_}.
 
@@ -93,14 +93,14 @@ Program Instance Monoid__OrdList {a} : GHC.Base.Monoid (OrdList a) :=
            GHC.Base.mempty__ := Monoid__OrdList_mempty |}.
 
 Fixpoint mapOL {a} {b} (arg_0__ : (a -> b)) (arg_1__ : OrdList a) : OrdList b
-           := match arg_0__, arg_1__ with
-              | _, None => None
-              | f, One x => One (f x)
-              | f, Cons x xs => Cons (f x) (mapOL f xs)
-              | f, Snoc xs x => Snoc (mapOL f xs) (f x)
-              | f, Two x y => Two (mapOL f x) (mapOL f y)
-              | f, Many xs => Many (GHC.Base.map f xs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, None => None
+     | f, One x => One (f x)
+     | f, Cons x xs => Cons (f x) (mapOL f xs)
+     | f, Snoc xs x => Snoc (mapOL f xs) (f x)
+     | f, Two x y => Two (mapOL f x) (mapOL f y)
+     | f, Many xs => Many (GHC.Base.map f xs)
+     end.
 
 Local Definition Functor__OrdList_fmap
    : forall {a} {b}, (a -> b) -> OrdList a -> OrdList b :=
@@ -117,14 +117,14 @@ Program Instance Functor__OrdList : GHC.Base.Functor OrdList :=
 
 Fixpoint foldrOL {a} {b} (arg_0__ : (a -> b -> b)) (arg_1__ : b) (arg_2__
                    : OrdList a) : b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, None => z
-              | k, z, One x => k x z
-              | k, z, Cons x xs => k x (foldrOL k z xs)
-              | k, z, Snoc xs x => foldrOL k (k x z) xs
-              | k, z, Two b1 b2 => foldrOL k (foldrOL k z b2) b1
-              | k, z, Many xs => Data.Foldable.foldr k z xs
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, z, None => z
+     | k, z, One x => k x z
+     | k, z, Cons x xs => k x (foldrOL k z xs)
+     | k, z, Snoc xs x => foldrOL k (k x z) xs
+     | k, z, Two b1 b2 => foldrOL k (foldrOL k z b2) b1
+     | k, z, Many xs => Data.Foldable.foldr k z xs
+     end.
 
 Local Definition Foldable__OrdList_foldr
    : forall {a} {b}, (a -> b -> b) -> b -> OrdList a -> b :=
@@ -210,14 +210,14 @@ Program Instance Foldable__OrdList : Data.Foldable.Foldable OrdList :=
 Definition fromOL {a} : OrdList a -> list a :=
   fun a =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | None, acc => acc
-                 | One a, acc => cons a acc
-                 | Cons a b, acc => cons a (go b acc)
-                 | Snoc a b, acc => go a (cons b acc)
-                 | Two a b, acc => go a (go b acc)
-                 | Many xs, acc => Coq.Init.Datatypes.app xs acc
-                 end in
+      := match arg_0__, arg_1__ with
+         | None, acc => acc
+         | One a, acc => cons a acc
+         | Cons a b, acc => cons a (go b acc)
+         | Snoc a b, acc => go a (cons b acc)
+         | Two a b, acc => go a (go b acc)
+         | Many xs, acc => Coq.Init.Datatypes.app xs acc
+         end in
     go a nil.
 
 Definition toOL {a} : list a -> OrdList a :=
@@ -271,14 +271,14 @@ Definition isNilOL {a} : OrdList a -> bool :=
 
 Fixpoint foldlOL {b} {a} (arg_0__ : (b -> a -> b)) (arg_1__ : b) (arg_2__
                    : OrdList a) : b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, None => z
-              | k, z, One x => k z x
-              | k, z, Cons x xs => foldlOL k (k z x) xs
-              | k, z, Snoc xs x => k (foldlOL k z xs) x
-              | k, z, Two b1 b2 => foldlOL k (foldlOL k z b1) b2
-              | k, z, Many xs => Data.Foldable.foldl k z xs
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, z, None => z
+     | k, z, One x => k z x
+     | k, z, Cons x xs => foldlOL k (k z x) xs
+     | k, z, Snoc xs x => k (foldlOL k z xs) x
+     | k, z, Two b1 b2 => foldlOL k (foldlOL k z b1) b2
+     | k, z, Many xs => Data.Foldable.foldl k z xs
+     end.
 
 (* External variables:
      bool cons false list nil true Coq.Init.Datatypes.app Coq.Program.Basics.compose

--- a/examples/ghc/lib/Panic.v
+++ b/examples/ghc/lib/Panic.v
@@ -18,17 +18,17 @@ Require GHC.Num.
 
 (* Converted type declarations: *)
 
-Inductive GhcException : Type
-  := | Signal : GHC.Num.Int -> GhcException
-  |  UsageError : GHC.Base.String -> GhcException
-  |  CmdLineError : GHC.Base.String -> GhcException
-  |  Panic : GHC.Base.String -> GhcException
-  |  PprPanic : GHC.Base.String -> GHC.Base.String -> GhcException
-  |  Sorry : GHC.Base.String -> GhcException
-  |  PprSorry : GHC.Base.String -> GHC.Base.String -> GhcException
-  |  InstallationError : GHC.Base.String -> GhcException
-  |  ProgramError : GHC.Base.String -> GhcException
-  |  PprProgramError : GHC.Base.String -> GHC.Base.String -> GhcException.
+Inductive GhcException : Type :=
+  | Signal : GHC.Num.Int -> GhcException
+  | UsageError : GHC.Base.String -> GhcException
+  | CmdLineError : GHC.Base.String -> GhcException
+  | Panic : GHC.Base.String -> GhcException
+  | PprPanic : GHC.Base.String -> GHC.Base.String -> GhcException
+  | Sorry : GHC.Base.String -> GhcException
+  | PprSorry : GHC.Base.String -> GHC.Base.String -> GhcException
+  | InstallationError : GHC.Base.String -> GhcException
+  | ProgramError : GHC.Base.String -> GhcException
+  | PprProgramError : GHC.Base.String -> GHC.Base.String -> GhcException.
 
 (* Converted value declarations: *)
 
@@ -81,9 +81,9 @@ Axiom assertPanic : forall {a} `{GHC.Err.Default a},
 Axiom panicStr : forall {a} `{GHC.Err.Default a},
                  GHC.Base.String -> GHC.Base.String -> a.
 
-Inductive panicked {a} : a -> Prop
-  := | PlainPanic `{GHC.Err.Default a} {s} : panicked (panic s)
-  |  StrPanic `{GHC.Err.Default a} {s} {d} : panicked (panicStr s d).
+Inductive panicked {a} : a -> Prop :=
+  | PlainPanic `{GHC.Err.Default a} {s} : panicked (panic s)
+  | StrPanic `{GHC.Err.Default a} {s} {d} : panicked (panicStr s d).
 
 Definition warnPprTrace
    : forall {a} `{GHC.Err.Default a},

--- a/examples/ghc/lib/SetLevels.v
+++ b/examples/ghc/lib/SetLevels.v
@@ -28,14 +28,14 @@ Require UniqSupply.
 Definition LvlM :=
   UniqSupply.UniqSM%type.
 
-Inductive LevelType : Type := | BndrLvl : LevelType |  JoinCeilLvl : LevelType.
+Inductive LevelType : Type := | BndrLvl : LevelType | JoinCeilLvl : LevelType.
 
-Inductive Level : Type
-  := | Mk_Level : BinNums.N -> BinNums.N -> LevelType -> Level.
+Inductive Level : Type :=
+  | Mk_Level : BinNums.N -> BinNums.N -> LevelType -> Level.
 
-Inductive FloatSpec : Type
-  := | FloatMe : Level -> FloatSpec
-  |  StayPut : Level -> FloatSpec.
+Inductive FloatSpec : Type :=
+  | FloatMe : Level -> FloatSpec
+  | StayPut : Level -> FloatSpec.
 
 Definition LevelledBind :=
   (Core.TaggedBind FloatSpec)%type.
@@ -46,8 +46,8 @@ Definition LevelledBndr :=
 Definition LevelledExpr :=
   (Core.TaggedExpr FloatSpec)%type.
 
-Inductive LevelEnv : Type
-  := | LE (le_switches : CoreMonad.FloatOutSwitches) (le_ctxt_lvl : Level)
+Inductive LevelEnv : Type :=
+  | LE (le_switches : CoreMonad.FloatOutSwitches) (le_ctxt_lvl : Level)
   (le_lvl_env : Core.VarEnv Level) (le_join_ceil : Level) (le_subst
     : CoreSubst.Subst) (le_env : Core.IdEnv (list Core.OutVar * LevelledExpr)%type)
    : LevelEnv.

--- a/examples/ghc/lib/SrcLoc.v
+++ b/examples/ghc/lib/SrcLoc.v
@@ -25,23 +25,22 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive RealSrcSpan : Type
-  := | RealSrcSpan' (srcSpanFile : FastString.FastString) (srcSpanSLine
+Inductive RealSrcSpan : Type :=
+  | RealSrcSpan' (srcSpanFile : FastString.FastString) (srcSpanSLine
     : GHC.Num.Int) (srcSpanSCol : GHC.Num.Int) (srcSpanELine : GHC.Num.Int)
   (srcSpanECol : GHC.Num.Int)
    : RealSrcSpan.
 
-Inductive SrcSpan : Type
-  := | ARealSrcSpan : RealSrcSpan -> SrcSpan
-  |  UnhelpfulSpan : FastString.FastString -> SrcSpan.
+Inductive SrcSpan : Type :=
+  | ARealSrcSpan : RealSrcSpan -> SrcSpan
+  | UnhelpfulSpan : FastString.FastString -> SrcSpan.
 
-Inductive RealSrcLoc : Type
-  := | ASrcLoc
-   : FastString.FastString -> GHC.Num.Int -> GHC.Num.Int -> RealSrcLoc.
+Inductive RealSrcLoc : Type :=
+  | ASrcLoc : FastString.FastString -> GHC.Num.Int -> GHC.Num.Int -> RealSrcLoc.
 
-Inductive SrcLoc : Type
-  := | ARealSrcLoc : RealSrcLoc -> SrcLoc
-  |  UnhelpfulLoc : FastString.FastString -> SrcLoc.
+Inductive SrcLoc : Type :=
+  | ARealSrcLoc : RealSrcLoc -> SrcLoc
+  | UnhelpfulLoc : FastString.FastString -> SrcLoc.
 
 Inductive GenLocated l e : Type := | L : l -> e -> GenLocated l e.
 

--- a/examples/ghc/lib/State.v
+++ b/examples/ghc/lib/State.v
@@ -17,8 +17,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive State s a : Type
-  := | Mk_State (runState' : s -> (a * s)%type) : State s a.
+Inductive State s a : Type :=
+  | Mk_State (runState' : s -> (a * s)%type) : State s a.
 
 Arguments Mk_State {_} {_} _.
 

--- a/examples/ghc/lib/TrieMap.v
+++ b/examples/ghc/lib/TrieMap.v
@@ -37,8 +37,8 @@ Definition XT a :=
 
 Axiom TypeMapX : forall (a : Type), Type.
 
-Inductive TyLitMap a : Type
-  := | TLM (tlm_number : Data.Map.Internal.Map GHC.Num.Integer a) (tlm_string
+Inductive TyLitMap a : Type :=
+  | TLM (tlm_number : Data.Map.Internal.Map GHC.Num.Integer a) (tlm_string
     : Data.Map.Internal.Map FastString.FastString a)
    : TyLitMap a.
 
@@ -55,8 +55,8 @@ Arguments Key _ {_}.
 Definition TickishMap :=
   (Data.Map.Internal.Map (Core.Tickish Core.Id))%type.
 
-Inductive MaybeMap m a : Type
-  := | MM (mm_nothing : option a) (mm_just : m a) : MaybeMap m a.
+Inductive MaybeMap m a : Type :=
+  | MM (mm_nothing : option a) (mm_just : m a) : MaybeMap m a.
 
 Definition LiteralMap :=
   (Data.Map.Internal.Map Literal.Literal)%type.
@@ -68,11 +68,11 @@ Axiom GenMap : forall (m : Type -> Type) (a : Type), Type.
 Definition TypeMapG :=
   (GenMap TypeMapX)%type.
 
-Inductive LooseTypeMap a : Type
-  := | Mk_LooseTypeMap : (TypeMapG a) -> LooseTypeMap a.
+Inductive LooseTypeMap a : Type :=
+  | Mk_LooseTypeMap : (TypeMapG a) -> LooseTypeMap a.
 
-Inductive TypeMap a : Type
-  := | Mk_TypeMap : (TypeMapG (TypeMapG a)) -> TypeMap a.
+Inductive TypeMap a : Type :=
+  | Mk_TypeMap : (TypeMapG (TypeMapG a)) -> TypeMap a.
 
 Axiom CoreMapX : forall (a : Type), Type.
 
@@ -81,35 +81,35 @@ Definition CoreMapG :=
 
 Inductive CoreMap a : Type := | Mk_CoreMap : (CoreMapG a) -> CoreMap a.
 
-Inductive CoercionMapX a : Type
-  := | Mk_CoercionMapX : (TypeMapX a) -> CoercionMapX a.
+Inductive CoercionMapX a : Type :=
+  | Mk_CoercionMapX : (TypeMapX a) -> CoercionMapX a.
 
 Definition CoercionMapG :=
   (GenMap CoercionMapX)%type.
 
-Inductive CoercionMap a : Type
-  := | Mk_CoercionMap : (CoercionMapG a) -> CoercionMap a.
+Inductive CoercionMap a : Type :=
+  | Mk_CoercionMap : (CoercionMapG a) -> CoercionMap a.
 
 Definition BoundVarMap :=
   IntMap.IntMap%type.
 
-Inductive VarMap a : Type
-  := | VM (vm_bvar : BoundVarMap a) (vm_fvar : Core.DVarEnv a) : VarMap a.
+Inductive VarMap a : Type :=
+  | VM (vm_bvar : BoundVarMap a) (vm_fvar : Core.DVarEnv a) : VarMap a.
 
 Definition BoundVar :=
   Data.IntSet.Internal.Key%type.
 
-Inductive CmEnv : Type
-  := | CME (cme_next : BoundVar) (cme_env : Core.VarEnv BoundVar) : CmEnv.
+Inductive CmEnv : Type :=
+  | CME (cme_next : BoundVar) (cme_env : Core.VarEnv BoundVar) : CmEnv.
 
 Inductive DeBruijn a : Type := | D : CmEnv -> a -> DeBruijn a.
 
 Definition BndrMap :=
   TypeMapG%type.
 
-Inductive AltMap a : Type
-  := | AM (am_deflt : CoreMapG a) (am_data : NameEnv.DNameEnv (CoreMapG a))
-  (am_lit : LiteralMap (CoreMapG a))
+Inductive AltMap a : Type :=
+  | AM (am_deflt : CoreMapG a) (am_data : NameEnv.DNameEnv (CoreMapG a)) (am_lit
+    : LiteralMap (CoreMapG a))
    : AltMap a.
 
 Arguments TLM {_} _ _.
@@ -949,12 +949,12 @@ Definition Eq___DeBruijn__list_op_zeze__ {a} `{GHC.Base.Eq_ (DeBruijn a)}
   match dbl_xs, dbl_ys with
   | D env_xs xs0, D env_ys ys0 =>
       let fix equal xs ys
-                := match xs, ys with
-                   | nil, nil => true
-                   | cons x xs', cons y ys' =>
-                       andb (D env_xs x GHC.Base.== D env_ys y) (equal xs' ys')
-                   | _, _ => false
-                   end in
+        := match xs, ys with
+           | nil, nil => true
+           | cons x xs', cons y ys' =>
+               andb (D env_xs x GHC.Base.== D env_ys y) (equal xs' ys')
+           | _, _ => false
+           end in
       equal xs0 ys0
   end.
 

--- a/examples/ghc/lib/UnVarGraph.v
+++ b/examples/ghc/lib/UnVarGraph.v
@@ -26,12 +26,12 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive UnVarSet : Type
-  := | Mk_UnVarSet : (Data.IntSet.Internal.IntSet) -> UnVarSet.
+Inductive UnVarSet : Type :=
+  | Mk_UnVarSet : (Data.IntSet.Internal.IntSet) -> UnVarSet.
 
-Inductive Gen : Type
-  := | CBPG : UnVarSet -> UnVarSet -> Gen
-  |  CG : UnVarSet -> Gen.
+Inductive Gen : Type :=
+  | CBPG : UnVarSet -> UnVarSet -> Gen
+  | CG : UnVarSet -> Gen.
 
 Inductive UnVarGraph : Type := | Mk_UnVarGraph : (Bag.Bag Gen) -> UnVarGraph.
 

--- a/examples/ghc/lib/UniqSet.v
+++ b/examples/ghc/lib/UniqSet.v
@@ -21,8 +21,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive UniqSet a : Type
-  := | Mk_UniqSet (getUniqSet' : UniqFM.UniqFM a) : UniqSet a.
+Inductive UniqSet a : Type :=
+  | Mk_UniqSet (getUniqSet' : UniqFM.UniqFM a) : UniqSet a.
 
 Arguments Mk_UniqSet {_} _.
 

--- a/examples/ghc/lib/UniqSupply.v
+++ b/examples/ghc/lib/UniqSupply.v
@@ -20,11 +20,11 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive UniqSupply : Type
-  := | MkSplitUniqSupply : BinNums.N -> UniqSupply -> UniqSupply -> UniqSupply.
+Inductive UniqSupply : Type :=
+  | MkSplitUniqSupply : BinNums.N -> UniqSupply -> UniqSupply -> UniqSupply.
 
-Inductive UniqSM result : Type
-  := | USM (unUSM : UniqSupply -> (result * UniqSupply)%type) : UniqSM result.
+Inductive UniqSM result : Type :=
+  | USM (unUSM : UniqSupply -> (result * UniqSupply)%type) : UniqSM result.
 
 Record MonadUnique__Dict m := MonadUnique__Dict_Build {
   getUniqueM__ : m Unique.Unique ;
@@ -162,8 +162,8 @@ Local Definition MonadUnique__UniqSM_getUniqueSupplyM : UniqSM UniqSupply :=
   getUs.
 
 Fixpoint uniqsFromSupply (arg_0__ : UniqSupply) : list Unique.Unique
-           := let 'MkSplitUniqSupply n _ s2 := arg_0__ in
-              cons (Unique.mkUniqueGrimily n) (uniqsFromSupply s2).
+  := let 'MkSplitUniqSupply n _ s2 := arg_0__ in
+     cons (Unique.mkUniqueGrimily n) (uniqsFromSupply s2).
 
 Definition getUniquesUs : UniqSM (list Unique.Unique) :=
   USM (fun us =>
@@ -183,8 +183,8 @@ Program Instance MonadUnique__UniqSM : MonadUnique UniqSM :=
 (* Skipping definition `UniqSupply.mkSplitUniqSupply' *)
 
 Fixpoint listSplitUniqSupply (arg_0__ : UniqSupply) : list UniqSupply
-           := let 'MkSplitUniqSupply _ s1 s2 := arg_0__ in
-              cons s1 (listSplitUniqSupply s2).
+  := let 'MkSplitUniqSupply _ s1 s2 := arg_0__ in
+     cons s1 (listSplitUniqSupply s2).
 
 Definition uniqFromSupply : UniqSupply -> Unique.Unique :=
   fun '(MkSplitUniqSupply n _ _) => Unique.mkUniqueGrimily n.
@@ -232,13 +232,13 @@ Definition liftUs {m} {a} `{MonadUnique m} : UniqSM a -> m a :=
     (GHC.Base.return_ GHC.Base.∘ GHC.Base.flip initUs_ m).
 
 Fixpoint lazyMapUs {a} {b} (arg_0__ : (a -> UniqSM b)) (arg_1__ : list a)
-           : UniqSM (list b)
-           := match arg_0__, arg_1__ with
-              | _, nil => returnUs nil
-              | f, cons x xs =>
-                  lazyThenUs (f x) (fun r =>
-                                lazyThenUs (lazyMapUs f xs) (fun rs => returnUs (cons r rs)))
-              end.
+  : UniqSM (list b)
+  := match arg_0__, arg_1__ with
+     | _, nil => returnUs nil
+     | f, cons x xs =>
+         lazyThenUs (f x) (fun r =>
+                       lazyThenUs (lazyMapUs f xs) (fun rs => returnUs (cons r rs)))
+     end.
 
 (* External variables:
      cons list nil op_zt__ pair BinNums.N GHC.Base.Applicative GHC.Base.Functor

--- a/examples/ghc/lib/Util.v
+++ b/examples/ghc/lib/Util.v
@@ -39,15 +39,15 @@ Import GHC.Num.Notations.
 Definition Suffix :=
   GHC.Base.String%type.
 
-Inductive OverridingBool : Type
-  := | Auto : OverridingBool
-  |  Always : OverridingBool
-  |  Never : OverridingBool.
+Inductive OverridingBool : Type :=
+  | Auto : OverridingBool
+  | Always : OverridingBool
+  | Never : OverridingBool.
 
 Definition HasDebugCallStack :=
   unit.
 
-Inductive Direction : Type := | Forwards : Direction |  Backwards : Direction.
+Inductive Direction : Type := | Forwards : Direction | Backwards : Direction.
 
 Instance Default__OverridingBool : GHC.Err.Default OverridingBool :=
   GHC.Err.Build_Default _ Auto.
@@ -147,35 +147,35 @@ Definition first3M {m} {a} {d} {b} {c} `{GHC.Base.Monad m}
     end.
 
 Fixpoint filterOut {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | p, cons x xs => if p x : bool then filterOut p xs else cons x (filterOut p xs)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => nil
+     | p, cons x xs => if p x : bool then filterOut p xs else cons x (filterOut p xs)
+     end.
 
 Fixpoint partitionWith {a} {b} {c} (arg_0__ : (a -> Data.Either.Either b c))
                        (arg_1__ : list a) : (list b * list c)%type
-           := match arg_0__, arg_1__ with
-              | _, nil => pair nil nil
-              | f, cons x xs =>
-                  let 'pair bs cs := partitionWith f xs in
-                  match f x with
-                  | Data.Either.Left b => pair (cons b bs) cs
-                  | Data.Either.Right c => pair bs (cons c cs)
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => pair nil nil
+     | f, cons x xs =>
+         let 'pair bs cs := partitionWith f xs in
+         match f x with
+         | Data.Either.Left b => pair (cons b bs) cs
+         | Data.Either.Right c => pair bs (cons c cs)
+         end
+     end.
 
 Fixpoint splitEithers {a} {b} (arg_0__ : list (Data.Either.Either a b)) : (list
                                                                            a *
                                                                            list b)%type
-           := match arg_0__ with
-              | nil => pair nil nil
-              | cons e es =>
-                  let 'pair xs ys := splitEithers es in
-                  match e with
-                  | Data.Either.Left x => pair (cons x xs) ys
-                  | Data.Either.Right y => pair xs (cons y ys)
-                  end
-              end.
+  := match arg_0__ with
+     | nil => pair nil nil
+     | cons e es =>
+         let 'pair xs ys := splitEithers es in
+         match e with
+         | Data.Either.Left x => pair (cons x xs) ys
+         | Data.Either.Right y => pair xs (cons y ys)
+         end
+     end.
 
 Definition chkAppend {a} : list a -> list a -> list a :=
   fun xs ys =>
@@ -202,65 +202,65 @@ Definition zipWith4Equal {a} {b} {c} {d} {e}
 
 Fixpoint zipLazy {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list (a *
                                                                        b)%type
-           := match arg_0__, arg_1__ with
-              | nil, _ => nil
-              | cons x xs, cons y ys => cons (pair x y) (zipLazy xs ys)
-              | _, _ => GHC.Err.patternFailure
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, _ => nil
+     | cons x xs, cons y ys => cons (pair x y) (zipLazy xs ys)
+     | _, _ => GHC.Err.patternFailure
+     end.
 
 Fixpoint zipWithLazy {a} {b} {c} (arg_0__ : (a -> b -> c)) (arg_1__ : list a)
                      (arg_2__ : list b) : list c
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, nil, _ => nil
-              | f, cons a as_, cons b bs => cons (f a b) (zipWithLazy f as_ bs)
-              | _, _, _ => GHC.Err.patternFailure
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, nil, _ => nil
+     | f, cons a as_, cons b bs => cons (f a b) (zipWithLazy f as_ bs)
+     | _, _, _ => GHC.Err.patternFailure
+     end.
 
 Fixpoint zipWith3Lazy {a} {b} {c} {d} (arg_0__ : (a -> b -> c -> d)) (arg_1__
                         : list a) (arg_2__ : list b) (arg_3__ : list c) : list d
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, nil, _, _ => nil
-              | f, cons a as_, cons b bs, cons c cs =>
-                  cons (f a b c) (zipWith3Lazy f as_ bs cs)
-              | _, _, _, _ => GHC.Err.patternFailure
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | _, nil, _, _ => nil
+     | f, cons a as_, cons b bs, cons c cs =>
+         cons (f a b c) (zipWith3Lazy f as_ bs cs)
+     | _, _, _, _ => GHC.Err.patternFailure
+     end.
 
 Fixpoint filterByList {a} (arg_0__ : list bool) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | cons true bs, cons x xs => cons x (filterByList bs xs)
-              | cons false bs, cons _ xs => filterByList bs xs
-              | _, _ => nil
-              end.
+  := match arg_0__, arg_1__ with
+     | cons true bs, cons x xs => cons x (filterByList bs xs)
+     | cons false bs, cons _ xs => filterByList bs xs
+     | _, _ => nil
+     end.
 
 Fixpoint filterByLists {a} (arg_0__ : list bool) (arg_1__ arg_2__ : list a)
-           : list a
-           := match arg_0__, arg_1__, arg_2__ with
-              | cons true bs, cons x xs, cons _ ys => cons x (filterByLists bs xs ys)
-              | cons false bs, cons _ xs, cons y ys => cons y (filterByLists bs xs ys)
-              | _, _, _ => nil
-              end.
+  : list a
+  := match arg_0__, arg_1__, arg_2__ with
+     | cons true bs, cons x xs, cons _ ys => cons x (filterByLists bs xs ys)
+     | cons false bs, cons _ xs, cons y ys => cons y (filterByLists bs xs ys)
+     | _, _, _ => nil
+     end.
 
 Definition partitionByList {a}
    : list bool -> list a -> (list a * list a)%type :=
   let fix go arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | trues, falses, cons true bs, cons x xs => go (cons x trues) falses bs xs
-               | trues, falses, cons false bs, cons x xs => go trues (cons x falses) bs xs
-               | trues, falses, _, _ => pair (GHC.List.reverse trues) (GHC.List.reverse falses)
-               end in
+    := match arg_0__, arg_1__, arg_2__, arg_3__ with
+       | trues, falses, cons true bs, cons x xs => go (cons x trues) falses bs xs
+       | trues, falses, cons false bs, cons x xs => go trues (cons x falses) bs xs
+       | trues, falses, _, _ => pair (GHC.List.reverse trues) (GHC.List.reverse falses)
+       end in
   go nil nil.
 
 Fixpoint stretchZipWith {a} {b} {c} (arg_0__ : (a -> bool)) (arg_1__ : b)
                         (arg_2__ : (a -> b -> c)) (arg_3__ : list a) (arg_4__ : list b) : list c
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-              | _, _, _, nil, _ => nil
-              | p, z, f, cons x xs, ys =>
-                  if p x : bool then cons (f x z) (stretchZipWith p z f xs ys) else
-                  match ys with
-                  | nil => nil
-                  | cons y ys => cons (f x y) (stretchZipWith p z f xs ys)
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+     | _, _, _, nil, _ => nil
+     | p, z, f, cons x xs, ys =>
+         if p x : bool then cons (f x z) (stretchZipWith p z f xs ys) else
+         match ys with
+         | nil => nil
+         | cons y ys => cons (f x y) (stretchZipWith p z f xs ys)
+         end
+     end.
 
 Definition mapFst {a} {c} {b}
    : (a -> c) -> list (a * b)%type -> list (c * b)%type :=
@@ -276,33 +276,33 @@ Definition mapSnd {b} {c} {a}
 
 Fixpoint mapAndUnzip {a} {b} {c} (arg_0__ : (a -> (b * c)%type)) (arg_1__
                        : list a) : (list b * list c)%type
-           := match arg_0__, arg_1__ with
-              | _, nil => pair nil nil
-              | f, cons x xs =>
-                  let 'pair rs1 rs2 := mapAndUnzip f xs in
-                  let 'pair r1 r2 := f x in
-                  pair (cons r1 rs1) (cons r2 rs2)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => pair nil nil
+     | f, cons x xs =>
+         let 'pair rs1 rs2 := mapAndUnzip f xs in
+         let 'pair r1 r2 := f x in
+         pair (cons r1 rs1) (cons r2 rs2)
+     end.
 
 Fixpoint mapAndUnzip3 {a} {b} {c} {d} (arg_0__ : (a -> (b * c * d)%type))
                       (arg_1__ : list a) : (list b * list c * list d)%type
-           := match arg_0__, arg_1__ with
-              | _, nil => pair (pair nil nil) nil
-              | f, cons x xs =>
-                  let 'pair (pair rs1 rs2) rs3 := mapAndUnzip3 f xs in
-                  let 'pair (pair r1 r2) r3 := f x in
-                  pair (pair (cons r1 rs1) (cons r2 rs2)) (cons r3 rs3)
-              end.
+  := match arg_0__, arg_1__ with
+     | _, nil => pair (pair nil nil) nil
+     | f, cons x xs =>
+         let 'pair (pair rs1 rs2) rs3 := mapAndUnzip3 f xs in
+         let 'pair (pair r1 r2) r3 := f x in
+         pair (pair (cons r1 rs1) (cons r2 rs2)) (cons r3 rs3)
+     end.
 
 Fixpoint zipWithAndUnzip {a} {b} {c} {d} (arg_0__ : (a -> b -> (c * d)%type))
                          (arg_1__ : list a) (arg_2__ : list b) : (list c * list d)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, cons a as_, cons b bs =>
-                  let 'pair rs1 rs2 := zipWithAndUnzip f as_ bs in
-                  let 'pair r1 r2 := f a b in
-                  pair (cons r1 rs1) (cons r2 rs2)
-              | _, _, _ => pair nil nil
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | f, cons a as_, cons b bs =>
+         let 'pair rs1 rs2 := zipWithAndUnzip f as_ bs in
+         let 'pair r1 r2 := f a b in
+         pair (cons r1 rs1) (cons r2 rs2)
+     | _, _, _ => pair nil nil
+     end.
 
 (* Skipping definition `Util.mapAccumL2' *)
 
@@ -312,14 +312,14 @@ Definition nOfThem {a} : nat -> a -> list a :=
 Definition atLength {a} {b} : (list a -> b) -> b -> list a -> nat -> b :=
   fun atLenPred atEnd ls0 n0 =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | num_2__, ls =>
-                     if num_2__ GHC.Base.== #0 : bool then atLenPred ls else
-                     match arg_0__, arg_1__ with
-                     | _, nil => atEnd
-                     | n, cons _ xs => go (n GHC.Num.- #1) xs
-                     end
-                 end in
+      := match arg_0__, arg_1__ with
+         | num_2__, ls =>
+             if num_2__ GHC.Base.== #0 : bool then atLenPred ls else
+             match arg_0__, arg_1__ with
+             | _, nil => atEnd
+             | n, cons _ xs => go (n GHC.Num.- #1) xs
+             end
+         end in
     if n0 GHC.Base.< #0 : bool then atLenPred ls0 else
     go n0 ls0.
 
@@ -357,27 +357,27 @@ Definition listLengthCmp {a} : list a -> nat -> comparison :=
   let atEnd := Lt in atLength atLen atEnd.
 
 Fixpoint equalLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
-           := match arg_0__, arg_1__ with
-              | nil, nil => true
-              | cons _ xs, cons _ ys => equalLength xs ys
-              | _, _ => false
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, nil => true
+     | cons _ xs, cons _ ys => equalLength xs ys
+     | _, _ => false
+     end.
 
 Fixpoint neLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
-           := match arg_0__, arg_1__ with
-              | nil, nil => false
-              | cons _ xs, cons _ ys => neLength xs ys
-              | _, _ => true
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, nil => false
+     | cons _ xs, cons _ ys => neLength xs ys
+     | _, _ => true
+     end.
 
 Fixpoint compareLength {a} {b} (arg_0__ : list a) (arg_1__ : list b)
-           : comparison
-           := match arg_0__, arg_1__ with
-              | nil, nil => Eq
-              | cons _ xs, cons _ ys => compareLength xs ys
-              | nil, _ => Lt
-              | _, nil => Gt
-              end.
+  : comparison
+  := match arg_0__, arg_1__ with
+     | nil, nil => Eq
+     | cons _ xs, cons _ ys => compareLength xs ys
+     | nil, _ => Lt
+     | _, nil => Gt
+     end.
 
 Definition leLength {a} {b} : list a -> list b -> bool :=
   fun xs ys =>
@@ -419,11 +419,11 @@ Definition isn'tIn {a} `{GHC.Base.Eq_ a}
 (* Skipping definition `Util.chunkList' *)
 
 Fixpoint changeLast {a} (arg_0__ : list a) (arg_1__ : a) : list a
-           := match arg_0__, arg_1__ with
-              | nil, _ => Panic.panic (GHC.Base.hs_string__ "changeLast")
-              | cons _ nil, x => cons x nil
-              | cons x xs, x' => cons x (changeLast xs x')
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, _ => Panic.panic (GHC.Base.hs_string__ "changeLast")
+     | cons _ nil, x => cons x nil
+     | cons x xs, x' => cons x (changeLast xs x')
+     end.
 
 (* Skipping definition `Util.minWith' *)
 
@@ -433,10 +433,10 @@ Definition transitiveClosure {a}
    : (a -> list a) -> (a -> a -> bool) -> list a -> list a :=
   fun succ eq xs =>
     let fix is_in arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, nil => false
-                 | x, cons y ys => if eq x y : bool then true else is_in x ys
-                 end in
+      := match arg_0__, arg_1__ with
+         | _, nil => false
+         | x, cons y ys => if eq x y : bool then true else is_in x ys
+         end in
     let go :=
       GHC.DeferredFix.deferredFix2 (fun go arg_5__ arg_6__ =>
                                       match arg_5__, arg_6__ with
@@ -449,64 +449,64 @@ Definition transitiveClosure {a}
 
 Fixpoint foldl2 {acc} {a} {b} `{GHC.Err.Default acc} (arg_0__
                   : acc -> a -> b -> acc) (arg_1__ : acc) (arg_2__ : list a) (arg_3__ : list b)
-           : acc
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, z, nil, nil => z
-              | k, z, cons a as_, cons b bs => foldl2 k (k z a b) as_ bs
-              | _, _, _, _ => Panic.panic (GHC.Base.hs_string__ "Util: foldl2")
-              end.
+  : acc
+  := match arg_0__, arg_1__, arg_2__, arg_3__ with
+     | _, z, nil, nil => z
+     | k, z, cons a as_, cons b bs => foldl2 k (k z a b) as_ bs
+     | _, _, _, _ => Panic.panic (GHC.Base.hs_string__ "Util: foldl2")
+     end.
 
 Fixpoint all2 {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : list a) (arg_2__
                 : list b) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, nil, nil => true
-              | p, cons x xs, cons y ys => andb (p x y) (all2 p xs ys)
-              | _, _, _ => false
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, nil, nil => true
+     | p, cons x xs, cons y ys => andb (p x y) (all2 p xs ys)
+     | _, _, _ => false
+     end.
 
 Definition count {a} : (a -> bool) -> list a -> nat :=
   fun p =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | n, nil => n
-                 | n, cons x xs => if p x : bool then go (n GHC.Num.+ #1) xs else go n xs
-                 end in
+      := match arg_0__, arg_1__ with
+         | n, nil => n
+         | n, cons x xs => if p x : bool then go (n GHC.Num.+ #1) xs else go n xs
+         end in
     go #0.
 
 Fixpoint takeList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | nil, _ => nil
-              | cons _ xs, ls =>
-                  match ls with
-                  | nil => nil
-                  | cons y ys => cons y (takeList xs ys)
-                  end
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, _ => nil
+     | cons _ xs, ls =>
+         match ls with
+         | nil => nil
+         | cons y ys => cons y (takeList xs ys)
+         end
+     end.
 
 Fixpoint dropList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | nil, xs => xs
-              | _, (nil as xs) => xs
-              | cons _ xs, cons _ ys => dropList xs ys
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, xs => xs
+     | _, (nil as xs) => xs
+     | cons _ xs, cons _ ys => dropList xs ys
+     end.
 
 Fixpoint splitAtList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : (list a *
                                                                       list a)%type
-           := match arg_0__, arg_1__ with
-              | nil, xs => pair nil xs
-              | _, (nil as xs) => pair xs xs
-              | cons _ xs, cons y ys =>
-                  let 'pair ys' ys'' := splitAtList xs ys in
-                  pair (cons y ys') ys''
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, xs => pair nil xs
+     | _, (nil as xs) => pair xs xs
+     | cons _ xs, cons y ys =>
+         let 'pair ys' ys'' := splitAtList xs ys in
+         pair (cons y ys') ys''
+     end.
 
 Definition dropTail {a} : nat -> list a -> list a :=
   fun n xs =>
     let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | cons _ ys, cons x xs => cons x (go ys xs)
-                 | _, _ => nil
-                 end in
+      := match arg_0__, arg_1__ with
+         | cons _ ys, cons x xs => cons x (go ys xs)
+         | _, _ => nil
+         end in
     go (Coq.Lists.List.skipn n xs) xs.
 
 Definition dropWhileEndLE {a} : (a -> bool) -> list a -> list a :=
@@ -519,12 +519,12 @@ Definition dropWhileEndLE {a} : (a -> bool) -> list a -> list a :=
 Definition spanEnd {a} : (a -> bool) -> list a -> (list a * list a)%type :=
   fun p l =>
     let fix go arg_0__ arg_1__ arg_2__ arg_3__
-              := match arg_0__, arg_1__, arg_2__, arg_3__ with
-                 | yes, _rev_yes, rev_no, nil => pair yes (GHC.List.reverse rev_no)
-                 | yes, rev_yes, rev_no, cons x xs =>
-                     if p x : bool then go yes (cons x rev_yes) rev_no xs else
-                     go xs nil (cons x (Coq.Init.Datatypes.app rev_yes rev_no)) xs
-                 end in
+      := match arg_0__, arg_1__, arg_2__, arg_3__ with
+         | yes, _rev_yes, rev_no, nil => pair yes (GHC.List.reverse rev_no)
+         | yes, rev_yes, rev_no, cons x xs =>
+             if p x : bool then go yes (cons x rev_yes) rev_no xs else
+             go xs nil (cons x (Coq.Init.Datatypes.app rev_yes rev_no)) xs
+         end in
     go l nil nil l.
 
 Definition snocView {a} : list a -> option (list a * a)%type :=
@@ -533,11 +533,11 @@ Definition snocView {a} : list a -> option (list a * a)%type :=
     | nil => None
     | xs =>
         let fix go arg_1__ arg_2__
-                  := match arg_1__, arg_2__ with
-                     | acc, cons x nil => Some (pair (GHC.List.reverse acc) x)
-                     | acc, cons x xs => go (cons x acc) xs
-                     | _, nil => Panic.panic (GHC.Base.hs_string__ "Util: snocView")
-                     end in
+          := match arg_1__, arg_2__ with
+             | acc, cons x nil => Some (pair (GHC.List.reverse acc) x)
+             | acc, cons x xs => go (cons x acc) xs
+             | _, nil => Panic.panic (GHC.Base.hs_string__ "Util: snocView")
+             end in
         go nil xs
     end.
 
@@ -566,12 +566,12 @@ Definition thenCmp : comparison -> comparison -> comparison :=
     end.
 
 Fixpoint eqListBy {a} (arg_0__ : (a -> a -> bool)) (arg_1__ arg_2__ : list a)
-           : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, nil, nil => true
-              | eq, cons x xs, cons y ys => andb (eq x y) (eqListBy eq xs ys)
-              | _, _, _ => false
-              end.
+  : bool
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, nil, nil => true
+     | eq, cons x xs, cons y ys => andb (eq x y) (eqListBy eq xs ys)
+     | _, _, _ => false
+     end.
 
 Definition eqMaybeBy {a} : (a -> a -> bool) -> option a -> option a -> bool :=
   fun arg_0__ arg_1__ arg_2__ =>
@@ -583,16 +583,16 @@ Definition eqMaybeBy {a} : (a -> a -> bool) -> option a -> option a -> bool :=
 
 Fixpoint cmpList {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ arg_2__
                    : list a) : comparison
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, nil, nil => Eq
-              | _, nil, _ => Lt
-              | _, _, nil => Gt
-              | cmp, cons a as_, cons b bs =>
-                  match cmp a b with
-                  | Eq => cmpList cmp as_ bs
-                  | xxx => xxx
-                  end
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | _, nil, nil => Eq
+     | _, nil, _ => Lt
+     | _, _, nil => Gt
+     | cmp, cons a as_, cons b bs =>
+         match cmp a b with
+         | Eq => cmpList cmp as_ bs
+         | xxx => xxx
+         end
+     end.
 
 (* Skipping definition `Util.removeSpaces' *)
 
@@ -634,10 +634,10 @@ Definition unzipWith {a} {b} {c}
   fun f pairs => GHC.Base.map (fun '(pair a b) => f a b) pairs.
 
 Fixpoint seqList {a} {b} (arg_0__ : list a) (arg_1__ : b) : b
-           := match arg_0__, arg_1__ with
-              | nil, b => b
-              | cons x xs, b => GHC.Prim.seq x (seqList xs b)
-              end.
+  := match arg_0__, arg_1__ with
+     | nil, b => b
+     | cons x xs, b => GHC.Prim.seq x (seqList xs b)
+     end.
 
 (* Skipping definition `Util.global' *)
 

--- a/examples/ghc/manual/CallArity.v
+++ b/examples/ghc/manual/CallArity.v
@@ -111,65 +111,65 @@ Definition unitArityRes : Core.Var -> BasicTypes.Arity -> CallArityRes :=
 
 Fixpoint callArityAnal (arg_0__ : BasicTypes.Arity) (arg_1__ : Core.VarSet)
                        (arg_2__ : Core.CoreExpr) : (CallArityRes * Core.CoreExpr)%type
-           := let j_26__ :=
-                match arg_0__, arg_1__, arg_2__ with
-                | arity, int, Core.Lam v e =>
-                    let 'pair ae e' := callArityAnal (arity GHC.Num.- #1) (Core.delVarSet int v)
-                                         e in
-                    pair ae (Core.Lam v e')
-                | arity, int, Core.App e (Core.Mk_Type t) =>
-                    Control.Arrow.arrow_second (fun e => Core.App e (Core.Mk_Type t)) (callArityAnal
-                                                                                       arity int e)
-                | arity, int, Core.App e1 e2 =>
-                    let 'pair ae2 e2' := callArityAnal #0 int e2 in
-                    let ae2' :=
-                      if CoreUtils.exprIsTrivial e2 : bool then calledMultipleTimes ae2 else
-                      ae2 in
-                    let 'pair ae1 e1' := callArityAnal (arity GHC.Num.+ #1) int e1 in
-                    let final_ae := both ae1 ae2' in pair final_ae (Core.App e1' e2')
-                | arity, int, Core.Case scrut bndr ty alts =>
-                    let 'pair scrut_ae scrut' := callArityAnal #0 int scrut in
-                    let go :=
-                      fun '(pair (pair dc bndrs) e) =>
-                        let 'pair ae e' := callArityAnal arity int e in
-                        pair ae (pair (pair dc bndrs) e') in
-                    let 'pair alt_aes alts' := GHC.List.unzip (GHC.Base.map go alts) in
-                    let alt_ae := lubRess alt_aes in
-                    let final_ae := both scrut_ae alt_ae in
-                    pair final_ae (Core.Case scrut' bndr ty alts')
-                | arity, int, Core.Let bind e =>
-                    let int_body := addInterestingBinds int bind in
-                    let 'pair ae_body e' := callArityAnal arity int_body e in
-                    let 'pair final_ae bind' := callArityBind1 (boringBinds bind) ae_body int
-                                                  bind in
-                    pair final_ae (Core.Let bind' e')
-                | _, _, _ => GHC.Err.patternFailure
-                end in
-              let j_30__ :=
-                match arg_0__, arg_1__, arg_2__ with
-                | num_3__, int, Core.Lam v e =>
-                    let 'pair ae e' := callArityAnal #0 (Core.delVarSet int v) e in
-                    let ae' := calledMultipleTimes ae in
-                    if num_3__ GHC.Base.== #0 : bool then pair ae' (Core.Lam v e') else
-                    j_26__
-                | _, _, _ => j_26__
-                end in
-              match arg_0__, arg_1__, arg_2__ with
-              | _, _, (Core.Lit _ as e) => pair emptyArityRes e
-              | _, _, (Core.Mk_Type _ as e) => pair emptyArityRes e
-              | _, _, (Core.Mk_Coercion _ as e) => pair emptyArityRes e
-              | arity, int, Core.Cast e co =>
-                  Control.Arrow.arrow_second (fun e => Core.Cast e co) (callArityAnal arity int e)
-              | arity, int, (Core.Mk_Var v as e) =>
-                  if Core.elemVarSet v int : bool then pair (unitArityRes v arity) e else
-                  pair emptyArityRes e
-              | arity, int, Core.Lam v e =>
-                  if negb (Core.isId v) : bool
-                  then Control.Arrow.arrow_second (Core.Lam v) (callArityAnal arity
-                                                                              (Core.delVarSet int v) e) else
-                  j_30__
-              | _, _, _ => j_30__
-              end.
+  := let j_26__ :=
+       match arg_0__, arg_1__, arg_2__ with
+       | arity, int, Core.Lam v e =>
+           let 'pair ae e' := callArityAnal (arity GHC.Num.- #1) (Core.delVarSet int v)
+                                e in
+           pair ae (Core.Lam v e')
+       | arity, int, Core.App e (Core.Mk_Type t) =>
+           Control.Arrow.arrow_second (fun e => Core.App e (Core.Mk_Type t)) (callArityAnal
+                                                                              arity int e)
+       | arity, int, Core.App e1 e2 =>
+           let 'pair ae2 e2' := callArityAnal #0 int e2 in
+           let ae2' :=
+             if CoreUtils.exprIsTrivial e2 : bool then calledMultipleTimes ae2 else
+             ae2 in
+           let 'pair ae1 e1' := callArityAnal (arity GHC.Num.+ #1) int e1 in
+           let final_ae := both ae1 ae2' in pair final_ae (Core.App e1' e2')
+       | arity, int, Core.Case scrut bndr ty alts =>
+           let 'pair scrut_ae scrut' := callArityAnal #0 int scrut in
+           let go :=
+             fun '(pair (pair dc bndrs) e) =>
+               let 'pair ae e' := callArityAnal arity int e in
+               pair ae (pair (pair dc bndrs) e') in
+           let 'pair alt_aes alts' := GHC.List.unzip (GHC.Base.map go alts) in
+           let alt_ae := lubRess alt_aes in
+           let final_ae := both scrut_ae alt_ae in
+           pair final_ae (Core.Case scrut' bndr ty alts')
+       | arity, int, Core.Let bind e =>
+           let int_body := addInterestingBinds int bind in
+           let 'pair ae_body e' := callArityAnal arity int_body e in
+           let 'pair final_ae bind' := callArityBind1 (boringBinds bind) ae_body int
+                                         bind in
+           pair final_ae (Core.Let bind' e')
+       | _, _, _ => GHC.Err.patternFailure
+       end in
+     let j_30__ :=
+       match arg_0__, arg_1__, arg_2__ with
+       | num_3__, int, Core.Lam v e =>
+           let 'pair ae e' := callArityAnal #0 (Core.delVarSet int v) e in
+           let ae' := calledMultipleTimes ae in
+           if num_3__ GHC.Base.== #0 : bool then pair ae' (Core.Lam v e') else
+           j_26__
+       | _, _, _ => j_26__
+       end in
+     match arg_0__, arg_1__, arg_2__ with
+     | _, _, (Core.Lit _ as e) => pair emptyArityRes e
+     | _, _, (Core.Mk_Type _ as e) => pair emptyArityRes e
+     | _, _, (Core.Mk_Coercion _ as e) => pair emptyArityRes e
+     | arity, int, Core.Cast e co =>
+         Control.Arrow.arrow_second (fun e => Core.Cast e co) (callArityAnal arity int e)
+     | arity, int, (Core.Mk_Var v as e) =>
+         if Core.elemVarSet v int : bool then pair (unitArityRes v arity) e else
+         pair emptyArityRes e
+     | arity, int, Core.Lam v e =>
+         if negb (Core.isId v) : bool
+         then Control.Arrow.arrow_second (Core.Lam v) (callArityAnal arity
+                                                                     (Core.delVarSet int v) e) else
+         j_30__
+     | _, _, _ => j_30__
+     end.
 
 Definition calledWith : CallArityRes -> Core.Var -> UnVarGraph.UnVarSet :=
   fun arg_0__ arg_1__ =>
@@ -337,20 +337,19 @@ Definition callArityBind
 
 Fixpoint callArityTopLvl (arg_0__ : list Core.Var) (arg_1__ : Core.VarSet)
                          (arg_2__ : list Core.CoreBind) : (CallArityRes * list Core.CoreBind)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | exported, _, nil =>
-                  pair (calledMultipleTimes (pair UnVarGraph.emptyUnVarGraph (Core.mkVarEnv
-                                                   (Coq.Lists.List.flat_map (fun v => cons (pair v #0) nil) exported))))
-                       nil
-              | exported, int1, cons b bs =>
-                  let int' := addInterestingBinds int1 b in
-                  let int2 := Core.bindersOf b in
-                  let exported' :=
-                    Coq.Init.Datatypes.app (GHC.List.filter Core.isExportedId int2) exported in
-                  let 'pair ae1 bs' := callArityTopLvl exported' int' bs in
-                  let 'pair ae2 b' := callArityBind (boringBinds b) ae1 int1 b in
-                  pair ae2 (cons b' bs')
-              end.
+  := match arg_0__, arg_1__, arg_2__ with
+     | exported, _, nil =>
+         pair (calledMultipleTimes (pair UnVarGraph.emptyUnVarGraph (Core.mkVarEnv
+                                          (Coq.Lists.List.flat_map (fun v => cons (pair v #0) nil) exported)))) nil
+     | exported, int1, cons b bs =>
+         let int' := addInterestingBinds int1 b in
+         let int2 := Core.bindersOf b in
+         let exported' :=
+           Coq.Init.Datatypes.app (GHC.List.filter Core.isExportedId int2) exported in
+         let 'pair ae1 bs' := callArityTopLvl exported' int' bs in
+         let 'pair ae2 b' := callArityBind (boringBinds b) ae1 int1 b in
+         pair ae2 (cons b' bs')
+     end.
 
 Definition callArityAnalProgram
    : DynFlags.DynFlags -> Core.CoreProgram -> Core.CoreProgram :=

--- a/examples/transformers/lib/Control/Applicative/Backwards.v
+++ b/examples/transformers/lib/Control/Applicative/Backwards.v
@@ -23,8 +23,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Backwards (f : Type -> Type) (a : Type) : Type
-  := | Mk_Backwards (forwards : f a) : Backwards f a.
+Inductive Backwards (f : Type -> Type) (a : Type) : Type :=
+  | Mk_Backwards (forwards : f a) : Backwards f a.
 
 Arguments Mk_Backwards {_} {_} _.
 

--- a/examples/transformers/lib/Control/Applicative/Lift.v
+++ b/examples/transformers/lib/Control/Applicative/Lift.v
@@ -28,9 +28,7 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Lift f a : Type
-  := | Pure : a -> Lift f a
-  |  Other : (f a) -> Lift f a.
+Inductive Lift f a : Type := | Pure : a -> Lift f a | Other : (f a) -> Lift f a.
 
 Definition Errors e :=
   (Lift (Data.Functor.Constant.Constant e))%type.

--- a/examples/transformers/lib/Control/Monad/Trans/Cont.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Cont.v
@@ -20,8 +20,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive ContT (r : Type) (m : Type -> Type) a : Type
-  := | Mk_ContT (runContT : (a -> m r) -> m r) : ContT r m a.
+Inductive ContT (r : Type) (m : Type -> Type) a : Type :=
+  | Mk_ContT (runContT : (a -> m r) -> m r) : ContT r m a.
 
 Definition Cont r :=
   (ContT r Data.Functor.Identity.Identity)%type.

--- a/examples/transformers/lib/Control/Monad/Trans/Except.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Except.v
@@ -31,8 +31,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive ExceptT e m a : Type
-  := | Mk_ExceptT : (m (Data.Either.Either e a)) -> ExceptT e m a.
+Inductive ExceptT e m a : Type :=
+  | Mk_ExceptT : (m (Data.Either.Either e a)) -> ExceptT e m a.
 
 Definition Except e :=
   (ExceptT e Data.Functor.Identity.Identity)%type.

--- a/examples/transformers/lib/Control/Monad/Trans/Identity.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Identity.v
@@ -28,8 +28,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive IdentityT (f : Type -> Type) a : Type
-  := | Mk_IdentityT (runIdentityT : f a) : IdentityT f a.
+Inductive IdentityT (f : Type -> Type) a : Type :=
+  | Mk_IdentityT (runIdentityT : f a) : IdentityT f a.
 
 Arguments Mk_IdentityT {_} {_} _.
 

--- a/examples/transformers/lib/Control/Monad/Trans/Maybe.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Maybe.v
@@ -32,8 +32,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive MaybeT m a : Type
-  := | Mk_MaybeT (runMaybeT : m (option a)) : MaybeT m a.
+Inductive MaybeT m a : Type :=
+  | Mk_MaybeT (runMaybeT : m (option a)) : MaybeT m a.
 
 Arguments Mk_MaybeT {_} {_} _.
 

--- a/examples/transformers/lib/Control/Monad/Trans/RWS/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/RWS/Lazy.v
@@ -22,8 +22,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive RWST r w s m a : Type
-  := | Mk_RWST (runRWST : r -> s -> m (a * s * w)%type) : RWST r w s m a.
+Inductive RWST r w s m a : Type :=
+  | Mk_RWST (runRWST : r -> s -> m (a * s * w)%type) : RWST r w s m a.
 
 Definition RWS r w s :=
   (RWST r w s Data.Functor.Identity.Identity)%type.

--- a/examples/transformers/lib/Control/Monad/Trans/Reader.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Reader.v
@@ -21,8 +21,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive ReaderT (r : Type) (m : Type -> Type) a : Type
-  := | Mk_ReaderT (runReaderT : r -> m a) : ReaderT r m a.
+Inductive ReaderT (r : Type) (m : Type -> Type) a : Type :=
+  | Mk_ReaderT (runReaderT : r -> m a) : ReaderT r m a.
 
 Definition Reader r :=
   (ReaderT r Data.Functor.Identity.Identity)%type.

--- a/examples/transformers/lib/Control/Monad/Trans/State/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/State/Lazy.v
@@ -22,8 +22,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive StateT s m a : Type
-  := | Mk_StateT (runStateT : s -> m (a * s)%type) : StateT s m a.
+Inductive StateT s m a : Type :=
+  | Mk_StateT (runStateT : s -> m (a * s)%type) : StateT s m a.
 
 Definition State s :=
   (StateT s Data.Functor.Identity.Identity)%type.

--- a/examples/transformers/lib/Control/Monad/Trans/Writer/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Writer/Lazy.v
@@ -28,8 +28,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive WriterT (w : Type) (m : Type -> Type) a : Type
-  := | Mk_WriterT (runWriterT : m (a * w)%type) : WriterT w m a.
+Inductive WriterT (w : Type) (m : Type -> Type) a : Type :=
+  | Mk_WriterT (runWriterT : m (a * w)%type) : WriterT w m a.
 
 Definition Writer w :=
   (WriterT w Data.Functor.Identity.Identity)%type.

--- a/examples/transformers/lib/Data/Functor/Constant.v
+++ b/examples/transformers/lib/Data/Functor/Constant.v
@@ -30,8 +30,8 @@ Import GHC.Num.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Constant (a : Type) (b : Type) : Type
-  := | Mk_Constant (getConstant : a) : Constant a b.
+Inductive Constant (a : Type) (b : Type) : Type :=
+  | Mk_Constant (getConstant : a) : Constant a b.
 
 Arguments Mk_Constant {_} {_} _.
 

--- a/examples/transformers/lib/Data/Functor/Reverse.v
+++ b/examples/transformers/lib/Data/Functor/Reverse.v
@@ -23,8 +23,8 @@ Import GHC.Base.Notations.
 
 (* Converted type declarations: *)
 
-Inductive Reverse (f : Type -> Type) (a : Type) : Type
-  := | Mk_Reverse (getReverse : f a) : Reverse f a.
+Inductive Reverse (f : Type -> Type) (a : Type) : Type :=
+  | Mk_Reverse (getReverse : f a) : Reverse f a.
 
 Arguments Mk_Reverse {_} {_} _.
 


### PR DESCRIPTION
Fixes #179 

```coq
(* before *)
Fixpoint f x :=
  match x with
  end with g y :=
         match y with
         end with h z :=
               match z with
               end.

(* after *)
Fixpoint f x :=
  match x with
  end
with g y :=
  match y with
  end
with h z :=
  match z with
  end.


(* before *)
Program Definition f :=
          blah.
(* hanging off "Definition" *)

(* after *)
Program Definition f :=
  blah.
(* indentation starts at beginning of line *)


(* before *)
Inductive t
:= | F
|  G.

(* after *)
Inductive t :=
| F
| G.
```