### PR TITLE
add `Makefile` generation to `make all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 all:
+	cd base && coq_makefile -f _CoqProject -o Makefile
+	cd base-thy && coq_makefile -f _CoqProject -o Makefile
+	cd examples/containers/lib && coq_makefile -f _CoqProject -o Makefile
 	make -C base
 	make -C base-thy
 	make -C examples/containers/lib


### PR DESCRIPTION
Hi! I struggled for a bit with `make all` because the `Makefile`s weren't generated yet. I think future users would appreciate being able to just type `make all` from the top level directory. 

The install procedure in [queue tutorial](https://www.cis.upenn.edu/~plclub/blog/2020-10-09-hs-to-coq/) neglects the generation of the per-directory `Makefile`s. 

Happy to hear that it's not a best practice or something, just wanted to suggest something that I think would've lowered the friction on my end. 