### PR TITLE
bump ghcVersion 882 -> 884

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
 # After building, you can run result/bin/hs-to-coq
 
 { coqPackages ? "coqPackages_8_10"
-, ghcVersion  ? "ghc882"
+, ghcVersion  ? "ghc884"
 
 , rev    ? "4c2e7becf1c942553dadd6527996d25dbf5a7136"
 , sha256 ? "10dzi5xizgm9b3p5k963h5mmp0045nkcsabqyarpr7mj151f6jpm"


### PR DESCRIPTION
Closes https://github.com/plclub/hs-to-coq/issues/190

A friend pulled down the available `haskell.packages` ghc versions from the particular `nix` tarball you're using. 
```
nix-repl> x = import (fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/4c2e7becf1c942553dadd6527996d25dbf5a7136.tar.gz"; }) {}

nix-repl> x.pkgs.haskell.packages.ghc                                                                                                        
x.pkgs.haskell.packages.ghc8102Binary         x.pkgs.haskell.packages.ghc865Binary          x.pkgs.haskell.packages.ghcHEAD
x.pkgs.haskell.packages.ghc8102BinaryMinimal  x.pkgs.haskell.packages.ghc884
x.pkgs.haskell.packages.ghc8104               x.pkgs.haskell.packages.ghc901
```

The closest to `882` is `884`.

I'm currently building and will test the `Queue.hs` tutorial code, but it's my first time using it so I might not know all edge case behavior you'd be worried about. 

Feel free to reject this PR in favor of rolling back to an older `nix` tarball! (i.e. the one you were using before https://github.com/plclub/hs-to-coq/pull/189 )