### PR TITLE
Fix boot script by generating a makefile for examples/ghc/lib

### DIFF
--- a/examples/boot.sh
+++ b/examples/boot.sh
@@ -139,6 +139,7 @@ coq make -C transformers coq
 #coq make -C transformers/theories no theories yet
 
 make -C ghc vfiles
+(cd ghc/lib; coq coq_makefile -f _CoqProject -o Makefile)
 coq make -C ghc/lib
 (cd ghc/theories; coq coq_makefile -f _CoqProject -o Makefile)
 coq make -C ghc/theories


### PR DESCRIPTION
Note that the CI tests already do this correctly:

https://github.com/plclub/hs-to-coq/blob/03e823972fc7c5f85a300e554c691563f89a3e5f/.github/workflows/hs-to-coq.yml#L182