### PR TITLE
make hyperlinks point to `plclub` repo version

### DIFF
--- a/doc/source/interface.rst
+++ b/doc/source/interface.rst
@@ -12,7 +12,7 @@ Some notes about interface file:
 
  * You need to pass `--iface-dir foo/` to make `hs-to-coq` search for interface
    files in `foo/`. This flag can be used multiple times. Usually, you will
-   at least passt `--iface-dir path/to/base --iface-dir output/` where `output/`
+   at least pass `--iface-dir path/to/base --iface-dir output/` where `output/`
    is the argument to `-o`.
 
  * When it cannot find an interface file, `hs-to-coq` complains loudly (but still
@@ -26,8 +26,8 @@ Some notes about interface file:
    as dependencies of `Foo.v`, ensuring that from now on all files are built in
    the right order.
 
- * Skipping instances prevents hs-to-coq from trying to load the interface
-   files of the class’es module.
+ * Skipping instances prevents `hs-to-coq` from trying to load the interface
+   files of the class’s module.
 
  * Coq types as well as information about the type classes `Eq` and `Ord` are hard-coded
    in `src/lib/HsToCoq/ConvertHaskell/BuiltIn.hs`.

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart
 ==========
 
 The easiest way to see how to use ``hs-to-coq`` is to look at the Makefiles in
-each of the subdirectories in the `examples <https://github.com/antalsz/hs-to-coq/tree/master/examples/>`_ subdirectory of the repository.
+each of the subdirectories in the `examples <https://github.com/plclub/hs-to-coq/tree/master/examples/>`_ subdirectory of the repository.
 
 Translating a single Haskell file
 ---------------------------------
@@ -40,7 +40,7 @@ In this case, it is the current directory.
 
 An example translated in this way
 is `simple
-<https://github.com/antalsz/hs-to-coq/blob/master/examples/simple>`_. Check
+<https://github.com/plclub/hs-to-coq/tree/master/examples/simple>`_. Check
 out the ``Makefile`` in the ``examples/simple`` subdirectory to see how
 ``hs-to-coq`` is invoked with these arguments.
 
@@ -50,7 +50,7 @@ Local Edit files
 Often, a particular file will require its own set of edits. These edits can be
 provided with additional uses of the ``-e <editfile>`` command line argument.
 
-An example that uses a local edit file is `intervals <https://github.com/antalsz/hs-to-coq/tree/master/examples/intervals>`_,
+An example that uses a local edit file is `intervals <https://github.com/plclub/hs-to-coq/tree/master/examples/intervals>`_,
 as described in Joachim Breitner's
 `blog post <https://www.joachim-breitner.de/blog/734-Finding_bugs_in_Haskell_code_by_proving_it>`_.
 
@@ -69,7 +69,7 @@ Inserts the Coq definitions from the specified file at
 the beginning of the output.
 
 For example, the `rle
-<https://github.com/antalsz/hs-to-coq/blob/master/examples/rle>`_ example uses
+<https://github.com/plclub/hs-to-coq/tree/master/examples/rle>`_ example uses
 a preamble to add additional imports to the output.
 
 .. option:: -m <midamble-file>
@@ -117,8 +117,8 @@ Translating a multi-file project
 
 Larger examples include
 `containers
-<https://github.com/antalsz/hs-to-coq/tree/master/examples/containers>`_  and
-`transformers <https://github.com/antalsz/hs-to-coq/tree/master/examples/transformers>`_.
+<https://github.com/plclub/hs-to-coq/tree/master/examples/containers>`_  and
+`transformers <https://github.com/plclub/hs-to-coq/tree/master/examples/transformers>`_.
 
 These examples use a ``Makefile`` to translate each module in the library
 individually, using edit files, preambles and midambles specific to each


### PR DESCRIPTION
at the moment of opening this PR I only went through `quickstart.rst` to update hyperlinks to point to `plclub/` github account's version of repo (off from `antalsz`). I can try updating more files before we merge this in, feel free to leave it open for a while to increase the probability that I do that. Also anyone else can feel free to push to this branch if they see hyperlinks in other files. 