### PR TITLE
Parse Gallina's let-tick syntax

### DIFF
--- a/examples/tests/ParserTests.hs
+++ b/examples/tests/ParserTests.hs
@@ -1,4 +1,4 @@
-module ParserTests where
+module ParserTests (Foo(..), Test(..)) where
 
 class C a where
   c :: a -> a
@@ -8,3 +8,8 @@ a1 = c
 
 a2 :: (a -> b) -> a -> b
 a2 x = x
+
+
+-- For testing the parsing of the let-tick syntax in edit files:
+data Foo = MkFoo
+data Test = MkTest Foo

--- a/examples/tests/ParserTests/edits
+++ b/examples/tests/ParserTests/edits
@@ -5,3 +5,9 @@ redefine Definition ParserTests.a1 `{C a} : a -> a := c.
 
 # Right-nested arrows
 redefine Definition ParserTests.a2 {a} {b} : (a -> b) -> a -> b := fun x => x.
+
+# Let-tick syntax
+skip module GHC.Err
+skip ParserTests.Default__Foo
+add ParserTests Definition ParserTests.letTick : (ParserTests.Test -> ParserTests.Foo) 
+  := fun x => let ' MkTest y := x in y.

--- a/src/lib/HsToCoq/Edits/Parser.y
+++ b/src/lib/HsToCoq/Edits/Parser.y
@@ -157,6 +157,7 @@ import HsToCoq.Edits.ParserState
   '{'             { TokOpen    '{'              }
   '}'             { TokClose   '}'              }
   '_'             { TokWord    "_"              }
+  '\''            { TokTick                     }
   eol             { TokNewline                  }
   Word            { TokWord    $$               }
   Op              { TokOp      $$               }
@@ -394,6 +395,7 @@ LargeTerm :: { Term }
 -- Lets us implement EqlessTerm
 MediumTerm(Binop, RTerm) :: { Term }
   : 'let' Qualid Many(Binder) Optional(TypeAnnotation) ':=' Term 'in' RTerm     { Let $2 $3 $4 $6 $8 }
+  | 'let' '\'' Pattern ':=' Term 'in' RTerm                                     { LetTick $3 $5 $7 }
   | SmallishTerm(Binop) ':' RTerm { HasType $1 $3 }
   | SmallishTerm(Binop) { $1 }
 


### PR DESCRIPTION
This branch adds support for parsing Gallina's "let-tick" construct.

The code for the test case is in `examples/tests/ParserTests.hs` and `examples/tests/ParserTests/edits`.